### PR TITLE
fix(mode): ship mode-CLI allowlist to neutralize CC name collision (gh-53)

### DIFF
--- a/framework/policies/base/operations/autonomous_operation.md
+++ b/framework/policies/base/operations/autonomous_operation.md
@@ -172,6 +172,16 @@ macf_tools mode set AUTO_MODE --auth-token "$(python3 -c "import json; print(jso
 - Agent does NOT know WHAT the token value is
 - Token never appears in agent context or logs
 
+### Name Collision With Claude Code's "auto mode"
+
+Claude Code 2.1.116+ introduced its own `--auto-mode` harness-level concept for permissions bypass. Name collision with MACF's AUTO_MODE means a fresh MacEff agent running the activation command above may hit a Claude Code permission denial, because the permission layer heuristically reads the inline `python3 -c 'json.load(...auth_token)'` as "agent self-authorizing by reading its own auth token from a config file" — a classic self-auth anti-pattern.
+
+That heuristic is a false positive here: the activation is policy-prescribed (see above), the token is a path-validator proving the command flowed through the skill, and the real second factor is the user's safety phrase.
+
+**Shipped mitigation**: `macf_tools framework install` merges an allowlist entry for `Bash(macf_tools mode:*)` from `framework/templates/settings.permissions.json` into the agent's Claude Code settings. This tells Claude Code to trust MacEff's own CLI-level enforcement (auth token for AUTO_MODE, justification for MANUAL_MODE escape) instead of applying the generic heuristic.
+
+**If an agent still hits the denial** (e.g. the allowlist entry is missing because hooks were installed before v0.5.1, or the setting was edited away): the user should temporarily enable Claude Code's permissions-bypass mode, the agent should retry the activation, and then the user should re-run `macf_tools framework install --hooks-only` to restore the allowlist entry.
+
 ### Token Configuration
 
 The auth token is stored in `.maceff/settings.json`:

--- a/framework/skills/maceff-auto-mode/SKILL.md
+++ b/framework/skills/maceff-auto-mode/SKILL.md
@@ -111,6 +111,8 @@ After extracting policy answers:
    macf_tools mode set AUTO_MODE --auth-token "$(python3 -c "import json; print(json.load(open('.maceff/settings.json'))['auto_mode_auth_token'])")"
    ```
 
+   If this is denied by Claude Code's permission layer as "self-authorizing", see the `autonomous_operation` policy section "Name Collision With Claude Code's 'auto mode'" — the fix is an allowlist entry that `macf_tools framework install` ships automatically; if missing, user toggles permissions-bypass mode and agent retries.
+
 3. **Review CLI output**: Every permission toggle is individually reported. Confirm deny list, ask list, and safety permissions installed.
 
 4. **Remind about restart**: Session restart is required for CC to load updated permissions.

--- a/framework/templates/settings.permissions.json
+++ b/framework/templates/settings.permissions.json
@@ -1,6 +1,9 @@
 {
   "_comment": "MACF Task Permissions Template - merged by hooks install",
   "permissions": {
+    "allow": [
+      "Bash(macf_tools mode:*)"
+    ],
     "ask": [
       "Bash(macf_tools task grant-update:*)",
       "Bash(macf_tools task grant-delete:*)"

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -554,7 +554,8 @@ def _update_settings_file(settings_path: Path, hooks_prefix: str) -> bool:
                 }
             ]
 
-        # Merge permissions from template (grant commands require "ask")
+        # Merge permissions from template (allow/ask/deny lists are additively merged,
+        # deduplicated per-bucket — user's existing entries are preserved)
         try:
             maceff_root = find_maceff_root()
             template_path = maceff_root / "framework" / "templates" / "settings.permissions.json"
@@ -564,13 +565,13 @@ def _update_settings_file(settings_path: Path, hooks_prefix: str) -> bool:
                 if "permissions" in perm_template:
                     if "permissions" not in settings:
                         settings["permissions"] = {}
-                    # Merge "ask" permissions
-                    if "ask" in perm_template["permissions"]:
-                        if "ask" not in settings["permissions"]:
-                            settings["permissions"]["ask"] = []
-                        for perm in perm_template["permissions"]["ask"]:
-                            if perm not in settings["permissions"]["ask"]:
-                                settings["permissions"]["ask"].append(perm)
+                    for bucket in ("allow", "ask", "deny"):
+                        if bucket in perm_template["permissions"]:
+                            if bucket not in settings["permissions"]:
+                                settings["permissions"][bucket] = []
+                            for perm in perm_template["permissions"][bucket]:
+                                if perm not in settings["permissions"][bucket]:
+                                    settings["permissions"][bucket].append(perm)
         except Exception as e:
             print(f"   Warning: Could not merge permissions template: {e}", file=sys.stderr)
 

--- a/macf/tests/test_permissions_template_merge.py
+++ b/macf/tests/test_permissions_template_merge.py
@@ -1,0 +1,94 @@
+"""Regression tests for the permissions template merge (issue #53).
+
+The `macf_tools framework install` path merges permissions from
+`framework/templates/settings.permissions.json` into the agent's Claude
+Code settings. Historically only the `ask` bucket was merged; the
+`allow` bucket was silently ignored. The allowlist entry that neutralizes
+the AUTO_MODE/CC name collision lives under `allow`, so this bucket must
+be merged for the shipped allowlist to actually reach agent settings.
+
+These tests lock down the behavior of `_update_settings_file` against the
+real shipped template, as well as the template's content itself.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from macf.cli import _update_settings_file
+from macf.utils.paths import find_maceff_root
+
+
+@pytest.fixture(autouse=True)
+def _clear_maceff_root_cache():
+    """find_maceff_root is @lru_cache'd — earlier tests that override
+    MACEFF_ROOT_DIR may leave a stale cache pointing at a tmp_path. Clear
+    before and after so these tests see the real repo root."""
+    find_maceff_root.cache_clear()
+    yield
+    find_maceff_root.cache_clear()
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_shipped_template_allowlists_mode_cli():
+    """The shipped template must include the mode CLI allowlist — that is the
+    mechanism that prevents CC's permission layer from denying AUTO_MODE
+    activation as 'self-authorizing' (issue #53)."""
+    root = find_maceff_root()
+    template = root / "framework" / "templates" / "settings.permissions.json"
+    data = _read(template)
+    allow = (data.get("permissions") or {}).get("allow") or []
+    assert "Bash(macf_tools mode:*)" in allow, (
+        "shipped template must allowlist `Bash(macf_tools mode:*)` to neutralize "
+        "CC's name-collision denial of the AUTO_MODE activation command"
+    )
+
+
+def test_update_settings_file_merges_allow_bucket(tmp_path, monkeypatch):
+    """A fresh settings file should gain the shipped allowlist entries after
+    _update_settings_file runs — not just the `ask` entries."""
+    # Run from tmp_path so the _update_settings_file doesn't clobber anything real
+    monkeypatch.chdir(tmp_path)
+    settings_file = tmp_path / "settings.json"
+    hooks_prefix = "python .claude/hooks"
+
+    result = _update_settings_file(settings_file, hooks_prefix)
+    assert result is True
+    data = _read(settings_file)
+    allow = (data.get("permissions") or {}).get("allow") or []
+    assert "Bash(macf_tools mode:*)" in allow
+
+
+def test_update_settings_file_preserves_existing_user_allow_entries(tmp_path, monkeypatch):
+    """The merge must be additive: existing user entries in `allow` stay,
+    template entries are added, no duplicates."""
+    monkeypatch.chdir(tmp_path)
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({
+        "permissions": {
+            "allow": ["Bash(ls:*)", "Bash(macf_tools mode:*)"]  # one user entry + one overlap
+        }
+    }))
+
+    result = _update_settings_file(settings_file, "python .claude/hooks")
+    assert result is True
+    data = _read(settings_file)
+    allow = data["permissions"]["allow"]
+    assert "Bash(ls:*)" in allow, "user's existing entries must survive merge"
+    # No duplicates
+    assert allow.count("Bash(macf_tools mode:*)") == 1
+
+
+def test_update_settings_file_merges_ask_bucket_regression(tmp_path, monkeypatch):
+    """The ask bucket merge must still work — this is the behavior the old code
+    had, and we must not regress it while extending to allow/deny."""
+    monkeypatch.chdir(tmp_path)
+    settings_file = tmp_path / "settings.json"
+    _update_settings_file(settings_file, "python .claude/hooks")
+    data = _read(settings_file)
+    ask = (data.get("permissions") or {}).get("ask") or []
+    assert "Bash(macf_tools task grant-update:*)" in ask
+    assert "Bash(macf_tools task grant-delete:*)" in ask


### PR DESCRIPTION
## Summary

Claude Code 2.1.116+ introduced its own `--auto-mode` harness concept for permissions bypass. Name collision with MACF's AUTO_MODE causes a fresh MacEff agent running the policy-prescribed activation command

```bash
macf_tools mode set AUTO_MODE --auth-token "$(python3 -c "... auth_token ...")"
```

to hit a Claude Code permission denial — CC's heuristic reads the inline token extraction as *"agent self-authorizing by reading its own auth token"*, a classic self-auth anti-pattern. But `autonomous_operation` policy §3 explicitly prescribes this exact command (agent knows WHERE and HOW to extract, never WHAT; the real second factor is the user's safety phrase). The heuristic is a false positive and blocks policy-compliant activation until the user manually flips `bypassPermissions` and retries.

## Approach

Rather than renaming AUTO_MODE (high blast radius across policies, skills, tests, muscle memory), this PR ships the **tactical** fix. The strategic rename question is deferred — ask in a follow-up issue if desired.

- `framework/templates/settings.permissions.json` gains an `allow` bucket with `Bash(macf_tools mode:*)`. MacEff's own CLI enforces auth-token validation for AUTO_MODE and justification for MANUAL_MODE escape, so telling CC to trust that enforcement is safe and scoped.
- `_update_settings_file` is extended to merge the `allow` and `deny` buckets additively (dedup-per-bucket, user entries preserved), not only `ask` as before.
- `autonomous_operation.md` gains a *"Name Collision With Claude Code's 'auto mode'"* subsection documenting the false-positive, the shipped mitigation, and the recovery path when the allowlist entry is missing.
- The `maceff-auto-mode` skill cross-references the policy subsection on the activation step.

Reported by SiloMacEff during their first AUTO_MODE sprint on v0.5.0.

Fixes #53

## Test plan

4 new tests in `tests/test_permissions_template_merge.py`:

- [x] Shipped template must allowlist `Bash(macf_tools mode:*)`.
- [x] Fresh settings file gains allowlist entries on merge.
- [x] Existing user allow entries survive merge, no duplicates.
- [x] `ask` bucket merge behavior is preserved (regression guard).

Autouse fixture clears `find_maceff_root`'s `@lru_cache` to prevent pollution from earlier tests that override `MACEFF_ROOT_DIR`.

- [x] `pytest tests/test_permissions_template_merge.py` → 4 passed
- [x] Full suite: 500 passed, 9 xfailed, 0 regressions

🔧 Generated with Claude Code