### PR TITLE
Bug batch: TM auto-start + chain-mode emoji visibility + LOW_CONTEXT wind-down

### DIFF
--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -18,7 +18,7 @@ from macf.utils import (
     get_breadcrumb,
     detect_auto_mode
 )
-from macf.modes import detect_active_modes, anticipate_mode_change, format_mode_indicators
+from macf.modes import detect_active_modes, anticipate_mode_change, format_mode_indicators, get_active_task_type_marker
 from macf.agent_events_log import append_event
 from macf.event_queries import get_active_policy_injections_from_events
 from macf.hooks.hook_logging import log_hook_event
@@ -164,7 +164,8 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             token_info = get_token_info(session_id)
             active_modes = detect_active_modes(session_id, token_info)
             active_modes = anticipate_mode_change(tool_name, tool_input, active_modes)
-            mode_indicator = format_mode_indicators(active_modes)
+            task_type_marker = get_active_task_type_marker()
+            mode_indicator = format_mode_indicators(active_modes, task_type_marker)
         except (OSError, ValueError) as e:
             print(f"⚠️ MACF: mode detection failed, falling back: {e}", file=sys.stderr)
             auto_mode_active, _ = detect_auto_mode(session_id)

--- a/macf/src/macf/hooks/handle_stop.py
+++ b/macf/src/macf/hooks/handle_stop.py
@@ -29,6 +29,7 @@ from macf.modes import (
     detect_active_modes, get_current_work_mode,
     sample_next_work_mode, format_recommendation,
     should_self_manage_closeout, format_mode_indicators,
+    should_suppress_markov, format_low_context_directive,
 )
 
 
@@ -341,9 +342,17 @@ Development Drive Stats:
                     try:
                         active_modes = detect_active_modes(session_id, token_info)
                         current_wm = get_current_work_mode(active_modes)
-                        op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
-                        selected, dist = sample_next_work_mode(current_wm, op_modes)
-                        recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
+                        # BUG #1081: when LOW_CONTEXT is active, suppress Markov
+                        # entirely and emit the mandatory wind-down directive
+                        # instead. Markov sampling at low context produces
+                        # out-of-phase mode-change suggestions that compete
+                        # with closeout discipline.
+                        if should_suppress_markov(active_modes, current_wm) and "LOW_CONTEXT" in active_modes:
+                            recommendation = "\n" + format_low_context_directive()
+                        else:
+                            op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
+                            selected, dist = sample_next_work_mode(current_wm, op_modes)
+                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
                     except (OSError, ValueError, ImportError) as e:
                         print(f"⚠️ MACF: recommender failed: {e}", file=sys.stderr)
 
@@ -430,13 +439,18 @@ Development Drive Stats:
                         except Exception as e:
                             print(f"⚠️ MACF: Timer gate Telegram error: {e}", file=sys.stderr)
                         # Markov recommender: suggest next work mode transition
+                        # (suppressed in LOW_CONTEXT — BUG #1081 — replaced
+                        # with mandatory wind-down directive).
                         recommendation = ""
                         try:
                             active_modes = detect_active_modes(session_id, token_info)
                             current_wm = get_current_work_mode(active_modes)
-                            op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
-                            selected, dist = sample_next_work_mode(current_wm, op_modes)
-                            recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
+                            if should_suppress_markov(active_modes, current_wm) and "LOW_CONTEXT" in active_modes:
+                                recommendation = "\n" + format_low_context_directive()
+                            else:
+                                op_modes = {m for m in active_modes if m in ("AUTO_MODE", "USER_IDLE", "QUIET_MODE", "LOW_CONTEXT")}
+                                selected, dist = sample_next_work_mode(current_wm, op_modes)
+                                recommendation = "\n" + format_recommendation(current_wm, selected, dist, "maceff")
                         except (OSError, ValueError, ImportError) as e:
                             print(f"⚠️ MACF: recommender failed: {e}", file=sys.stderr)
 

