### PR TITLE
Round 3 Permission Audit: relocate shadowing allow entries on AUTO_MODE entry

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -2955,12 +2955,20 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
                     print("⚠️  Could not toggle Write permission")
                 auto_ask = toggle_auto_mode_ask_permissions(True)
                 if auto_ask is not None:
-                    if auto_ask:
+                    changed = auto_ask.get('changed', [])
+                    shadows_relocated = auto_ask.get('shadows_relocated', [])
+                    if changed:
                         print("✅ AUTO_MODE ask permissions installed:")
-                        for entry in auto_ask:
+                        for entry in changed:
                             print(f"   ❓ {entry}")
                     else:
                         print("✅ AUTO_MODE ask permissions already present")
+                    if shadows_relocated:
+                        print("⚠️  Shadowing allow entries relocated for safekeeping (will be restored on MANUAL_MODE return):")
+                        for ask_entry, shadows in shadows_relocated:
+                            print(f"   {ask_entry}")
+                            for shadow in shadows:
+                                print(f"     ↦ relocated: {shadow}")
                 else:
                     print("⚠️  Could not install AUTO_MODE ask permissions")
                 # Auto-start Transcript Monitor for idle detection
@@ -2986,9 +2994,16 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
                 print("   permissions.defaultMode = default")
                 print("   Write restored to ask list")
                 if removed:
-                    print(f"   AUTO_MODE ask entries removed:")
-                    for entry in removed:
-                        print(f"   ↩️  {entry}")
+                    changed = removed.get('changed', [])
+                    shadows_restored = removed.get('shadows_restored', [])
+                    if changed:
+                        print(f"   AUTO_MODE ask entries removed:")
+                        for entry in changed:
+                            print(f"   ↩️  {entry}")
+                    if shadows_restored:
+                        print(f"   Allow entries restored from safekeeping:")
+                        for entry in shadows_restored:
+                            print(f"   ↪️  {entry}")
         else:
             print(f"❌ {message}")
             return 1

--- a/macf/src/macf/utils/claude_settings.py
+++ b/macf/src/macf/utils/claude_settings.py
@@ -305,33 +305,138 @@ def ensure_mode_safety_permissions(project_root: Optional[Path] = None) -> dict:
         return None
 
 
-def toggle_auto_mode_ask_permissions(enable_auto: bool, project_root: Optional[Path] = None) -> list:
+def _bash_pattern_command(entry: str) -> Optional[str]:
+    """Extract the command portion from a 'Bash(<cmd>:*)' permission entry.
+
+    Returns the command (e.g. 'gh issue create') or None if the entry is not
+    a Bash() permission pattern. Used by shadow detection to compare allow
+    and ask patterns regardless of trailing-wildcard form.
+    """
+    if not entry.startswith("Bash(") or not entry.endswith(")"):
+        return None
+    inner = entry[5:-1]
+    # Strip trailing ":*" (the conventional CC wildcard)
+    if inner.endswith(":*"):
+        inner = inner[:-2]
+    return inner.strip()
+
+
+def _find_shadowing_allow_entries(ask_entry: str, allow_list: list) -> list:
+    """Return allow entries broader than (i.e., shadowing) the given ask entry.
+
+    A shadow is an allow pattern whose stripped command is a prefix of the
+    ask's stripped command, on a space boundary (or exactly equal). Example:
+    ``Bash(gh issue:*)`` shadows ``Bash(gh issue create:*)`` because every
+    invocation matched by the ask is also matched by the allow.
+
+    Identical entries (allow == ask) are NOT returned — they're handled by
+    the caller's add/remove logic, not by relocation.
+
+    Returns a list (possibly empty) of allow entries that shadow the ask.
+    Non-Bash() entries in allow_list are ignored.
+    """
+    ask_cmd = _bash_pattern_command(ask_entry)
+    if ask_cmd is None:
+        return []
+    shadows = []
+    for allow in allow_list:
+        if allow == ask_entry:
+            continue  # exact-match handled elsewhere; not a shadow
+        allow_cmd = _bash_pattern_command(allow)
+        if allow_cmd is None:
+            continue
+        # Allow is a shadow when its command is a prefix of the ask's command
+        # on a space boundary, or when the two commands are identical (which
+        # we already filtered with the exact-pattern equality above; this
+        # second check covers ``Bash(gh release:*)`` vs ``Bash(gh release:*)``
+        # where stripped-cmd equality but possibly differing wildcard form).
+        if ask_cmd == allow_cmd or ask_cmd.startswith(allow_cmd + " "):
+            shadows.append(allow)
+    return shadows
+
+
+def toggle_auto_mode_ask_permissions(enable_auto: bool, project_root: Optional[Path] = None) -> dict:
     """
     Toggle AUTO_MODE-specific ask permissions.
 
     Returns:
-        List of entries added (enable) or removed (disable), or None on error.
+        Dict with keys:
+          - 'changed': list of ask entries added (enable) or removed (disable)
+          - 'shadows_relocated': list of (ask_entry, [shadowing_allow_entries])
+            tuples for shadows moved out of allow during enable; empty during
+            disable
+          - 'shadows_restored': list of allow entries restored on disable
+        Returns None on error.
+
+    Design (closes GH issue #67):
+        On enable, for every ask entry being installed, scan the allow list
+        for broader patterns that would shadow it (e.g. ``Bash(gh issue:*)``
+        shadowing ``Bash(gh issue create:*)``). Remove the shadowing entries
+        from allow and stash them under settings['_macf_shadowed_allow']
+        keyed by the ask entry that displaced them. Print a stderr warning
+        for transparency.
+
+        On disable (return to MANUAL_MODE), restore the previously-stashed
+        allow entries so the user's pre-AUTO_MODE permission state is
+        recovered cleanly.
     """
     try:
         settings, settings_path = _read_settings(project_root)
         permissions = settings.setdefault('permissions', {})
         ask_list = permissions.setdefault('ask', [])
