### PR TITLE
fix(viz): markdown presenter — full-width wrapping + loud fallback warning

### DIFF
--- a/macf/src/macf/viz/markdown.py
+++ b/macf/src/macf/viz/markdown.py
@@ -32,7 +32,13 @@ TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 
 def _convert_md_to_html(md_text: str) -> str:
-    """Convert markdown to HTML, with graceful fallback."""
+    """Convert markdown to HTML, with graceful fallback.
+
+    If the optional `markdown` library is not installed, falls back to
+    wrapping escaped raw text in <pre>. A clear warning is printed to
+    stderr so the user can discover the missing dependency instead of
+    seeing a confusing raw-text render.
+    """
     try:
         import markdown
         return markdown.markdown(
@@ -43,6 +49,12 @@ def _convert_md_to_html(md_text: str) -> str:
             },
         )
     except ImportError:
+        print(
+            "⚠️ MACF: `markdown` library not installed — output will be "
+            "RAW TEXT in a <pre> block, not rendered HTML.\n"
+            "   Install with: pip install markdown    (or `pip install -e .[viz]` for the full viz extras)",
+            file=sys.stderr,
+        )
         # Fallback: escape HTML and wrap in <pre>
         escaped = (md_text
                    .replace("&", "&amp;")

--- a/macf/src/macf/viz/templates/markdown_dark.html
+++ b/macf/src/macf/viz/templates/markdown_dark.html
@@ -14,9 +14,9 @@
     font-family: Georgia, 'Times New Roman', serif;
     font-size: 15px;
     line-height: 1.75;
-    max-width: 820px;
+    max-width: min(1100px, 95vw);
     margin: 0 auto;
-    padding: 48px 24px 96px;
+    padding: 48px max(24px, 3vw) 96px;
   }
 
   /* Headings — amber warmth */
@@ -74,14 +74,19 @@
     border: 1px solid #222;
     border-radius: 6px;
     padding: 16px 20px;
-    overflow-x: auto;
     margin: 1em 0;
     line-height: 1.5;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
   pre code {
     background: none;
     padding: 0;
     font-size: 0.85em;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   /* Block quotes — left bar accent */


### PR DESCRIPTION
## Summary

Two related fixes to `macf_tools markdown present`:

### 1. Template (`markdown_dark.html`) — fluid full-width layout

- `body max-width: 820px` → `min(1100px, 95vw)` — the old fixed cap left big wasted side margins on any viewport > 820px (most modern desktops). The new fluid cap fills the viewport up to 1100px and degrades gracefully on narrow windows.
- `body padding: 48px 24px 96px` → `48px max(24px, 3vw) 96px` — fluid horizontal padding on small viewports.
- `pre` and `pre code` now use `white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word;` instead of `overflow-x: auto`. Long code lines wrap cleanly inside the code block instead of forcing a horizontal scrollbar.

### 2. Renderer (`markdown.py`) — louden the missing-dep fallback

When the optional `markdown` library is missing (e.g., bare-metal install without `[viz]` extras), the renderer now prints a clear stderr warning:

```
⚠️ MACF: \`markdown\` library not installed — output will be RAW TEXT in a <pre> block, not rendered HTML.
   Install with: pip install markdown    (or \`pip install -e .[viz]\` for the full viz extras)
```

Previously the fallback was silent — the user just saw raw markdown wrapped in `<pre>` and (reasonably) thought the tool was broken. The warning makes the missing-dep case discoverable.

## Repro that motivated the fix

A bare-metal install path (`pip install -e MacEff/macf` without `[viz]` extras) silently lacks `markdown`. Combined with the 820px max-width and `overflow-x: auto` on `<pre>`, presenting any non-trivial CA produced:

- Raw markdown text wrapped in `<pre>` (looked like preformatted plaintext)
- 820px column with wasted side margins on a 1280px+ desktop
- Horizontal scrollbars in code blocks for long Kotlin/Python lines

Verified before-and-after via headless-chromium screenshot loop:

```bash
chromium --headless --no-sandbox --disable-gpu --window-size=1280,800 \
    --screenshot=/tmp/snap.png file:///tmp/macf_md_<file>.html
```

Pre-fix: raw text, narrow column, side-scroll.
Post-fix: rendered HTML with amber headings, full-width responsive layout, code wraps cleanly.

## Test plan

- [x] Visual regression: rendered an existing 200-line CA (Reticulum brief, ~210 lines with multiple Kotlin + Python fenced code blocks) before and after; layout fills viewport, code blocks wrap, headings flow.
- [x] No JS, no new dependencies; pure CSS + one Python `print(file=sys.stderr)`.
- [ ] Suggest reviewer also try on a wider monitor (≥ 1600px) to confirm the 1100px cap is appropriate.
- [ ] Suggest reviewer try on narrow viewport (< 800px, e.g. iframe or split-screen) to verify the fluid `95vw` and `3vw` padding behave well.

## Related

- Sibling PR opportunity (not in this commit): consider promoting `markdown` from `[viz]` optional extras to default deps so `macf_tools markdown present` works after a plain install. Tradeoff: small added install size for everyone vs. opt-in for those who want viz tooling. Either path is fine; this PR doesn't take a position.

---
Filed by SiloMacEff@d0cdcf
Cycle 6 alpha-test follow-up sprint #89 — bug task #93