### PR TITLE
Round 4 Knowledge Infra: expand cross-CA indexer + whole-document wiki-link fallback

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6822,7 +6822,7 @@ def cmd_idea_graph(args: argparse.Namespace) -> int:
 
 
 def cmd_knowledge_graph(args: argparse.Namespace) -> int:
-    """Show cross-CA knowledge graph (ideas + learnings + observations)."""
+    """Show cross-CA knowledge graph (ideas + learnings + checkpoints + reflections + observations + experiments + reports)."""
     from .ideas import (build_knowledge_graph, format_graph_cluster_cross_ca,
                         format_graph_tree)
 
@@ -7887,7 +7887,7 @@ def _build_parser() -> argparse.ArgumentParser:
     idea_graph.set_defaults(func=cmd_idea_graph)
 
     # ── knowledge ────────────────────────────────────────────────────────
-    knowledge_parser = sub.add_parser("knowledge", help="cross-CA knowledge graph (ideas + learnings + observations)")
+    knowledge_parser = sub.add_parser("knowledge", help="cross-CA knowledge graph (ideas + learnings + checkpoints + reflections + observations + experiments + reports)")
     knowledge_sub = knowledge_parser.add_subparsers(dest="knowledge_cmd")
 
     kg_graph = knowledge_sub.add_parser("graph", help="show cross-CA knowledge graph")

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -346,7 +346,9 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
     wiki_index = defaultdict(set, {k: set(v) for k, v in graph["wiki_index"].items()})
     ca_nodes = {}  # non-idea CA nodes: {node_id: {type, title, path}}
 
-    # Scan additional directories for markdown files with ## Wiki-Links
+    # Scan additional CA directories for wiki-links. Extends beyond
+    # learnings/observations to cover the full Consciousness Artifact corpus
+    # (closes GH issue #73).
     if scan_dirs is None:
         try:
             from .utils.paths import find_agent_home
@@ -354,7 +356,11 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
             if agent_home:
                 scan_dirs = [
                     agent_home / "agent" / "private" / "learnings",
+                    agent_home / "agent" / "private" / "checkpoints",
+                    agent_home / "agent" / "private" / "reflections",
                     agent_home / "agent" / "public" / "observations",
+                    agent_home / "agent" / "public" / "experiments",
+                    agent_home / "agent" / "public" / "reports",
                 ]
         except (OSError, ImportError) as e:
             print(f"⚠️ MACF: knowledge graph scan dirs failed: {e}", file=sys.stderr)
@@ -363,24 +369,36 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
     for scan_dir in (scan_dirs or []):
         if not scan_dir.exists():
             continue
-        ca_type = scan_dir.name  # "learnings" or "observations"
-        for md_file in sorted(scan_dir.glob("*.md")):
+        ca_type = scan_dir.name  # "learnings", "checkpoints", "reflections", etc.
+        # Recursive walk so experiments/<dated>/ subfolders are picked up.
+        for md_file in sorted(scan_dir.rglob("*.md")):
             if md_file.name == "INDEX.md":
                 continue
             try:
                 content = md_file.read_text(errors='replace')
             except OSError:
                 continue
-            # Find ## Wiki-Links section
+            # Two-tier wiki-link extraction: prefer the explicit ## Wiki-Links
+            # section (canonical convention in learnings). Fall back to any
+            # [[concept]] occurrences elsewhere in the document so CAs that
+            # don't follow the explicit-section convention (most CCPs,
+            # JOTEWRs, experiment artifacts) still produce edges.
+            concepts = []
             wl_match = re_mod.search(r'## Wiki-Links\s*\n(.+?)(?:\n##|\Z)', content, re_mod.DOTALL)
-            if not wl_match:
-                continue
-            wl_section = wl_match.group(1)
-            concepts = re_mod.findall(r'\[\[(.+?)\]\]', wl_section)
+            if wl_match:
+                concepts = re_mod.findall(r'\[\[(.+?)\]\]', wl_match.group(1))
+            if not concepts:
+                # Fallback: scan whole document for [[...]] references
+                concepts = re_mod.findall(r'\[\[(.+?)\]\]', content)
             if not concepts:
                 continue