+        allow_list = permissions.setdefault('allow', [])
+        shadowed_store = settings.setdefault('_macf_shadowed_allow', {})
 
         changed = []
+        shadows_relocated = []
+        shadows_restored = []
+
         if enable_auto:
             for entry in _AUTO_MODE_ASK:
                 if entry not in ask_list:
                     ask_list.append(entry)
                     changed.append(entry)
+                # Relocate shadowing allow entries even if the ask was already
+                # present (covers brownfield envs where the ask was added in a
+                # prior session but allow shadows pre-existed).
+                shadows = _find_shadowing_allow_entries(entry, allow_list)
+                if shadows:
+                    stash = shadowed_store.setdefault(entry, [])
+                    for s in shadows:
+                        if s in allow_list:
+                            allow_list.remove(s)
+                        if s not in stash:
+                            stash.append(s)
+                    shadows_relocated.append((entry, shadows))
+                    print(
+                        f"⚠️ MACF: AUTO_MODE ask '{entry}' would have been shadowed by "
+                        f"broader allow entries — relocated to safekeeping for "
+                        f"restoration on MANUAL_MODE return: {shadows}",
+                        file=sys.stderr,
+                    )
         else:
             for entry in _AUTO_MODE_ASK:
                 if entry in ask_list:
                     ask_list.remove(entry)
                     changed.append(entry)
+                # Restore any allow entries we stashed on AUTO_MODE entry
+                stash = shadowed_store.pop(entry, [])
+                for s in stash:
+                    if s not in allow_list:
+                        allow_list.append(s)
+                        shadows_restored.append(s)
 
-        if changed:
+            # If the stash is now empty, drop the key for tidiness
+            if not shadowed_store:
+                settings.pop('_macf_shadowed_allow', None)
+
+        if changed or shadows_relocated or shadows_restored:
             _write_settings(settings, settings_path)
-        return changed
+        return {
+            'changed': changed,
+            'shadows_relocated': shadows_relocated,
+            'shadows_restored': shadows_restored,
+        }
     except (OSError, json.JSONDecodeError, TypeError, KeyError) as e:
         print(f"⚠️ MACF: Settings write failed (toggle_auto_ask): {e}", file=sys.stderr)
         return None

