### PR TITLE
fix(cli): framework install verifies hooks actually landed (gh-52)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -605,6 +605,20 @@ def _check_hooks_in_settings(settings_path: Path) -> bool:
         return False
 
 
+def _count_hook_events_in_settings(settings_path: Path) -> int:
+    """Count distinct hook events bound in a settings file. Returns 0 on any failure."""
+    try:
+        if not settings_path.exists():
+            return 0
+        with open(settings_path) as f:
+            settings = json.load(f)
+        hooks = settings.get("hooks") or {}
+        return len(hooks) if isinstance(hooks, dict) else 0
+    except (OSError, IOError, json.JSONDecodeError) as e:
+        print(f"⚠️ MACF: hooks count check failed: {e}", file=sys.stderr)
+        return 0
+
+
 def _clear_hooks_from_settings(settings_path: Path) -> bool:
     """Remove hooks section from a settings file to prevent duplicate execution."""
     try:
@@ -777,15 +791,33 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
         installed_count = {"hooks": 0, "commands": 0, "skills": 0}
 
         # Install hooks (unless skip_hooks or already done via hooks_only)
+        # The framework install hands cmd_hook_install a local mode choice, which
+        # writes the settings file at <CWD>/.claude/settings.local.json. We verify
+        # the post-install state below rather than trusting the return code alone
+        # — the migration path clears global hooks BEFORE writing local, so a
+        # silent write failure would leave the agent with no hooks anywhere.
+        in_container = Path("/.dockerenv").exists()
+        if in_container:
+            expected_settings = Path.home() / ".claude" / "settings.json"
+        else:
+            expected_settings = Path.cwd() / ".claude" / "settings.local.json"
+
         if not skip_hooks:
             print("\n📦 Installing hooks...")
-            # Reuse existing hook install logic
             hooks_args = argparse.Namespace(local_install=True, global_install=False)
             hook_result = cmd_hook_install(hooks_args)
-            if hook_result == 0:
-                installed_count["hooks"] = 10
-            else:
-                print("   Warning: Hook installation had issues")
+            if hook_result != 0:
+                print(f"\n❌ Hook installation failed (exit {hook_result}). Aborting framework install.")
+                print(f"   Expected settings file: {expected_settings}")
+                return 1
+            actual_hook_count = _count_hook_events_in_settings(expected_settings)
+            if actual_hook_count != 10:
+                print(f"\n❌ Hook installation reported success but settings file has {actual_hook_count}/10 hook events bound.")
+                print(f"   Expected settings file: {expected_settings}")
+                print(f"   This can happen after a global→local migration if the local write silently dropped the hooks block.")
+                print(f"   Recovery: re-run with `macf_tools framework install --hooks-only` from the same directory.")
+                return 1
+            installed_count["hooks"] = actual_hook_count
 
         if hooks_only:
             print(f"\n✅ Hooks-only installation complete")