-            # Create a node ID for this CA
-            node_id = f"{ca_type}:{md_file.stem}"
+            # Create a node ID for this CA. For nested CAs (experiments),
+            # include the immediate parent folder for disambiguation.
+            if md_file.parent != scan_dir:
+                stem_part = f"{md_file.parent.name}/{md_file.stem}"
+            else:
+                stem_part = md_file.stem
+            node_id = f"{ca_type}:{stem_part}"
             # Extract title from first heading
             title_match = re_mod.search(r'^#\s+(.+)', content, re_mod.MULTILINE)
             title = title_match.group(1)[:50] if title_match else md_file.stem[:50]

--- a/macf/tests/test_knowledge_graph.py
+++ b/macf/tests/test_knowledge_graph.py
@@ -1,0 +1,109 @@
+"""Tests for build_knowledge_graph() — cross-CA wiki-link indexing.
+
+Closes GH issue #73 (macf_tools knowledge cross-CA graph only indexed ideas).
+The expanded indexer now picks up learnings, checkpoints, reflections,
+observations, experiments (recursive), and reports — and falls back to
+whole-document ``[[concept]]`` scanning when no explicit ## Wiki-Links
+section is present.
+"""
+
+import pytest
+from pathlib import Path
+
+from macf.ideas import build_knowledge_graph
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+@pytest.fixture
+def fake_agent_root(tmp_path):
+    """An agent root tree mirroring the layout build_knowledge_graph scans."""
+    (tmp_path / "agent" / "private" / "learnings").mkdir(parents=True)
+    (tmp_path / "agent" / "private" / "checkpoints").mkdir(parents=True)
+    (tmp_path / "agent" / "private" / "reflections").mkdir(parents=True)
+    (tmp_path / "agent" / "public" / "observations").mkdir(parents=True)
+    (tmp_path / "agent" / "public" / "experiments").mkdir(parents=True)
+    (tmp_path / "agent" / "public" / "reports").mkdir(parents=True)
+    return tmp_path
+
+
+class TestBuildKnowledgeGraphCrossCA:
+    """Shape tests for the expanded cross-CA indexer."""
+
+    def test_indexes_learnings_with_explicit_wiki_links_section(self, fake_agent_root):
+        _write(
+            fake_agent_root / "agent" / "private" / "learnings" / "l1.md",
+            "# Learning One\n\n## Wiki-Links\n[[concept-A]] [[concept-B]]\n",
+        )
+        scan_dirs = [fake_agent_root / "agent" / "private" / "learnings"]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        assert "learnings:l1" in kg["ca_nodes"]
+        assert kg["ca_nodes"]["learnings:l1"]["title"] == "Learning One"
+
+    def test_falls_back_to_whole_document_wiki_link_scan(self, fake_agent_root):
+        """CCPs/JOTEWRs without an explicit ## Wiki-Links section still get edges."""
+        _write(
+            fake_agent_root / "agent" / "private" / "checkpoints" / "cp1.md",
+            (
+                "# Checkpoint One\n\n"
+                "We discussed [[concept-A]] in passing here. Also touched on [[concept-C]].\n\n"
+                "## Other Section\nNo wiki-links section header in this document.\n"
+            ),
+        )
+        scan_dirs = [fake_agent_root / "agent" / "private" / "checkpoints"]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        assert "checkpoints:cp1" in kg["ca_nodes"]
+
+    def test_indexes_recursive_experiment_subfolders(self, fake_agent_root):
+        """Experiments nest under dated subfolders; the indexer must rglob."""
+        exp_dir = fake_agent_root / "agent" / "public" / "experiments" / "2026-05-01_my_experiment"
+        _write(exp_dir / "protocol.md", "# Protocol\n\n[[concept-A]]\n")
+        scan_dirs = [fake_agent_root / "agent" / "public" / "experiments"]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        # Node id includes the dated parent folder for disambiguation
+        assert "experiments:2026-05-01_my_experiment/protocol" in kg["ca_nodes"]
+
+    def test_skips_index_md(self, fake_agent_root):
+        """INDEX.md is the human-readable index, not a CA — skip it."""
+        _write(
+            fake_agent_root / "agent" / "private" / "learnings" / "INDEX.md",
+            "# Learnings INDEX\n\n[[concept-A]]\n",
+        )
+        scan_dirs = [fake_agent_root / "agent" / "private" / "learnings"]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        assert "learnings:INDEX" not in kg["ca_nodes"]
+
+    def test_files_without_wiki_links_are_omitted(self, fake_agent_root):
+        """If a CA has no [[concept]] anywhere, no node is added."""
+        _write(
+            fake_agent_root / "agent" / "private" / "learnings" / "no_links.md",
+            "# Plain Learning\n\nNo wiki-link references in this document.\n",
+        )
+        scan_dirs = [fake_agent_root / "agent" / "private" / "learnings"]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        assert "learnings:no_links" not in kg["ca_nodes"]
+
+    def test_cross_ca_edges_via_shared_concept(self, fake_agent_root):
+        """Two CAs in different directories sharing a [[concept]] get an edge."""
+        _write(
+            fake_agent_root / "agent" / "private" / "learnings" / "lA.md",
+            "# Learning A\n\n[[shared-concept]]\n",
+        )
+        _write(
+            fake_agent_root / "agent" / "private" / "checkpoints" / "cpA.md",
+            "# Checkpoint A\n\n[[shared-concept]]\n",
+        )
+        scan_dirs = [
+            fake_agent_root / "agent" / "private" / "learnings",
+            fake_agent_root / "agent" / "private" / "checkpoints",
+        ]
+        kg = build_knowledge_graph(scan_dirs=scan_dirs)
+        assert "learnings:lA" in kg["ca_nodes"]
+        assert "checkpoints:cpA" in kg["ca_nodes"]
+        # Edges are bidirectional via the wiki-index
+        edges = kg["edges"]
+        assert "checkpoints:cpA" in edges.get("learnings:lA", set())
+        assert "learnings:lA" in edges.get("checkpoints:cpA", set())


