### PR TITLE
fix(tm): daemon fully detaches stderr from caller's pipeline (gh-54)

### DIFF
--- a/macf/src/macf/transcript_monitor/daemon.py
+++ b/macf/src/macf/transcript_monitor/daemon.py
@@ -33,6 +33,7 @@ from ..agent_events_log import append_event
 DEFAULT_POLL_INTERVAL = 1.0  # 1 second — negligible CPU, responsive detection
 CHUNK_SIZE = 65536  # 64KB read chunks
 PID_FILE_NAME = "macf_transcript_monitor.pid"
+LOG_FILE_NAME = "macf_transcript_monitor.log"
 
 
 # ============================================================================
@@ -160,6 +161,42 @@ def get_pid_file_path() -> Path:
     """Get path for PID file in runtime directory."""
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "/tmp")
     return Path(runtime_dir) / PID_FILE_NAME
+
+
+def get_log_file_path() -> Path:
+    """Get path for daemon stderr log file in runtime directory."""
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", "/tmp")
+    return Path(runtime_dir) / LOG_FILE_NAME
+
+
+def _detach_standard_streams() -> None:
+    """Fully detach the child's standard streams from the parent's environment.
+
+    Redirects stdin/stdout to /dev/null and stderr to a log file. This is the
+    textbook daemon-detach: without redirecting fd 2, the child inherits
+    whatever stderr the parent had — and if the parent's stderr was part of a
+    shell pipeline (e.g. `macf_tools mode set-work X 2>&1 | tail -50`), the
+    pipe's read-end stays held open by the daemon's fd 2 and the downstream
+    `tail` hangs until the daemon exits (issue #54).
+
+    dup2 implicitly closes the target fd first, so the parent pipe's
+    write-end is released even though Python still has an fd 2.
+    """
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, 0)  # stdin
+    os.dup2(devnull, 1)  # stdout
+    try:
+        log_fd = os.open(
+            str(get_log_file_path()),
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        os.dup2(log_fd, 2)  # stderr → daemon log file
+        os.close(log_fd)
+    except OSError:
+        # Fall back to /dev/null rather than keeping the inherited stderr open.
+        os.dup2(devnull, 2)
+    os.close(devnull)
 
 
 def write_pid_file(pid: int) -> None:
@@ -416,12 +453,10 @@ def start_daemon(foreground: bool = False, poll_interval: float = DEFAULT_POLL_I
     # Child: become daemon
     os.setsid()
 
-    # Redirect stdio to /dev/null (daemon has no terminal)
-    devnull = os.open(os.devnull, os.O_RDWR)
-    os.dup2(devnull, 0)
-    os.dup2(devnull, 1)
-    # Keep stderr for logging (goes to /tmp/macf/ via hook logging)
-    os.close(devnull)
+    # Fully detach standard streams — including stderr — so a parent bash
+    # pipeline (e.g. `... 2>&1 | tail -50`) doesn't stay held open via the
+    # daemon's inherited fd 2 (issue #54).
+    _detach_standard_streams()
 
     monitor = TranscriptMonitor(jsonl_path, poll_interval=poll_interval)
 

--- a/macf/tests/test_transcript_monitor_daemon.py
+++ b/macf/tests/test_transcript_monitor_daemon.py
@@ -1,0 +1,104 @@
+"""Regression tests for transcript-monitor daemonization (issue #54).
+
+The bug: when a parent process inherits a pipe as its stderr (e.g.
+`macf_tools mode set-work X 2>&1 | tail -50`), the old daemonize path only
+redirected stdin/stdout and left stderr pointing at the parent's pipe.
+After the parent exited, the pipe's write-end stayed held open by the
+daemon's fd 2, so downstream `tail` hung until the daemon died.
+
+The fix fully redirects stderr too, into a log file.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_detach_streams_releases_inherited_stderr_pipe(tmp_path):
+    """A child process that calls _detach_standard_streams should release
+    the parent pipe even though nothing else explicitly closes it.
+
+    Run under subprocess so fd surgery stays isolated from the pytest process.
+    The subprocess script:
+      1. Opens a pipe
+      2. dup2's the write-end to fd 2 (simulates `2>&1 | ...`)
+      3. Closes the original write-end so only fd 2 keeps the pipe open
+      4. Calls _detach_standard_streams()
+      5. Reports the pipe-read-end status — should be EOF immediately
+    """
+    script = textwrap.dedent(f"""
+        import os
+        # Point XDG_RUNTIME_DIR at the tmp_path so the daemon log lives there
+        os.environ["XDG_RUNTIME_DIR"] = {str(tmp_path)!r}
+        from macf.transcript_monitor.daemon import _detach_standard_streams
+
+        r, w = os.pipe()
+        # Make fd 2 point at the pipe's write-end, as if the parent shell
+        # had redirected stderr into a pipeline.
+        os.dup2(w, 2)
+        os.close(w)   # Only fd 2 references the write-end now.
+
+        # Preserve a handle to the original stdout BEFORE detach — otherwise
+        # _detach_standard_streams redirects fd 1 to /dev/null and the test
+        # result line vanishes.
+        saved_stdout = os.dup(1)
+
+        _detach_standard_streams()
+
+        # If the fix works, fd 2 no longer references the pipe, so reading
+        # from the read-end returns EOF immediately.
+        os.set_blocking(r, False)
+        try:
+            data = os.read(r, 1)
+        except BlockingIOError:
+            data = b"STILL_OPEN"  # pipe still has a write-end somewhere — BUG
+        msg = "RESULT=" + ("EOF" if data == b"" else data.decode(errors="replace")) + "\\n"
+        os.write(saved_stdout, msg.encode())
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert "RESULT=EOF" in result.stdout, (
+        f"Expected pipe to be EOF after _detach_standard_streams; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_detach_streams_writes_stderr_to_log_file(tmp_path):
+    """After detaching, writes to stderr should land in the daemon log file,
+    not vanish and not go to the inherited terminal."""
+    script = textwrap.dedent(f"""
+        import os, sys
+        os.environ["XDG_RUNTIME_DIR"] = {str(tmp_path)!r}
+        from macf.transcript_monitor.daemon import _detach_standard_streams
+
+        _detach_standard_streams()
+        # Bypass Python's buffered sys.stderr — write directly to fd 2.
+        os.write(2, b"sentinel-stderr-line\\n")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, f"subprocess failed: {result.stderr!r}"
+    log_path = tmp_path / "macf_transcript_monitor.log"
+    assert log_path.exists(), "daemon log file should exist after detach"
+    assert "sentinel-stderr-line" in log_path.read_text()
+
+
+def test_daemon_module_source_redirects_stderr(tmp_path):
+    """Source-level regression: the daemonize path must route stderr through
+    _detach_standard_streams, not leave it inherited. Guards against the fix
+    silently regressing to the old dup2(devnull, 0..1)-only pattern."""
+    import macf.transcript_monitor.daemon as daemon_mod
+    source = Path(daemon_mod.__file__).read_text()
+    # After the fix, the child block calls the helper.
+    assert "_detach_standard_streams()" in source, (
+        "expected daemon child block to call _detach_standard_streams()"
+    )
+    # And the comment preserving the old stderr-inheritance pattern is gone.
+    assert "Keep stderr for logging" not in source, (
+        "stale comment suggests the inherited-stderr bug has regressed"
+    )


### PR DESCRIPTION
## Summary

When a user ran `macf_tools mode set-work X 2>&1 | tail -50`, the command appeared to hang for ~90 seconds. The parent `macf_tools` process forks the Transcript Monitor daemon as its last action; the old daemonize path redirected stdin and stdout to `/dev/null` but deliberately left stderr inherited (comment: *"Keep stderr for logging"*), and stderr was the parent's pipe-write-end. The pipe stayed held open via the daemon's `fd 2` until the daemon itself exited, so downstream `tail` could not emit.

A MacEff agent in the field diagnosed this by reading `/proc/PID/fd` and the daemon source during an AUTO_MODE sprint.

## Fix

- New `_detach_standard_streams()` helper:
  - Redirects `stdin`/`stdout` to `/dev/null`.
  - Redirects `stderr` to a daemon log file at `{XDG_RUNTIME_DIR|/tmp}/macf_transcript_monitor.log`. Using a real log file preserves the "stderr for logging" intent while still releasing the inherited pipe.
  - `dup2(log_fd, 2)` implicitly closes the target fd first, so the parent pipe's write-end is released even though Python still holds an `fd 2`.
  - Falls back to `/dev/null` if the log file can't be opened, rather than keeping inherited stderr open.
- `start_daemon()` now calls the helper in the child block.

Reported by SiloMacEff during their first AUTO_MODE sprint on v0.5.0.

Fixes #54

## Test plan

3 new tests in `tests/test_transcript_monitor_daemon.py`:

- [x] Subprocess-isolated: a pipe inherited as `fd 2` is released after `_detach_standard_streams()` — read-end goes EOF immediately.
- [x] Subprocess: stderr writes after detach land in the log file.
- [x] Source-level regression: daemon module must call the helper and must not contain the stale *"Keep stderr for logging"* comment.

- [x] `pytest tests/test_transcript_monitor_daemon.py` → 3 passed
- [x] Full suite: 496 passed, 9 xfailed, 0 regressions

🔧 Generated with Claude Code