### PR TITLE
fix(hooks): guard Phase 3 compact_boundary against stale marker cascade

### DIFF
--- a/macf/src/macf/hooks/handle_session_start.py
+++ b/macf/src/macf/hooks/handle_session_start.py
@@ -273,29 +273,48 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
 
             # PHASE 3: Fallback detection via JSONL transcript scanning
             # Fallback: JSONL transcript scanning for backward compatibility
-            claude_dir = Path.home() / ".claude" / "projects"
+            #
+            # GUARD: Check if compaction was already detected for this session.
+            # compact_boundary markers persist in the transcript after a real
+            # compaction. Without this guard, every subsequent SessionStart
+            # re-detects the stale marker and emits a new compaction_detected
+            # event with cycle+1, creating a runaway cascade.
+            # See: https://github.com/cversek/MacEff/issues/30
+            existing_compactions = get_compaction_count_from_events(session_id)
+            if existing_compactions.get('count', 0) > 0:
+                # Stale marker — compaction already handled for this session
+                log_hook_event({
+                    "hook_name": "session_start",
+                    "event_type": "PHASE3_SKIP_STALE_MARKER",
+                    "session_id": session_id,
+                    "existing_compaction_count": existing_compactions.get('count', 0),
+                    "reason": "compact_boundary already processed for this session"
+                })
+                compaction_detected = False
+            else:
+                claude_dir = Path.home() / ".claude" / "projects"
 
-            if claude_dir.exists():
-                all_jsonl_files = []
-                for project_dir in claude_dir.iterdir():
-                    if project_dir.is_dir():
-                        all_jsonl_files.extend(project_dir.glob("*.jsonl"))
+                if claude_dir.exists():
+                    all_jsonl_files = []
+                    for project_dir in claude_dir.iterdir():
+                        if project_dir.is_dir():
+                            all_jsonl_files.extend(project_dir.glob("*.jsonl"))
 
-                if all_jsonl_files:
-                    latest_file = max(all_jsonl_files, key=lambda p: p.stat().st_mtime)
-                    compaction_detected = detect_compaction(latest_file)
-                    detection_method = "compact_boundary"
+                    if all_jsonl_files:
+                        latest_file = max(all_jsonl_files, key=lambda p: p.stat().st_mtime)
+                        compaction_detected = detect_compaction(latest_file)
+                        detection_method = "compact_boundary"
 
-                    # Log detection result
-                    log_hook_event({
-                        "hook_name": "session_start",
-                        "event_type": "COMPACTION_CHECK",
-                        "session_id": session_id,
-                        "compaction_detected": compaction_detected,
-                        "detection_method": "compact_boundary",
-                        "transcript": str(latest_file),
-                        "source": source  # Log source even if not "compact"
-                    })
+                        # Log detection result
+                        log_hook_event({
+                            "hook_name": "session_start",
+                            "event_type": "COMPACTION_CHECK",
+                            "session_id": session_id,
+                            "compaction_detected": compaction_detected,
+                            "detection_method": "compact_boundary",
+                            "transcript": str(latest_file),
+                            "source": source  # Log source even if not "compact"
+                        })
 
         if compaction_detected:
             # Get current values from events BEFORE modifications


### PR DESCRIPTION
## Summary

- Adds deduplication guard to Phase 3 fallback compaction detection in `handle_session_start.py`
- Before scanning the transcript for `compact_boundary` markers, checks if a `compaction_detected` event already exists for the current session
- If compaction was already handled, the marker is stale — Phase 3 is skipped with a `PHASE3_SKIP_STALE_MARKER` log entry

## Problem

Phase 3 re-detected the same `compact_boundary` marker on every SessionStart invocation after a real compaction, emitting a new `compaction_detected` event with `cycle+1` each time. This created a runaway feedback loop:

- **SiloMacEff@d0cdcf cycle counter**: 17,915 (true value: **2**, verified via JOTEWR count + 1)
- **False events**: 35,827 `compaction_detected` entries in the event log (~20 hours)
- **Detection method breakdown**: 1 legitimate `source_field`, 17,913 stale `compact_boundary` re-detections

## Test plan

- [x] `py_compile` syntax validation passes
- [x] 88 existing tests pass (1 pre-existing failure: hardcoded macOS path in `test_env_cli.py`, filed as #31)
- [ ] Manual validation: start session, trigger `/compact`, verify cycle increments to 2 (not runaway)
- [ ] Verify `PHASE3_SKIP_STALE_MARKER` appears in event log on subsequent SessionStart after real compaction

Fixes #30

---
SiloMacEff@d0cdcf | s_55ad894c/c_2/p_6a304b62

🤖 Generated with [Claude Code](https://claude.com/claude-code)