### PR DESCRIPTION
## Summary

Round 4 of the 8-issue clearance sprint (final round).

- **#73** — `macf_tools knowledge` advertised "cross-CA knowledge graph (ideas + learnings + ...)" but the indexer's default scan_dirs only covered learnings and observations, and even those only contributed when they had an explicit `## Wiki-Links` section. Agents authoring real-world consciousness artifacts (CCPs, JOTEWRs, experiment artifacts) saw "1 node, 0 edges" regardless of how many wiki-links the docs actually contained.

## Approach

Two complementary fixes:

1. **Extended scan_dirs** to cover the full CA corpus: learnings, **checkpoints (NEW)**, **reflections (NEW)**, observations, **experiments (NEW; recursive)**, **reports (NEW)**.

2. **Two-tier wiki-link extraction**: prefer the explicit `## Wiki-Links` section (canonical learning convention), but fall back to whole-document `[[concept]]` scan so CAs that don't follow the explicit-section convention (most CCPs, JOTEWRs, experiment artifacts) still produce nodes and edges.

Nested CA node IDs include the immediate parent folder for disambiguation (e.g., `experiments:2026-05-01_my_experiment/protocol`).

Help text on the cmd handler + subparser updated to reflect the expanded scope.

## Test plan

- [x] 6 new tests in `test_knowledge_graph.py`: explicit `## Wiki-Links` section, whole-document fallback scan, recursive experiment dirs, INDEX.md skipping, omission of files without wiki-links, cross-CA edge construction
- [x] All pass
- [ ] Reviewer: spot-check on a real env with N learnings, that `macf_tools knowledge graph` now reports N+ nodes (not just the ideas count)
- [ ] Reviewer: spot-check on an env with experiment CAs (recursive), that they appear as `experiments:<dated_folder>/<file>` nodes