### PR TITLE
fix(hooks): recommender emits /maceff-* prefix, not /ctb-* (gh-56)

### DIFF
--- a/macf/src/macf/hooks/handle_stop.py
+++ b/macf/src/macf/hooks/handle_stop.py
@@ -221,7 +221,7 @@ Development Drive Stats:
                             current_wm = get_current_work_mode(active_modes)
                             op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
                             selected, dist = sample_next_work_mode(current_wm, op_modes)
-                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "ctb")
+                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
                         except (OSError, ValueError, ImportError) as e:
                             print(f"⚠️ MACF: recommender failed: {e}", file=sys.stderr)
 
@@ -309,7 +309,7 @@ Development Drive Stats:
                             current_wm = get_current_work_mode(active_modes)
                             op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
                             selected, dist = sample_next_work_mode(current_wm, op_modes)
-                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "ctb")
+                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
                         except (OSError, ValueError, ImportError) as e:
                             print(f"⚠️ MACF: recommender failed: {e}", file=sys.stderr)
 

--- a/macf/tests/test_scope_and_stop.py
+++ b/macf/tests/test_scope_and_stop.py
@@ -126,3 +126,29 @@ class TestStopHookScopeGate:
         from macf.hooks.handle_stop import run
         result = run('{"stop_reason":"end_turn"}')
         assert result["continue"] is True
+
+
+class TestRecommenderPrefix:
+    """Regression guard for issue #56 — recommender must not leak /ctb-* into framework hook output."""
+
+    def test_format_recommendation_emits_maceff_prefix(self):
+        """format_recommendation with agent_prefix='maceff' must produce /maceff-* skill names."""
+        from macf.modes.detection import format_recommendation
+        output = format_recommendation(
+            current_work_mode="DISCOVER",
+            selected_mode="EXPERIMENT",
+            distribution={"DISCOVER": 0.1, "EXPERIMENT": 0.5, "BUILD": 0.2, "CURATE": 0.1, "CONSOLIDATE": 0.1},
+            agent_prefix="maceff",
+        )
+        assert "/maceff-experimental-self-motivation" in output
+        assert "/ctb-" not in output
+
+    def test_handle_stop_does_not_hardcode_ctb_prefix(self):
+        """Source-level regression: handle_stop.py must not pass "ctb" to format_recommendation."""
+        from pathlib import Path
+        import macf.hooks.handle_stop as hs
+        source = Path(hs.__file__).read_text()
+        # Any literal "ctb" token as the 4th positional arg to format_recommendation would match
+        assert 'format_recommendation(' in source  # sanity: function is still called
+        assert ', "ctb")' not in source, "hardcoded /ctb-* prefix leaked back into the stop hook"
+        assert ", 'ctb')" not in source, "hardcoded /ctb-* prefix leaked back into the stop hook"


### PR DESCRIPTION
## Summary

The Stop hook's Markov recommender was hardcoded to pass `\"ctb\"` as the `agent_prefix` to `format_recommendation()` at two callsites. That leaked CTB-specific slash-command naming into framework output — fresh MacEff agents saw `/ctb-exploratory-self-motivation` and either got a not-found error or got confused about their identity.

The fix is two identical edits: `\"ctb\"` → `\"maceff\"` in `handle_stop.py` (matching the function's default and the expected skill names in the MacEff family).

Reported by SiloMacEff during their first AUTO_MODE sprint on v0.5.0.

Fixes #56

## Changes

- `macf/src/macf/hooks/handle_stop.py` — 2 line fix
- `macf/tests/test_scope_and_stop.py` — 2 regression tests (unit + source-lint)

## Test plan

- [x] New: `TestRecommenderPrefix::test_format_recommendation_emits_maceff_prefix`
- [x] New: `TestRecommenderPrefix::test_handle_stop_does_not_hardcode_ctb_prefix`
- [x] `pytest tests/test_scope_and_stop.py` → 13 passed, 0 regressions

🔧 Generated with Claude Code