### PR TITLE
feat(eventlog): generic structured-event JSONL analyzer + events analyze CLI

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3115,6 +3115,80 @@ def cmd_events_history(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_events_analyze(args: argparse.Namespace) -> int:
+    """Analyze a structured-event JSONL log (BUG #1069 generalization).
+
+    Wraps :class:`macf.eventlog.EventLogAnalyzer` so any JSONL log following
+    the {ts, request_id, phase, ...} shape is analyzable from the CLI without
+    a per-domain script. Domain customization (started phase, success field,
+    elapsed field) flows through `--started-phase` / `--success-field` /
+    `--elapsed-field` flags.
+    """
+    from .eventlog import EventLogAnalyzer, parse_since
+    import json as _json
+
+    if not args.path.exists():
+        print(f"❌ Log file not found: {args.path}")
+        return 1
+
+    analyzer = EventLogAnalyzer(
+        args.path,
+        started_phase=args.started_phase,
+        success_field=args.success_field,
+        elapsed_field=args.elapsed_field,
+        correlation_field=args.correlation_field,
+    )
+
+    if args.tail and args.tail > 0:
+        rows = analyzer.tail(args.tail)
+        if args.json_output:
+            print(_json.dumps(rows, indent=2))
+        else:
+            print(f"Last {len(rows)} requests from {args.path}:")
+            for r in rows:
+                ok_emoji = "✅" if r.get("success") is True else (
+                    "⏳" if r.get("success") is None else "❌"
+                )
+                ms = r.get("elapsed_ms")
+                ms_str = f"{ms}ms" if ms is not None else "?ms"
+                rid = r.get(args.correlation_field, "?")
+                err = r.get("error", "") or ""
+                print(
+                    f"  {ok_emoji} {str(rid):<14} {r.get('terminal_phase', 'unknown'):<20} "
+                    f"{ms_str:<8} {err}"
+                )
+        return 0
+
+    since = parse_since(args.since) if args.since else None
+    summary = analyzer.summarize(since=since, group_by=args.by)
+
+    if args.json_output:
+        print(_json.dumps(summary, indent=2))
+        return 0
+
+    print(f"Event log analysis: {args.path}")
+    if since:
+        print(f"Window: since {args.since}")
+    print(f"  Total started:     {summary['total_started']}")
+    print(f"  Completed:         {summary['completed_count']}")
+    print(f"  Success count:     {summary['success_count']}")
+    sr = summary["success_rate"]
+    print(f"  Success rate:      {(f'{sr*100:.1f}%') if sr is not None else 'n/a'}")
+    print(f"  Phase counts:      {summary['phase_counts']}")
+    if summary["elapsed_ms_p50"] is not None:
+        print(
+            f"  Elapsed (ms):      "
+            f"min={summary['elapsed_ms_min']} "
+            f"p50={summary['elapsed_ms_p50']} "
+            f"p90={summary['elapsed_ms_p90']} "
+            f"p99={summary['elapsed_ms_p99']} "
+            f"max={summary['elapsed_ms_max']}"
+        )
+    if "groups" in summary:
+        print(f"  Groups (--by {summary['group_by_field']}): {summary['groups']}")
+    return 0
+
+
 def cmd_events_query(args: argparse.Namespace) -> int:
     """Query events with filters."""
     from .agent_events_log import query_events
@@ -7350,6 +7424,55 @@ def _build_parser() -> argparse.ArgumentParser:
     gaps_parser.add_argument("--threshold", type=float, default=3600,
                             help="gap threshold in seconds (default: 3600)")
     gaps_parser.set_defaults(func=cmd_events_gaps)
+
+    # events analyze (BUG #1069 — generic structured-event JSONL analyzer)
+    analyze_parser = events_sub.add_parser(
+        "analyze",
+        help="analyze a structured-event JSONL log (Hermes delegations, Telegram restart-events, etc.)",
+    )
+    analyze_parser.add_argument("path", type=Path, help="path to the JSONL log file")
+    analyze_parser.add_argument(
+        "--since",
+        help="filter to events in last N{s,m,h,d} (e.g. 1h, 7d)",
+    )
+    analyze_parser.add_argument(
+        "--by",
+        metavar="FIELD",
+        help="group started events by this field (e.g. trigger, caller)",
+    )
+    analyze_parser.add_argument(
+        "--tail",
+        type=int,
+        default=0,
+        help="show last N completed requests instead of summary",
+    )
+    analyze_parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="machine-readable JSON output",
+    )
+    analyze_parser.add_argument(
+        "--started-phase",
+        default="started",
+        help="phase value marking the start of a request (default: started)",
+    )
+    analyze_parser.add_argument(
+        "--success-field",
+        default="success",
+        help="bool field on terminal events (default: success)",
+    )
+    analyze_parser.add_argument(
+        "--elapsed-field",
+        default="elapsed_ms",
+        help="integer field on completed events for elapsed time (default: elapsed_ms)",
+    )
+    analyze_parser.add_argument(
+        "--correlation-field",
+        default="request_id",
+        help="field used to correlate started + terminal events (default: request_id)",
+    )
+    analyze_parser.set_defaults(func=cmd_events_analyze)
 
     # Task commands (MACF Task CLI)
     task_parser = sub.add_parser("task", help="task management with MTMD support")

