### PR TITLE
fix(telegram): rotate server.log to prevent unbounded growth

### DIFF
--- a/plugins/telegram/server.ts
+++ b/plugins/telegram/server.ts
@@ -35,11 +35,32 @@ import { homedir } from 'os'
 import { join, extname, sep } from 'path'
 
 const LOG_FILE = join(homedir(), '.claude', 'channels', 'telegram', 'server.log')
+// Prevent unbounded growth (issue #46: hit 191GB in 3 weeks on SiloMacEff's Pi).
+// Default 10MB per file, 2 rotated backups kept (30MB max on disk).
+const MAX_LOG_SIZE = (() => {
+  const n = parseInt(process.env.TELEGRAM_LOG_MAX_SIZE ?? '', 10)
+  return Number.isFinite(n) && n > 0 ? n : 10 * 1024 * 1024
+})()
+
+function rotateLogIfNeeded() {
+  try {
+    const sz = statSync(LOG_FILE).size
+    if (sz < MAX_LOG_SIZE) return
+    const bak1 = `${LOG_FILE}.1`
+    const bak2 = `${LOG_FILE}.2`
+    try { renameSync(bak1, bak2) } catch {} // .1 may not exist on first rotate
+    try { renameSync(LOG_FILE, bak1) } catch {} // race: another writer may have rotated
+  } catch {} // LOG_FILE may not exist yet — nothing to rotate
+}
+
 function log(msg: string) {
   const ts = new Date().toISOString()
   const line = `[${ts}] ${msg}\n`
   process.stderr.write(line)
-  try { appendFileSync(LOG_FILE, line) } catch {}
+  try {
+    rotateLogIfNeeded()
+    appendFileSync(LOG_FILE, line)
+  } catch {} // last-resort: never let logging crash the server
 }
 
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')


### PR DESCRIPTION
## Summary

- server.log grew to 191GB in 3 weeks on a long-running Pi deployment (#46)
- Root cause: `log()` appended with no size check, no rotation, no cleanup
- Fix: size-check-before-append with 2-level rotation (`.1`, `.2`), cap configurable via `TELEGRAM_LOG_MAX_SIZE` env var (default 10MB per file, 30MB total on disk)
- Smoke test verified first rotation, cascade to `.2`, and that no `.3` ever accumulates

## Test plan

- [ ] Set `TELEGRAM_LOG_MAX_SIZE=1024` for an aggressive test, run the server, confirm rotation after ~1KB of writes
- [ ] Confirm `.1` and `.2` files appear in `~/.claude/channels/telegram/` as expected
- [ ] Confirm server continues serving tools when rotate fails (e.g., read-only filesystem): no crash, logging silently degrades

## Scope note

This only fixes the log-growth bug on the existing custom server.ts. It does not pull in features from the official plugin. Per current project direction, the deployed recommendation is to use the official `plugin:telegram@claude-plugins-official` until a custom channel (LXMF) is ready to replace it. This patch exists so the fork is safe to run for any remaining deployments that still use it.

Fixes #46