--- a/macf/src/macf/modes/__init__.py
+++ b/macf/src/macf/modes/__init__.py
@@ -18,6 +18,8 @@ from .detection import (
     is_quiet,
     get_current_work_mode,
     is_markov_eligible,
+    should_suppress_markov,
+    format_low_context_directive,
     apply_sprint_mode_lock,
     get_transition_distribution,
     sample_next_work_mode,

--- a/macf/src/macf/modes/__init__.py
+++ b/macf/src/macf/modes/__init__.py
@@ -12,6 +12,7 @@ from .detection import (
     detect_active_modes,
     anticipate_mode_change,
     format_mode_indicators,
+    get_active_task_type_marker,
     should_self_manage_closeout,
     should_closeout_now,
     is_quiet,

--- a/macf/src/macf/modes/detection.py
+++ b/macf/src/macf/modes/detection.py
@@ -190,14 +190,54 @@ def anticipate_mode_change(tool_name: str, tool_input: dict, current_modes: Set[
 # Emoji Dashboard
 # ============================================================================
 
-def format_mode_indicators(modes: Set[str]) -> str:
+def get_active_task_type_marker() -> str:
+    """Return ⏲️ if a PLAY_TIME task is in active scope and in_progress, else "".
+
+    The PLAY_TIME marker composes with the chain-phase work-mode emoji in the
+    dashboard's work-mode slot (e.g. " ⏲️🔍" for DISCOVER, " ⏲️🧪" for
+    EXPERIMENT, etc.). SPRINT does NOT get a marker — its 🏃 already
+    occupies the work-mode slot via WORK_MODES.
+
+    Closes the visibility leg of GH issue #69-companion bug for PLAY_TIME
+    chain phases (this codebase: BUG #1072): without the marker, an active
+    PLAY_TIME's chain mode looked indistinguishable from an ad-hoc work mode
+    (e.g. a free DISCOVER outside any task), erasing the timer-bound nature
+    of the activity from the user's view.
+    """
+    try:
+        from ..task.scope import get_scope_check
+        from ..task.reader import TaskReader
+        scope = get_scope_check()
+        for entry in scope.get("active", []):
+            tid = entry.get("id")
+            task = TaskReader().read_task(tid)
+            if task and task.mtmd:
+                tt = getattr(task.mtmd, "task_type", None)
+                if tt == "PLAY_TIME" and task.status == "in_progress":
+                    return "⏲️"  # ⏲️
+    except (ImportError, OSError, AttributeError, ValueError) as e:
+        # Non-fatal: marker absent if scope check fails
+        print(f"⚠️ MACF: task-type marker check failed (non-blocking): {e}", file=sys.stderr)
+    return ""
+
+
+def format_mode_indicators(modes: Set[str], task_type_marker: str = "") -> str:
     """
     Format active modes as emoji string for the status line.
 
-    Operational modes first (🤖😴🔕🪫), space, then work mode (🔍🔨📋✍️).
-    Returns empty string if no modes active.
+    Operational modes first (🤖😴🔕🪫), space, then optional task-type marker
+    (⏲️ for active PLAY_TIME) composed with the work mode emoji
+    (🔍🧪🔨📋✍️🏃).
+
+    Examples:
+      Free DISCOVER:           " 🤖 🔍"
+      SPRINT:                  " 🤖 🏃"
+      PLAY_TIME / DISCOVER:    " 🤖 ⏲️🔍"
+      PLAY_TIME / no chain:    " 🤖 ⏲️"
+
+    Returns empty string if no modes active and no marker.
     """
-    if not modes:
+    if not modes and not task_type_marker:
         return ""
 
     op_emojis = []
@@ -213,8 +253,11 @@ def format_mode_indicators(modes: Set[str]) -> str:
     parts = []
     if op_emojis:
         parts.append("".join(op_emojis))
-    if work_emoji:
-        parts.append(work_emoji)
+    if work_emoji or task_type_marker:
+        # Compose marker + work emoji in the work-mode slot. If only marker is
+        # present (PLAY_TIME with no chain set yet), it stands alone. If only
+        # work emoji is present (free work mode, no PLAY_TIME), it stands alone.
+        parts.append(f"{task_type_marker}{work_emoji}")
 
     return " " + " ".join(parts) if parts else ""
 
@@ -509,7 +552,22 @@ def _get_current_work_mode() -> Optional[str]:
                 if tt == "SPRINT" and task.status == "in_progress":
                     return "SPRINT"
                 if tt == "PLAY_TIME" and task.status == "in_progress":
-                    return "PLAY_TIME"
+                    # Resolve the active chain phase's work mode rather than
+                    # returning the task-type string. PLAY_TIME has chain
+                    # phases (DISCOVER/EXPERIMENT/BUILD/CURATE/CONSOLIDATE)
+                    # that need to surface in the dashboard work-mode slot
+                    # so the agent and user see the actual current activity.
+                    custom = getattr(task.mtmd, "custom", None) or {}
+                    chain = custom.get("predetermined_chain") or []
+                    pos = custom.get("chain_position", 0)
+                    if isinstance(pos, int) and 0 <= pos < len(chain):
+                        chain_mode = chain[pos]
+                        if chain_mode in WORK_MODES:
+                            return chain_mode
+                    # Chain unavailable / position invalid → fall through
+                    # to the event-log lookup below so set-work events still
+                    # render the work mode.
+                    break
     except (ImportError, OSError, AttributeError, ValueError) as e:
         # Non-fatal: fall through to event-log lookup
         print(f"⚠️ MACF: SPRINT/PLAY_TIME scope check in _get_current_work_mode failed (non-blocking): {e}", file=sys.stderr)

--- a/macf/src/macf/modes/detection.py
+++ b/macf/src/macf/modes/detection.py
@@ -299,6 +299,44 @@ def is_markov_eligible(current_work_mode: Optional[str]) -> bool:
     return current_work_mode != "SPRINT"
 
 
+def should_suppress_markov(modes: Set[str], current_work_mode: Optional[str]) -> bool:
+    """Return True when the Markov recommender should be suppressed entirely.
+
+    Two suppression triggers:
+    - SPRINT mode (existing — see is_markov_eligible)
+    - LOW_CONTEXT mode (new — closes BUG #1081): when the dashboard signals
+      🪫 LOW_CONTEXT, the agent must enter mandatory wind-down (CCP → JOTEWR
+      → final commits → let auto-compaction fire). Markov sampling at this
+      point produces out-of-phase mode-change suggestions (DISCOVER /
+      EXPERIMENT / BUILD) that compete with closeout discipline. The
+      recommender is replaced with a directive banner instead.
+    """
+    if current_work_mode == "SPRINT":
+        return True
+    if "LOW_CONTEXT" in modes:
+        return True
+    return False
+
+
+def format_low_context_directive() -> str:
+    """Mandatory wind-down banner — replaces Markov when LOW_CONTEXT active.
+
+    The banner re-states the wind-down protocol (CCP → JOTEWR → commits →
+    compaction) so that the gate-firing message at low context is a
+    closeout directive, not an open-ended mode suggestion. Closes BUG
+    #1081.
+    """
+    return (
+        "🪫 LOW_CONTEXT — mandatory wind-down active. Markov suppressed.\n"
+        "Required sequence:\n"
+        "  1. CCP draft (strategic state preservation — minimum critical artifact)\n"
+        "  2. JOTEWR (cycle wisdom synthesis — if budget permits)\n"
+        "  3. Final commits + push\n"
+        "  4. Let auto-compaction fire naturally\n"
+        "Letting the timer expire is NOT wind-down — produce the CCP."
+    )
+
+
 def apply_sprint_mode_lock(
     requested_mode: str,
     current_work_mode: Optional[str],

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -1368,11 +1368,37 @@ def _run_task_note(task_id: int, message: str) -> bool:
 
 
 def _verify_tm_running() -> bool:
-    """Check if transcript monitor is running (non-fatal if not)."""
+    """Check if transcript monitor is running, auto-starting it if not.
+
+    Auto-start mirrors the same pattern used at AUTO_MODE entry
+    (cli.py mode_set path). Without auto-start the user has to run
+    `macf_tools transcript-monitor start` manually after every fresh
+    session — alarm-fatigue noise the warning was producing repeatedly
+    from `task create play_time` / `task create sprint`.
+
+    Returns True if TM is running (whether already-running or
+    just-started); False on import/OS errors or if start_daemon fails.
+    """
     try:
-        from ..transcript_monitor.daemon import is_running as tm_is_running
-        return tm_is_running()
+        from ..transcript_monitor.daemon import is_running as tm_is_running, start_daemon as tm_start
     except (ImportError, OSError):
+        return False
+    try:
+        if tm_is_running():
+            return True
+        # Auto-start: matches cli.py:3008-3013 pattern at AUTO_MODE entry
+        try:
+            tm_start()
+        except (OSError, RuntimeError) as e:
+            print(
+                f"⚠️ MACF: Transcript Monitor auto-start failed (non-blocking): {e}",
+                file=sys.stderr,
+            )
+            return False
+        # Re-check; daemon spawn may take a moment to settle
+        return tm_is_running()
+    except OSError as e:
+        print(f"⚠️ MACF: Transcript Monitor status check failed: {e}", file=sys.stderr)
         return False
 
 


### PR DESCRIPTION
## Summary

Three local-tracked BUGs cleared in one PR — all in the mode-system / Stop-hook / task-create surface, all coordinated:

### 1. Transcript Monitor auto-start (was: alarm-fatigue warning)
`task create sprint` and `task create play_time` printed "TM not running, USER_IDLE detection unavailable, start with: ..." on every fresh session. `_verify_tm_running()` now mirrors the auto-start pattern already used at AUTO_MODE entry: if TM is not running, try `start_daemon()` and re-check.

### 2. Chain-mode dashboard emoji + ⏲️ marker for active PLAY_TIME
Two related visibility bugs:
- `_get_current_work_mode()`'s PLAY_TIME branch returned the bare string `"PLAY_TIME"` (not in `WORK_MODES`), so the dashboard formatter dropped it. Now reads `MTMD.custom.predetermined_chain[chain_position]` and returns the actual chain phase work mode.
- New helper `get_active_task_type_marker()` returns `"⏲️"` for active PLAY_TIME. `format_mode_indicators()` gains a `task_type_marker` parameter that composes with the work-mode emoji in the work-mode slot:
  - ` 🤖 🔍`     (free DISCOVER)
  - ` 🤖 🏃`     (SPRINT, marker not used)
  - ` 🤖 ⏲️🔍`   (PLAY_TIME / DISCOVER chain phase)
  - ` 🤖 ⏲️`     (PLAY_TIME with no chain set yet)

### 3. LOW_CONTEXT mandatory wind-down (Markov suppression)
When 🪫 LOW_CONTEXT activates, the Stop hook continued sampling Markov work-mode suggestions that competed with closeout discipline. New helpers `should_suppress_markov(modes, current_work_mode)` and `format_low_context_directive()` replace the recommender at low context with a directive banner naming the required wind-down sequence (CCP → JOTEWR → commits → compaction). Both Markov dispatch sites in `handle_stop.py` updated.

## Test plan

- [x] 90+ mode/sprint/stop/pre_tool tests pass after each change
- [x] 20/20 sprint/play_time tests pass after TM auto-start refactor
- [ ] Reviewer (live env): create a play_time, confirm dashboard footer shows `⏲️🔍` etc. for chain phases (not bare `🤖`)
- [ ] Reviewer: trigger LOW_CONTEXT (e.g., MACF_LOW_CONTEXT_CL=80 + low-budget session), confirm Stop-hook gate prints the wind-down banner instead of a Markov recommendation
- [ ] Reviewer: fresh session + `task create play_time --timer 10` confirms TM auto-starts (no warning) or warns transparently if start fails

## Closes

Local-tracked: BUG #1082, BUG #1072, BUG #1081 (all cycle 514/515 PLAY_TIME #1071 retrospective frictions).