--- a/macf/src/macf/eventlog/__init__.py
+++ b/macf/src/macf/eventlog/__init__.py
@@ -1,0 +1,29 @@
+"""Generic structured-event JSONL analyzer (BUG #1069).
+
+Provides EventLogAnalyzer + free helpers for any JSONL log that follows the
+common shape:
+
+    {"ts": ISO8601, "request_id": str, "phase": str, ...domain_data}
+
+Two concrete domain logs use this shape today:
+- Hermes delegations.jsonl (~/.hermes/logs/) — phases: started/completed/timeout/...
+- Telegram restart-events.jsonl — phases: spawn/exit/...
+
+Adapters configure the started-phase name, success field, and elapsed field;
+the analyzer handles percentile + histogram + tail logic generically.
+"""
+from .analyzer import (
+    EventLogAnalyzer,
+    parse_since,
+    DEFAULT_STARTED_PHASE,
+    DEFAULT_SUCCESS_FIELD,
+    DEFAULT_ELAPSED_FIELD,
+)
+
+__all__ = [
+    "EventLogAnalyzer",
+    "parse_since",
+    "DEFAULT_STARTED_PHASE",
+    "DEFAULT_SUCCESS_FIELD",
+    "DEFAULT_ELAPSED_FIELD",
+]

--- a/macf/src/macf/eventlog/analyzer.py
+++ b/macf/src/macf/eventlog/analyzer.py
@@ -1,0 +1,214 @@
+"""Generic structured-event JSONL analyzer.
+
+Closes BUG #1069 — extracts the shared analysis pattern from
+hermes_cc_delegate/analyze_log.py (Phase 4.4 of MISSION #1044) so future
+JSONL logs (Telegram restart-events.jsonl, etc.) reuse the same percentile,
+histogram, and tail logic instead of copy-pasting it per domain.
+
+Each domain configures the analyzer with three field names:
+- started_phase: phase value marking the start of a request (default: "started")
+- success_field: bool field on terminal events indicating success (default: "success")
+- elapsed_field: integer field on completed events for elapsed time (default: "elapsed_ms")
+
+Anything beyond that is computed generically: phase counts, success rate,
+elapsed-time percentiles (p50/p90/p99/min/max), grouping by an arbitrary
+domain field (e.g., "trigger", "caller"), and tail of last N requests.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+
+DEFAULT_STARTED_PHASE = "started"
+DEFAULT_SUCCESS_FIELD = "success"
+DEFAULT_ELAPSED_FIELD = "elapsed_ms"
+
+
+def parse_since(spec: str) -> Optional[datetime]:
+    """Parse a relative time spec ('1h', '30m', '24h', '7d') to a UTC threshold.
+
+    Returns None for unparseable input so callers can pass through raw user
+    arguments without pre-validating.
+    """
+    m = re.match(r"^(\d+)([smhd])$", spec or "")
+    if not m:
+        return None
+    n, unit = int(m.group(1)), m.group(2)
+    delta = {
+        "s": timedelta(seconds=n),
+        "m": timedelta(minutes=n),
+        "h": timedelta(hours=n),
+        "d": timedelta(days=n),
+    }[unit]
+    return datetime.now(timezone.utc) - delta
+
+
+class EventLogAnalyzer:
+    """Analyze a JSONL event log following the standard MACF shape.
+
+    Shape: each line is a JSON object with at minimum a ``ts`` (ISO8601),
+    ``request_id`` (or equivalent correlation key), and ``phase`` field.
+    Domain-specific fields are passed through transparently.
+
+    Args:
+        path: Path to the JSONL file. Non-existent paths produce empty
+            results (no exception) so analyzers can be used optimistically.
+        started_phase: Phase name marking the start of a request lifecycle.
+        success_field: Bool field on terminal events indicating success.
+        elapsed_field: Integer field on completed events for elapsed time.
+        correlation_field: Field name used to correlate started + terminal
+            events (default: "request_id"). Some logs use "pid" instead.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        started_phase: str = DEFAULT_STARTED_PHASE,
+        success_field: str = DEFAULT_SUCCESS_FIELD,
+        elapsed_field: str = DEFAULT_ELAPSED_FIELD,
+        correlation_field: str = "request_id",
+    ):
+        self.path = Path(path)
+        self.started_phase = started_phase
+        self.success_field = success_field
+        self.elapsed_field = elapsed_field
+        self.correlation_field = correlation_field
+
+    def events(self, since: Optional[datetime] = None) -> Iterator[dict]:
+        """Yield events filtered by ``since`` (UTC threshold).
+
+        Lines with bad JSON are skipped silently — the log is treated as
+        append-only and may have partial writes during reads.
+        """
+        if not self.path.exists():
+            return
+        with self.path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if since:
+                    ts_str = event.get("ts", "")
+                    try:
+                        ts = datetime.fromisoformat(ts_str)
+                    except (ValueError, TypeError):
+                        continue
+                    if ts < since:
+                        continue
+                yield event
+
+    def summarize(
+        self,
+        since: Optional[datetime] = None,
+        group_by: Optional[str] = None,
+    ) -> dict:
+        """Compute summary statistics across all events in the window.
+
+        Returns dict with:
+            total_started, phase_counts, success_count, completed_count,
+            success_rate, elapsed_ms_p{50,90,99}, elapsed_ms_{min,max},
+            and (if group_by) groups: {field_value: count}.
+        """
+        phases: Counter = Counter()
+        terminal_outcomes: dict = defaultdict(list)
+        elapsed_completed: List[int] = []
+        groups: Counter = Counter()
+
+        for event in self.events(since):
+            phase = event.get("phase", "unknown")
+            phases[phase] += 1
+            rid = event.get(self.correlation_field, "")
+
+            if phase == self.started_phase:
+                if group_by:
+                    val = event.get(group_by)
+                    if val is not None:
+                        groups[val] += 1
+            else:
+                # terminal event
+                if rid:
+                    terminal_outcomes[rid].append(event)
+                if event.get(self.success_field) is True:
+                    ms = event.get(self.elapsed_field)
+                    if isinstance(ms, (int, float)):
+                        elapsed_completed.append(int(ms))
+
+        succeeded = sum(
+            1
+            for events in terminal_outcomes.values()
+            for e in events
+            if e.get(self.success_field) is True
+        )
+        # "completed" count = terminal events that have the success field set
+        # (True or False). Skip events lacking the field entirely (e.g.
+        # "rejected_recursion" outcomes that don't claim success/failure).
+        completed_count = sum(
+            1
+            for events in terminal_outcomes.values()
+            for e in events
+            if e.get(self.success_field) is not None
+        )
+        success_rate = (succeeded / completed_count) if completed_count else None
+        elapsed_completed.sort()
+
+        result = {
+            "total_started": phases.get(self.started_phase, 0),
+            "phase_counts": dict(phases),
+            "success_count": succeeded,
+            "completed_count": completed_count,
+            "success_rate": round(success_rate, 3) if success_rate is not None else None,
+            "elapsed_ms_p50": _pct(elapsed_completed, 0.5),
+            "elapsed_ms_p90": _pct(elapsed_completed, 0.9),
+            "elapsed_ms_p99": _pct(elapsed_completed, 0.99),
+            "elapsed_ms_min": elapsed_completed[0] if elapsed_completed else None,
+            "elapsed_ms_max": elapsed_completed[-1] if elapsed_completed else None,
+        }
+        if group_by:
+            result["groups"] = dict(groups)
+            result["group_by_field"] = group_by
+        return result
+
+    def tail(self, n: int) -> List[dict]:
+        """Return the last N requests as terminal-event records, oldest first.
+
+        Each record carries the started ts, terminal phase, elapsed_ms (if
+        available), success flag, and a short error/message excerpt.
+        Requests without a terminal event (still in flight) are omitted.
+        """
+        by_id: dict = {}
+        started_at: dict = {}
+        for event in self.events():
+            rid = event.get(self.correlation_field, "")
+            if not rid:
+                continue
+            if event.get("phase") == self.started_phase:
+                started_at[rid] = event.get("ts", "")
+            else:
+                by_id[rid] = {
+                    self.correlation_field: rid,
+                    "started_ts": started_at.get(rid, ""),
+                    "terminal_phase": event.get("phase", "unknown"),
+                    "elapsed_ms": event.get(self.elapsed_field),
+                    "success": event.get(self.success_field),
+                    "error": (event.get("msg") or event.get("error", ""))[:120],
+                }
+        rows = sorted(by_id.values(), key=lambda r: r.get("started_ts", ""))
+        return rows[-n:] if n > 0 else rows
+
+
+def _pct(vals: List[int], p: float) -> Optional[int]:
+    """Compute percentile via simple index lookup. Returns None for empty lists."""
+    if not vals:
+        return None
+    idx = int(len(vals) * p)
+    return vals[min(idx, len(vals) - 1)]

