### PR TITLE
fix(hooks): _is_bare_cd_command scans every command-fragment, not just first

### DIFF
--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -5,6 +5,7 @@ handle_pre_tool_use - PreToolUse hook runner.
 DELEG_DRV start tracking + tool operation awareness.
 """
 import json
+import re
 import sys
 import traceback
 from typing import Dict, Any
@@ -31,31 +32,28 @@ def _is_bare_cd_command(command: str) -> bool:
     Bare cd is dangerous because it breaks relative hook paths.
     Allow cd in subshells: (cd dir && cmd) or $(cd dir && cmd)
 
+    Detection scans EVERY command-fragment (split on \\n, ;, &&, ||) for
+    a leading `cd ` — multi-line bash scripts and ;-separated chains can
+    place a bare cd anywhere, not just first.
+
     Args:
         command: Bash command string
 
     Returns:
         True if bare cd detected, False if safe
     """
-    # Strip whitespace
     cmd = command.strip()
 
-    # Check if command starts with 'cd ' (bare cd)
-    if cmd.startswith("cd "):
-        # Check if it's in a subshell (starts with parenthesis)
-        if not cmd.startswith("("):
-            return True  # Bare cd detected
+    # Split on any command-boundary separator: \n, ;, &&, ||
+    # Each fragment is potentially its own command; check each for a leading
+    # `cd `. Subshell-prefixed fragments (those starting with `(`) are safe
+    # because subshell-cd doesn't change the parent shell's CWD.
+    fragments = re.split(r"\n|;|&&|\|\|", cmd)
+    for frag in fragments:
+        f = frag.strip()
+        if f.startswith("cd ") and not f.startswith("("):
+            return True
 
-    # Check for cd with && (chained commands without subshell)
-    # e.g., "cd /path && ls" is still bare cd that changes working dir
-    if " && " in cmd:
-        # Check if cd appears before && without being in subshell
-        parts = cmd.split(" && ")
-        first_part = parts[0].strip()
-        if first_part.startswith("cd ") and not first_part.startswith("("):
-            return True  # Bare cd in chain
-
-    # Safe: no bare cd detected
     return False
 
 

--- a/macf/tests/test_pre_tool_use_bare_cd.py
+++ b/macf/tests/test_pre_tool_use_bare_cd.py
@@ -1,0 +1,68 @@
+"""Unit tests for `_is_bare_cd_command` in handle_pre_tool_use.
+
+Regression coverage for the multi-line-bash detection gap (issue #82).
+Pre-fix the detector only checked the whole-string-startswith and the first
+`&&` fragment, so multi-line scripts with cd on a later line slipped past.
+"""
+
+import pytest
+
+from macf.hooks.handle_pre_tool_use import _is_bare_cd_command
+
+
+# --- Should DETECT (return True) -------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Original cases (covered before fix)
+        "cd /tmp",
+        "cd /tmp && ls",
+        "  cd /tmp  ",  # leading/trailing whitespace
+
+        # New cases (post-fix coverage — these slipped past before)
+        "mkdir foo\ncd foo",                       # newline-separated, second line
+        "echo a\ncd /tmp\necho b",                 # multi-line, cd in middle
+        "mkdir foo; cd foo",                       # ;-separated
+        "mkdir foo || cd /tmp",                    # ||-separated fallback
+        "echo hello\nmkdir foo\ncd foo\nls",       # multi-line script with cd in middle
+        "cd /a && cd /b",                          # both fragments are cd
+        "ls /tmp; cd /etc",                        # ; then bare cd
+    ],
+)
+def test_detects_bare_cd(command: str):
+    assert _is_bare_cd_command(command) is True, \
+        f"Expected detection for: {command!r}"
+
+
+# --- Should NOT detect (return False) --------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Subshell — safe (cd is scoped to subshell)
+        "(cd /tmp && ls)",
+        "(cd /tmp; ls)",
+
+        # Tool flags — not cd
+        "git -C /tmp status",
+        "pytest /full/path/to/tests",
+
+        # Variable + absolute paths
+        'D=/tmp; ls "$D"',
+        'export PATH=/foo:$PATH; echo done',
+
+        # Plain commands without cd
+        "ls /tmp",
+        "mkdir foo\nls foo",
+        "echo cd /tmp",                            # cd is an argument to echo, not a command
+        "git diff --cached",
+
+        # Empty / whitespace
+        "",
+        "   ",
+    ],
+)
+def test_does_not_detect_safe_commands(command: str):
+    assert _is_bare_cd_command(command) is False, \
+        f"Expected no detection for: {command!r}"


### PR DESCRIPTION
## Summary

Closes #82. Replays the legitimate scope of @silomaceff-d0cdcf's PR #83 on top of current `main`.

`_is_bare_cd_command()` previously only checked the whole-string prefix and the first `&&` fragment. Multi-line bash, `;`-chains, and `||`-fallbacks could place a bare `cd` anywhere and slip past detection. This PR splits on every command-boundary separator (`\n`, `;`, `&&`, `||`) and checks each stripped fragment, while still excluding subshell-prefixed fragments.

## Why a rebased PR

Original PR #83 was opened against a `main` that predates ~7 merged PRs (#75-#85: parser DRY, knowledge infra, eventlog analyzer, mode-system fixes, autocompact dual-write, etc.). Its diff against current `main` included 1592 unintended deletions across 38 files — merging would have wiped two days of shipped work.

This PR replays only the legitimate two-file change:
- `macf/src/macf/hooks/handle_pre_tool_use.py` — function rewrite
- `macf/tests/test_pre_tool_use_bare_cd.py` — 22 new test cases

Authorship preserved via `Co-Authored-By` line.

## Test plan

- [x] 22 / 22 new tests pass (multi-line + `;` + `||` detection cases plus safe-commands negative cases)
- [x] Existing 38 hook tests still pass
- [ ] Reviewer: spot-check that current main's `format_mode_indicators(modes, marker)` integration is preserved (was at risk of being reverted by PR #83's stale base)