### PR TITLE
docs(sprint): endorse multi-scope discipline in sprint setup (gh-55)

### DIFF
--- a/framework/policies/base/operations/autonomous_sprint.md
+++ b/framework/policies/base/operations/autonomous_sprint.md
@@ -27,9 +27,11 @@ Scope completion is a **transition point**, not a stop signal. When the Markov r
 - How does ULTRATHINK deliberation work?
 - When is overriding justified?
 
-**3 Scope Feeding Discipline**
-- How do I keep the scope gate fed?
-- What is the front-loading pattern?
+**3 Sprint Task Discipline**
+- What's the difference between timed and untimed sprints?
+- Should I scope just the sprint container, or every task I'll work on?
+- How do I document activity during a sprint?
+- How do completion and the scope/timer gates interact?
 
 **4 Domain Rotation**
 - When should I switch domains?
@@ -94,6 +96,23 @@ At each gate point, the recommender presents a suggestion:
 
 **CRITICAL**: Never invent a timer for workload-defined sprints.
 
+### Scope the Full Workload
+
+**Scope every individual task you intend to work on during the sprint** — all the tasks that together make up the logical collection of work implied by the user's request. `macf_tools task scope set` accepts multiple IDs; give the scope gate the complete picture of what you're committing to.
+
+**Why this matters**:
+- Scope gate only protects the work it knows about. If tasks aren't scoped, the gate clears early and Stop fires while real work is still unfinished.
+- `scope show` and the Stop-hook dashboard become accurate pictures of remaining sprint work.
+- Non-last completions proceed freely (no gate) — scoping many tasks does not slow the sprint down.
+
+**Canonical pattern**:
+
+```bash
+macf_tools task scope set <task_id_1> <task_id_2> <task_id_3> ... --timer <minutes>
+```
+
+If you realize mid-sprint that a task you'll actually work on isn't scoped, re-invoke `scope set` with the full list — the command replaces the scope, so include everything you want tracked.
+
 ### Task Note Discipline
 
 Document all activity in task notes with work mode prefix: `MODE_NAME: description`. This is required for BOTH sprint types, but especially important during timed sprint continuation periods.
@@ -135,7 +154,7 @@ Timer expiry lifts the timer gate. Agent then completes the last task with a rep
 
 ## 5. Timer Discipline
 
-**Timer is MANDATORY** when user specifies a time allotment: `macf_tools task scope set <id> --timer <minutes>`.
+**Timer is MANDATORY** when user specifies a time allotment: `macf_tools task scope set <task_id_1> [<task_id_2> ...] --timer <minutes>`. Scope every individual task you intend to work on (see §3 "Scope the Full Workload").
 
 **Session restart is MANDATORY** between AUTO_MODE activation and sprint work. Permissions only take effect after restart. Negotiate with user: "Please restart (Ctrl-D + claude -c) then say GO."
 

--- a/framework/skills/maceff-autonomous-sprint/SKILL.md
+++ b/framework/skills/maceff-autonomous-sprint/SKILL.md
@@ -76,13 +76,17 @@ Extract requirements by answering:
 
 ### Scope Setup
 
+Scope **every individual task** you intend to work on during the sprint — all the tasks that together make up the logical collection of work implied by the user's request. `task scope set` accepts multiple IDs. Give the scope gate the complete picture so it doesn't clear early while real work remains unfinished. Non-last completions proceed freely (no gate), so scoping many tasks does not slow the sprint down.
+
 ```bash
 # Timed sprint (user said "work for 2 hours"):
-macf_tools task scope set <task_id> --timer 120
+macf_tools task scope set <task_id_1> <task_id_2> <task_id_3> ... --timer 120
 
 # Untimed sprint (user said "finish this MISSION"):
-macf_tools task scope set <task_id>
+macf_tools task scope set <task_id_1> <task_id_2> <task_id_3> ...
 ```
+
+If mid-sprint you realize a task you'll actually work on isn't scoped, re-invoke `scope set` with the full list — the command replaces the scope, so include everything you want tracked.
 
 **Verify TM is running** (should be auto-started from Step 1):
 ```bash


### PR DESCRIPTION
## Summary

The `autonomous_sprint` policy §3 and the `maceff-autonomous-sprint` skill both showed `task scope set <task_id> --timer ...` with a single-ID placeholder. A field agent followed this literally on their first sprint and left individual work tasks unscoped — the scope gate then cleared early while real work remained unfinished. TM semantics actually expect scope to cover every task the agent will work on; the CLI has always accepted multiple IDs.

### Changes

- **Policy** (`framework/policies/base/operations/autonomous_sprint.md`):
  - New §3 subsection "Scope the Full Workload" explicitly endorses scoping every individual task in the logical collection implied by the user's request. Explains *why* (scope gate protects only what it knows about) and notes non-last completions proceed freely so multi-scope adds no overhead.
  - §5 timer example now shows multi-ID form and cross-refs §3.
  - CEP Nav Guide §3 title mismatch fixed ("Scope Feeding Discipline" → "Sprint Task Discipline" matching the actual heading) with concrete questions.
- **Skill** (`framework/skills/maceff-autonomous-sprint/SKILL.md`):
  - Scope Setup section rewritten to match: multi-ID, full workload, re-invoke if midstream addition needed.

Reported by SiloMacEff during their first AUTO_MODE sprint on v0.5.0.

Fixes #55

## Test plan

- [x] Docs-only change — no runtime code modified
- [x] Markdown renders cleanly (verified policy §3 and skill Scope Setup sections)
- [x] CEP Nav Guide now matches actual headings

🔧 Generated with Claude Code