--- a/macf/tests/test_framework_install_verification.py
+++ b/macf/tests/test_framework_install_verification.py
@@ -1,0 +1,140 @@
+"""Regression tests for framework install post-hook verification (issue #52).
+
+The framework install's global→local migration is non-atomic: it clears the
+global hooks block BEFORE writing the local one. If the local write silently
+fails (CWD mismatch, permission error, JSON exception swallowed by the caller),
+the agent loses ALL hooks and the install still reports success.
+
+These tests lock down the post-install verification that prevents that class
+of silent failure.
+"""
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from macf.cli import _count_hook_events_in_settings, cmd_framework_install
+
+
+# --- _count_hook_events_in_settings ----------------------------------------
+
+def _write_settings(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def test_count_returns_zero_for_missing_file(tmp_path):
+    assert _count_hook_events_in_settings(tmp_path / "missing.json") == 0
+
+
+def test_count_returns_zero_when_no_hooks_key(tmp_path):
+    settings = tmp_path / "settings.json"
+    _write_settings(settings, {"permissions": {}, "statusLine": {}})
+    assert _count_hook_events_in_settings(settings) == 0
+
+
+def test_count_returns_full_count_for_all_ten_events(tmp_path):
+    settings = tmp_path / "settings.json"
+    events = [
+        "SessionStart", "UserPromptSubmit", "Stop", "SubagentStop",
+        "PreToolUse", "PostToolUse", "SessionEnd", "PreCompact",
+        "PermissionRequest", "Notification",
+    ]
+    _write_settings(settings, {"hooks": {e: [{"matcher": "", "hooks": []}] for e in events}})
+    assert _count_hook_events_in_settings(settings) == 10
+
+
+def test_count_returns_partial_count_for_partial_bindings(tmp_path):
+    settings = tmp_path / "settings.json"
+    _write_settings(settings, {"hooks": {"SessionStart": [], "Stop": []}})
+    assert _count_hook_events_in_settings(settings) == 2
+
+
+# --- cmd_framework_install post-install verification -----------------------
+
+@pytest.fixture
+def fake_framework_root(tmp_path, monkeypatch):
+    """Give cmd_framework_install a minimal MACEFF root with a framework/ dir.
+
+    find_maceff_root is @lru_cache'd, so we must clear the cache on teardown —
+    otherwise later tests that rely on the real repo root will receive our
+    tmp_path (which gets cleaned up) and fail with misleading errors.
+    """
+    from macf.utils.paths import find_maceff_root
+    root = tmp_path / "MacEff"
+    (root / "framework" / "commands").mkdir(parents=True)
+    (root / "framework" / "skills").mkdir()
+    monkeypatch.setenv("MACEFF_ROOT_DIR", str(root))
+    monkeypatch.chdir(tmp_path)
+    find_maceff_root.cache_clear()
+    try:
+        yield root
+    finally:
+        find_maceff_root.cache_clear()
+
+
+def test_framework_install_bails_when_hook_install_returns_nonzero(fake_framework_root):
+    """If cmd_hook_install signals failure, framework install must NOT continue."""
+    real_exists = Path.exists
+
+    def fake_exists(self):
+        if str(self) == "/.dockerenv":
+            return False
+        return real_exists(self)
+
+    with patch("macf.cli.cmd_hook_install", return_value=1), \
+         patch.object(Path, "exists", fake_exists):
+        args = argparse.Namespace()
+        result = cmd_framework_install(args)
+    assert result == 1
+
+
+def test_framework_install_bails_when_settings_has_no_hooks(fake_framework_root, capsys):
+    """If hook install returns 0 but settings file has no hooks, install must fail loudly."""
+    real_exists = Path.exists
+    def fake_exists(self):
+        if str(self) == "/.dockerenv":
+            return False
+        return real_exists(self)
+
+    # Simulate the silent-failure: hook_install returns 0 but never wrote the file
+    with patch("macf.cli.cmd_hook_install", return_value=0), \
+         patch.object(Path, "exists", fake_exists):
+        args = argparse.Namespace()
+        result = cmd_framework_install(args)
+
+    out = capsys.readouterr().out
+    assert result == 1
+    assert "Hook installation reported success" in out
+    assert "hook events bound" in out
+
+
+def test_framework_install_reports_actual_count_on_success(fake_framework_root, capsys):
+    """On success, the summary must reflect the ACTUAL hook count, not a hardcoded 10."""
+    real_exists = Path.exists
+    def fake_exists(self):
+        if str(self) == "/.dockerenv":
+            return False
+        return real_exists(self)
+
+    # Seed settings file with all 10 hooks as if hook_install wrote them
+    settings_file = Path.cwd() / ".claude" / "settings.local.json"
+    events = [
+        "SessionStart", "UserPromptSubmit", "Stop", "SubagentStop",
+        "PreToolUse", "PostToolUse", "SessionEnd", "PreCompact",
+        "PermissionRequest", "Notification",
+    ]
+    _write_settings(settings_file, {"hooks": {e: [] for e in events}})
+
+    with patch("macf.cli.cmd_hook_install", return_value=0), \
+         patch.object(Path, "exists", fake_exists):
+        args = argparse.Namespace()
+        result = cmd_framework_install(args)
+
+    out = capsys.readouterr().out
+    assert result == 0
+    assert "Hooks: 10" in out
+    # Must not have hit the failure path
+    assert "Hook installation reported success" not in out


### PR DESCRIPTION
## Summary

The `framework install` global→local migration is non-atomic: it clears the global hooks block *before* writing the local one. If the local write silently fails (CWD mismatch, permission quirk, exception swallowed by the caller), `cmd_hook_install` can still return 0 and the framework install trusts a hardcoded `installed_count["hooks"] = 10` — summary then says **"✅ Framework installation complete! Hooks: 10"** while the agent's `settings.local.json` has no `hooks` key at all. The agent loses every hook with zero error signal. A field MacEff agent hit this on v0.5.0 and only noticed because DEV_DRV footers stopped appearing mid-session.

## Fix

- New helper `_count_hook_events_in_settings(path) -> int` returns the actual number of hook events bound (0 if the file or hooks block is absent).
- `cmd_framework_install` now verifies after `cmd_hook_install` returns:
  - Non-zero return → bail immediately, show expected settings path. No silent continuation into commands/skills.
  - Settings file has `< 10` bound events → bail with a clear error naming the expected path, explaining the failure mode, and pointing at `--hooks-only` as the recovery path.
  - Report the **actual** hook count in the summary, not a hardcoded 10.

## Changes

- `macf/src/macf/cli.py` — added `_count_hook_events_in_settings`, replaced hardcoded count with verification + bail-out.
- `macf/tests/test_framework_install_verification.py` — 7 new tests (4 unit, 3 integration-style via patched `cmd_hook_install`). The fake-root fixture clears `find_maceff_root`'s `@lru_cache` on teardown so later tests that rely on the real repo root aren't polluted.

Fixes #52

## Test plan

- [x] `pytest tests/test_framework_install_verification.py` → 7 passed
- [x] Full suite: `pytest tests/` → 493 passed, 9 xfailed, 0 regressions
- [x] Count helper: missing file / no hooks key / 10 bound events / partial bindings
- [x] Integration: bail on non-zero hook_install, bail on empty settings, report actual count on success

🔧 Generated with Claude Code