### PR TITLE
fix(cli): build scope_state dict in cmd_task_list (gh-48)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3279,6 +3279,13 @@ def cmd_task_list(args: argparse.Namespace) -> int:
     def get_children(parent_id):
         return sorted([t for t in tasks if t.parent_id == parent_id], key=lambda t: str(t.id).zfill(10))
 
+    # Load scope state from MTMD scope_status field on tasks (same source as cmd_task_tree).
+    # Without this, format_task's scope indicator block raises NameError (gh-48).
+    scope_state = {}
+    for t in tasks:
+        if t.mtmd and getattr(t.mtmd, 'scope_status', None):
+            scope_state[t.id] = t.mtmd.scope_status
+
     def format_task(t: MacfTask, indent: int = 0) -> str:
         prefix = "  " * indent
         # CC-style markers with colors:

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -861,3 +861,58 @@ class TestTaskLifecycleEvents:
         assert 'task_management' in injected_names
         assert 'roadmaps_following' in injected_names
         assert all(e['data']['task_id'] == str(tid) for e in injections)
+
+
+class TestTaskListCommand:
+    """Regression tests for `macf_tools task list` display pipeline.
+
+    Introduced after gh-48: cmd_task_list.format_task referenced a
+    scope_state variable that was never built in cmd_task_list's scope,
+    causing NameError on every invocation that reached the display path.
+    """
+
+    def _write_task(self, session_dir, task_id, status='pending', scope_status=None):
+        mtmd_lines = [
+            'task_type: MISSION',
+            'creation_breadcrumb: s_test/c_1/g_abc/p_def/t_123',
+            'created_cycle: 1',
+            'created_by: PA',
+            "parent_id: '000'",
+        ]
+        if scope_status:
+            mtmd_lines.append(f'scope_status: {scope_status}')
+        mtmd = '\n'.join(mtmd_lines) + '\n'
+        desc = f'Regression test task\n\n<macf_task_metadata version="1.0">\n{mtmd}</macf_task_metadata>'
+        (session_dir / f'{task_id}.json').write_text(json.dumps({
+            'id': str(task_id), 'subject': f'Test task {task_id}',
+            'description': desc, 'status': status,
+        }))
+        return task_id
+
+    def test_task_list_does_not_crash_with_one_task(self, isolated_task_env):
+        """gh-48: task list must not raise NameError on any task."""
+        self._write_task(isolated_task_env['session_dir'], 100)
+        result = subprocess.run(
+            ['macf_tools', 'task', 'list'],
+            capture_output=True, text=True, env=isolated_task_env['env'])
+        assert result.returncode == 0, f'stderr: {result.stderr}'
+        assert 'NameError' not in result.stderr
+        assert 'Test task 100' in result.stdout
+
+    def test_task_list_shows_scope_indicator_for_active_scope(self, isolated_task_env):
+        """Positive test: active scope shows 👀 indicator (the feature gh-48's bug gated)."""
+        self._write_task(isolated_task_env['session_dir'], 101, scope_status='active')
+        result = subprocess.run(
+            ['macf_tools', 'task', 'list'],
+            capture_output=True, text=True, env=isolated_task_env['env'])
+        assert result.returncode == 0, f'stderr: {result.stderr}'
+        assert '👀' in result.stdout
+
+    def test_task_list_shows_scope_indicator_for_inactive_scope(self, isolated_task_env):
+        """Inactive scope shows ✅ indicator."""
+        self._write_task(isolated_task_env['session_dir'], 102, scope_status='inactive')
+        result = subprocess.run(
+            ['macf_tools', 'task', 'list'],
+            capture_output=True, text=True, env=isolated_task_env['env'])
+        assert result.returncode == 0, f'stderr: {result.stderr}'
+        assert '✅' in result.stdout


### PR DESCRIPTION
## Summary

- `macf_tools task list` crashed with `NameError: name 'scope_state' is not defined` on every invocation that reached the display path (#48)
- Regression from 58d37fb (feat: scope indicators, 2026-04-04) — the display block was copy-pasted into `cmd_task_list` but the dict construction stayed in `cmd_task_tree` only
- Fix: port the 4-line `scope_state` dict construction into `cmd_task_list` before `format_task` is defined. Same MTMD field (`scope_status`), same semantics, so `task list` and `task tree` stay consistent.
- Added `TestTaskListCommand` regression class (3 tests): doesn't crash with one task, active scope shows `👀`, inactive scope shows `✅`.

## Test plan

- [x] `pytest macf/tests/test_task_cli.py::TestTaskListCommand -v` — 3 passed
- [x] `pytest macf/tests/test_task_cli.py -q` — full file, 44 passed, no regressions
- [x] Live smoke: `macf_tools task list` on CTB's session (973 tasks) exits 0, scope indicators render on scoped tasks

Fixes #48