--- a/macf/tests/test_eventlog_analyzer.py
+++ b/macf/tests/test_eventlog_analyzer.py
@@ -1,0 +1,180 @@
+"""Tests for the generic structured-event JSONL analyzer (BUG #1069)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from macf.eventlog import EventLogAnalyzer, parse_since
+
+
+def _write_jsonl(path: Path, events: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class TestParseSince:
+    def test_parses_h_unit(self):
+        thresh = parse_since("1h")
+        assert thresh is not None
+        # Roughly an hour ago
+        assert datetime.now(timezone.utc) - thresh - timedelta(hours=1) < timedelta(seconds=2)
+
+    def test_parses_d_unit(self):
+        thresh = parse_since("7d")
+        assert thresh is not None
+
+    def test_returns_none_on_garbage(self):
+        assert parse_since("nope") is None
+        assert parse_since("") is None
+        assert parse_since(None) is None  # type: ignore[arg-type]
+
+
+class TestEventLogAnalyzerEvents:
+    def test_missing_file_yields_nothing(self, tmp_path):
+        analyzer = EventLogAnalyzer(tmp_path / "nope.jsonl")
+        assert list(analyzer.events()) == []
+
+    def test_skips_blank_and_malformed_lines(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        path.write_text(
+            json.dumps({"ts": _now_iso(), "phase": "started", "request_id": "r1"}) + "\n"
+            "\n"
+            "{ not json }\n"
+            + json.dumps({"ts": _now_iso(), "phase": "completed", "request_id": "r1", "success": True, "elapsed_ms": 10}) + "\n"
+        )
+        analyzer = EventLogAnalyzer(path)
+        events = list(analyzer.events())
+        assert len(events) == 2
+
+    def test_since_filters_old_events(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        new_ts = datetime.now(timezone.utc).isoformat()
+        _write_jsonl(path, [
+            {"ts": old_ts, "phase": "started", "request_id": "old"},
+            {"ts": new_ts, "phase": "started", "request_id": "new"},
+        ])
+        analyzer = EventLogAnalyzer(path)
+        recent = list(analyzer.events(since=parse_since("1h")))
+        assert len(recent) == 1
+        assert recent[0]["request_id"] == "new"
+
+
+class TestEventLogAnalyzerSummarize:
+    def test_basic_success_rate_and_percentiles(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        ts = _now_iso()
+        _write_jsonl(path, [
+            {"ts": ts, "phase": "started", "request_id": "r1"},
+            {"ts": ts, "phase": "completed", "request_id": "r1", "success": True, "elapsed_ms": 100},
+            {"ts": ts, "phase": "started", "request_id": "r2"},
+            {"ts": ts, "phase": "completed", "request_id": "r2", "success": True, "elapsed_ms": 200},
+            {"ts": ts, "phase": "started", "request_id": "r3"},
+            {"ts": ts, "phase": "timeout", "request_id": "r3", "success": False},
+        ])
+        summary = EventLogAnalyzer(path).summarize()
+
+        assert summary["total_started"] == 3
+        assert summary["completed_count"] == 3  # 2 success + 1 fail terminal
+        assert summary["success_count"] == 2
+        assert summary["success_rate"] == round(2 / 3, 3)
+        assert summary["elapsed_ms_min"] == 100
+        assert summary["elapsed_ms_max"] == 200
+        # Percentiles on 2 values: index = floor(2 * p)
+        assert summary["elapsed_ms_p50"] == 200  # idx 1
+        assert summary["phase_counts"] == {"started": 3, "completed": 2, "timeout": 1}
+
+    def test_group_by_passes_through_field(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        ts = _now_iso()
+        _write_jsonl(path, [
+            {"ts": ts, "phase": "started", "request_id": "r1", "trigger": "T1"},
+            {"ts": ts, "phase": "started", "request_id": "r2", "trigger": "T1"},
+            {"ts": ts, "phase": "started", "request_id": "r3", "trigger": "T2"},
+        ])
+        summary = EventLogAnalyzer(path).summarize(group_by="trigger")
+        assert summary["groups"] == {"T1": 2, "T2": 1}
+        assert summary["group_by_field"] == "trigger"
+
+    def test_custom_phase_and_field_names(self, tmp_path):
+        """Adapter pattern: a domain log with non-default field names still analyzes."""
+        path = tmp_path / "restart.jsonl"
+        ts = _now_iso()
+        _write_jsonl(path, [
+            {"ts": ts, "phase": "spawn", "pid": 100},
+            {"ts": ts, "phase": "exit", "pid": 100, "ok": True, "duration_ms": 50},
+            {"ts": ts, "phase": "spawn", "pid": 101},
+            {"ts": ts, "phase": "exit", "pid": 101, "ok": False, "duration_ms": 75},
+        ])
+        analyzer = EventLogAnalyzer(
+            path,
+            started_phase="spawn",
+            success_field="ok",
+            elapsed_field="duration_ms",
+            correlation_field="pid",
+        )
+        summary = analyzer.summarize()
+        assert summary["total_started"] == 2
+        assert summary["success_count"] == 1
+        assert summary["completed_count"] == 2
+        assert summary["elapsed_ms_min"] == 50
+
+    def test_empty_log_returns_safe_zeros(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("")
+        summary = EventLogAnalyzer(path).summarize()
+        assert summary["total_started"] == 0
+        assert summary["success_rate"] is None
+        assert summary["elapsed_ms_min"] is None
+
+
+class TestEventLogAnalyzerTail:
+    def test_returns_terminal_records_for_last_n(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        # Distinct started timestamps so sort order is deterministic
+        base = datetime.now(timezone.utc)
+        _write_jsonl(path, [
+            {"ts": (base - timedelta(seconds=30)).isoformat(),
+             "phase": "started", "request_id": "old"},
+            {"ts": (base - timedelta(seconds=29)).isoformat(),
+             "phase": "completed", "request_id": "old", "success": True, "elapsed_ms": 1000},
+            {"ts": (base - timedelta(seconds=10)).isoformat(),
+             "phase": "started", "request_id": "mid"},
+            {"ts": (base - timedelta(seconds=9)).isoformat(),
+             "phase": "completed", "request_id": "mid", "success": False, "elapsed_ms": 500},
+            {"ts": base.isoformat(),
+             "phase": "started", "request_id": "new"},
+            {"ts": base.isoformat(),
+             "phase": "timeout", "request_id": "new", "success": False},
+        ])
+        analyzer = EventLogAnalyzer(path)
+        rows = analyzer.tail(2)
+        assert len(rows) == 2
+        # Oldest-first → second-most-recent then most-recent
+        assert rows[0]["request_id"] == "mid"
+        assert rows[1]["request_id"] == "new"
+        assert rows[1]["terminal_phase"] == "timeout"
+
+    def test_tail_skips_in_flight_requests(self, tmp_path):
+        """A started-only request (no terminal yet) is not in the tail."""
+        path = tmp_path / "log.jsonl"
+        ts = _now_iso()
+        _write_jsonl(path, [
+            {"ts": ts, "phase": "started", "request_id": "r1"},
+            {"ts": ts, "phase": "completed", "request_id": "r1", "success": True, "elapsed_ms": 50},
+            {"ts": ts, "phase": "started", "request_id": "r2"},
+            # r2 has NO terminal — still in flight
+        ])
+        rows = EventLogAnalyzer(path).tail(10)
+        ids = [r["request_id"] for r in rows]
+        assert "r1" in ids
+        assert "r2" not in ids


### PR DESCRIPTION
## Summary

Closes local BUG #1069.

Extracts the shared analysis pattern from `agent/public/dev_scripts/hermes_cc_delegate/analyze_log.py` (Phase 4.4 of MISSION #1044) into a reusable `macf/eventlog/` module. Adds `macf_tools events analyze <path>` CLI so any JSONL log following the standard `{ts, request_id, phase, ...}` shape gets percentile + histogram + tail analysis without a per-domain script.

## What's new

**Module**: `macf.eventlog.EventLogAnalyzer`
- Configurable `started_phase` / `success_field` / `elapsed_field` / `correlation_field` for domain adaptation
- `events(since=)`, `summarize(since=, group_by=)`, `tail(n)`, `parse_since(spec)`

**CLI**: `macf_tools events analyze <path>` with flags for time-window filter, group-by field, tail mode, JSON output, and per-domain field name overrides.

## Domains

- **Hermes delegations.jsonl**: works with defaults (phase=started/completed/timeout, success/elapsed_ms/request_id)
- **Telegram restart-events.jsonl**: works with `--started-phase spawn --correlation-field pid --success-field ok --elapsed-field duration_ms` — verified in tests
- **Future logs**: any new structured-event JSONL gets percentile + grouping analysis for free

## Test plan

- [x] 12 unit tests cover parse_since, event iteration, summary stats with custom field names, group-by, empty-log safe defaults, tail with in-flight-skipping, malformed-line tolerance
- [x] CLI smoke test with synthetic JSONL produces expected human + JSON output
- [ ] Reviewer: try against a real `~/.hermes/logs/delegations.jsonl` and compare output to existing `analyze_log.py` (should match)

## Notes

Existing `analyze_log.py` (Hermes Phase 4.4) is unchanged — migration to the generic CLI is opportunistic, not forced. Telegram restart-event analyzer (Phase 7 #1060 Component B) becomes greenfield via this pattern.