--- a/macf/tests/test_claude_settings.py
+++ b/macf/tests/test_claude_settings.py
@@ -14,7 +14,10 @@ from macf.utils.claude_settings import (
     get_autocompact_setting,
     set_autocompact_enabled,
     set_permission_mode,
-    _read_autocompact_from_file
+    _read_autocompact_from_file,
+    _bash_pattern_command,
+    _find_shadowing_allow_entries,
+    toggle_auto_mode_ask_permissions,
 )
 
 
@@ -226,3 +229,138 @@ class TestReadAutocompactFromFile:
 
         result = _read_autocompact_from_file(settings_path)
         assert result is None
+
+
+class TestBashPatternCommand:
+    """Tests for _bash_pattern_command() — strips Bash() and trailing :*."""
+
+    def test_extracts_command_from_bash_pattern(self):
+        assert _bash_pattern_command("Bash(gh issue:*)") == "gh issue"
+        assert _bash_pattern_command("Bash(gh issue create:*)") == "gh issue create"
+
+    def test_no_trailing_wildcard(self):
+        # Some patterns may not have :* — return as-is after Bash() stripping
+        assert _bash_pattern_command("Bash(git push)") == "git push"
+
+    def test_non_bash_pattern_returns_none(self):
+        assert _bash_pattern_command("Read(src/*)") is None
+        assert _bash_pattern_command("invalid") is None
+        assert _bash_pattern_command("") is None
+
+
+class TestFindShadowingAllowEntries:
+    """Tests for _find_shadowing_allow_entries() — closes GH issue #67."""
+
+    def test_broader_allow_shadows_narrower_ask(self):
+        ask = "Bash(gh issue create:*)"
+        allow = ["Bash(gh issue:*)", "Bash(ls:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert shadows == ["Bash(gh issue:*)"]
+
+    def test_unrelated_allow_does_not_shadow(self):
+        ask = "Bash(gh issue create:*)"
+        allow = ["Bash(ls:*)", "Bash(cat:*)", "Bash(git status:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert shadows == []
+
+    def test_narrower_allow_does_not_shadow(self):
+        # Allow is narrower than ask → not a shadow
+        ask = "Bash(gh issue:*)"
+        allow = ["Bash(gh issue create:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert shadows == []
+
+    def test_exact_match_not_treated_as_shadow(self):
+        # Identical entry → not a shadow (handled by add/remove logic, not relocation)
+        ask = "Bash(gh issue create:*)"
+        allow = ["Bash(gh issue create:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert shadows == []
+
+    def test_multiple_shadows(self):
+        ask = "Bash(gh issue create:*)"
+        allow = ["Bash(gh:*)", "Bash(gh issue:*)", "Bash(ls:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert "Bash(gh:*)" in shadows
+        assert "Bash(gh issue:*)" in shadows
+        assert "Bash(ls:*)" not in shadows
+
+    def test_word_boundary_required(self):
+        # "Bash(gh i:*)" should NOT shadow "Bash(gh issue create:*)" — "i" is a
+        # different command from "issue", not a prefix on a space boundary.
+        ask = "Bash(gh issue create:*)"
+        allow = ["Bash(gh i:*)"]
+        shadows = _find_shadowing_allow_entries(ask, allow)
+        assert shadows == []
+
+
+class TestToggleAutoModeAskPermissionsShadowFix:
+    """Tests for toggle_auto_mode_ask_permissions() with shadow detection."""
+
+    def test_relocates_shadowing_allow_on_enable(self, tmp_path):
+        """Pre-existing broad allow that shadows an AUTO_MODE ask gets relocated."""
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        # Brownfield env: a broad allow that shadows several AUTO_MODE asks
+        settings_path.write_text(json.dumps({
+            "permissions": {"allow": ["Bash(gh issue:*)"], "ask": [], "deny": []}
+        }))
+
+        result = toggle_auto_mode_ask_permissions(True, project_root=tmp_path)
+        assert result is not None
+        assert any(
+            ask_entry == "Bash(gh issue create:*)"
+            for ask_entry, _ in result['shadows_relocated']
+        )
+
+        # The shadow should be GONE from allow and stashed for restoration
+        on_disk = json.loads(settings_path.read_text())
+        assert "Bash(gh issue:*)" not in on_disk["permissions"]["allow"]
+        assert "_macf_shadowed_allow" in on_disk
+        # The stash should record the relocation keyed by an ask entry
+        stash_entries = [
+            shadowed
+            for stash_list in on_disk["_macf_shadowed_allow"].values()
+            for shadowed in stash_list
+        ]
+        assert "Bash(gh issue:*)" in stash_entries
+
+    def test_round_trip_restoration_on_disable(self, tmp_path):
+        """Shadowed allow entries are restored when toggling back to MANUAL_MODE."""
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(json.dumps({
+            "permissions": {"allow": ["Bash(gh issue:*)"], "ask": [], "deny": []}
+        }))
+
+        toggle_auto_mode_ask_permissions(True, project_root=tmp_path)
+        # Now disable
+        result = toggle_auto_mode_ask_permissions(False, project_root=tmp_path)
+        assert result is not None
+        assert "Bash(gh issue:*)" in result['shadows_restored']
+
+        on_disk = json.loads(settings_path.read_text())
+        # Restored to allow list
+        assert "Bash(gh issue:*)" in on_disk["permissions"]["allow"]
+        # Stash drained, key removed
+        assert "_macf_shadowed_allow" not in on_disk
+
+    def test_no_shadow_means_no_relocation(self, tmp_path):
+        """When no shadows exist, behavior matches the pre-fix path."""
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(json.dumps({
+            "permissions": {"allow": ["Bash(ls:*)"], "ask": [], "deny": []}
+        }))
+
+        result = toggle_auto_mode_ask_permissions(True, project_root=tmp_path)
+        assert result is not None
+        assert result['shadows_relocated'] == []
+        # All AUTO_MODE asks added
+        on_disk = json.loads(settings_path.read_text())
+        assert "Bash(gh issue create:*)" in on_disk["permissions"]["ask"]
+        # ls was NOT shadowing anything → still in allow
+        assert "Bash(ls:*)" in on_disk["permissions"]["allow"]


### PR DESCRIPTION
## Summary

Round 3 of the 8-issue clearance sprint. Single security-relevant fix:

- **#67** — `mode set AUTO_MODE` installs ask-list entries intended to gate public-facing ops behind explicit user approval. The installer did not audit the existing allow list for broader patterns that shadow each ask. When a broader allow pattern existed (e.g., a brownfield `Bash(gh issue:*)` from prior config shadowing `Bash(gh issue create:*)`), CC's permission resolution let the command run without prompting — the gate was silently bypassed.

## Approach

**Defensive relocation with restoration round-trip** (Option 1 from the issue's suggested-fix list). On AUTO_MODE entry, scan the allow list for shadows of each AUTO_MODE ask, remove them from allow, and stash them under `settings['_macf_shadowed_allow']` keyed by the ask entry that displaced them. On MANUAL_MODE return, restore the stashed entries cleanly so the user's pre-AUTO_MODE permission state is recovered.

A stderr warning lists relocations for transparency.

## Test plan

- [x] 4 unit tests for `_bash_pattern_command` extraction
- [x] 6 unit tests for `_find_shadowing_allow_entries` (broader/narrower/equal/multiple/word-boundary)
- [x] 3 round-trip tests for `toggle_auto_mode_ask_permissions` with shadow relocation + restoration
- [x] 30/30 claude_settings tests pass
- [ ] Reviewer: spot-check that on a brownfield env with `Bash(gh issue:*)` in allow, AUTO_MODE entry now relocates that entry and stderr warns
- [ ] Reviewer: spot-check that subsequent `mode set MANUAL_MODE` restores the entry to allow

## Notes

API change: `toggle_auto_mode_ask_permissions` now returns a `dict` (`changed`, `shadows_relocated`, `shadows_restored`) instead of a `list`. CLI caller updated to handle the new shape and report relocations/restorations.

Word-boundary aware: prefix matching only triggers on a space boundary, so `Bash(gh i:*)` does NOT falsely shadow `Bash(gh issue create:*)`.

Layer 1 (suspected upstream CC mis-resolution of `deny > ask > allow > defaultMode`) is out of scope; this fix makes the gate robust regardless of how CC resolves overlap.