### PR TITLE
fix(knowledge): accept bare-concept wiki_links in idea JSONs

### DIFF
--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -276,11 +276,21 @@ def build_idea_graph() -> Dict[str, Any]:
                 edges[idea_id].add(rid)
                 edges[rid].add(idea_id)
         for wl in (links.get("wiki_links") or []):
-            m = re_mod.match(r'\[\[(.+?)\]\]', wl)
-            if m:
-                # Normalize: strip .md suffix for consistent matching
-                concept = re_mod.sub(r'\.md$', '', m.group(1))
-                wiki_index[concept].add(idea_id)
+            # Accept both bracketed (`[[concept]]`) and bare (`concept`) forms
+            # in the JSON array. Bracketed form lets ideas use the same syntax
+            # as markdown CAs ([[concept]] in body); bare form is the more
+            # natural JSON-array shape and the one the cross-CA index expects
+            # (concept keys in wiki_index are stored sans brackets). Without
+            # this, ideas with bare-concept arrays never enter wiki_index and
+            # the idea↔learning bridge breaks at the seam — closes GH #87.
+            if not isinstance(wl, str) or not wl.strip():
+                continue
+            raw = wl.strip()
+            m = re_mod.match(r'^\[\[(.+?)\]\]$', raw)
+            concept = m.group(1) if m else raw
+            # Normalize: strip .md suffix for consistent matching
+            concept = re_mod.sub(r'\.md$', '', concept)
+            wiki_index[concept].add(idea_id)
 
     for concept, ids in wiki_index.items():
         ids_list = list(ids)

--- a/macf/tests/test_knowledge_graph.py
+++ b/macf/tests/test_knowledge_graph.py
@@ -7,6 +7,8 @@ whole-document ``[[concept]]`` scanning when no explicit ## Wiki-Links
 section is present.
 """
 
+import json
+
 import pytest
 from pathlib import Path
 
@@ -107,3 +109,88 @@ class TestBuildKnowledgeGraphCrossCA:
         edges = kg["edges"]
         assert "checkpoints:cpA" in edges.get("learnings:lA", set())
         assert "learnings:lA" in edges.get("checkpoints:cpA", set())
+
+
+class TestIdeaGraphWikiLinks:
+    """Regression for GH issue #87 — idea JSON wiki_links bridge to learnings.
+
+    The original `build_idea_graph()` extracted concepts from
+    `links.wiki_links[]` only when entries matched the bracketed `[[concept]]`
+    form. Bare-concept entries (the natural JSON-array shape, used by Silo's
+    9-idea population) never entered `wiki_index`, so cross-CA partitions
+    never bridged at the idea↔learning seam (cross_ca_edges=0).
+    """
+
+    def _write_idea(self, agent_root, idea_id, wiki_links):
+        ideas_dir = agent_root / "agent" / "public" / "ideas"
+        ideas_dir.mkdir(parents=True, exist_ok=True)
+        path = ideas_dir / f"{idea_id:03d}_2026-01-01_120000_test_idea.json"
+        path.write_text(json.dumps({
+            "schema_version": "1.0",
+            "id": idea_id,
+            "title": f"Test idea {idea_id}",
+            "slug": f"test_idea_{idea_id}",
+            "status": "captured",
+            "category": "tooling",
+            "description": "fixture",
+            "links": {
+                "related_ideas": [],
+                "related_learnings": [],
+                "wiki_links": wiki_links,
+                "promoted_to": None,
+                "archived_reason": None,
+            },
+            "history": [],
+        }))
+
+    def test_bare_concept_form_is_indexed(self, fake_agent_root, monkeypatch):
+        """Bare-string wiki_links (the canonical JSON form) populate wiki_index."""
+        from macf.ideas import build_idea_graph
+        from macf.utils import paths as paths_mod
+        monkeypatch.setattr(paths_mod, "find_agent_home", lambda: fake_agent_root)
+        self._write_idea(fake_agent_root, 1, ["augerlink"])
+        graph = build_idea_graph()
+        assert "augerlink" in graph["wiki_index"]
+        assert 1 in graph["wiki_index"]["augerlink"]
+
+    def test_bracketed_form_still_works(self, fake_agent_root, monkeypatch):
+        """Legacy bracketed form `[[concept]]` keeps working."""
+        from macf.ideas import build_idea_graph
+        from macf.utils import paths as paths_mod
+        monkeypatch.setattr(paths_mod, "find_agent_home", lambda: fake_agent_root)
+        self._write_idea(fake_agent_root, 2, ["[[shared-concept]]"])
+        graph = build_idea_graph()
+        assert "shared-concept" in graph["wiki_index"]
+        assert 2 in graph["wiki_index"]["shared-concept"]
+
+    def test_idea_to_learning_bridge_via_shared_concept(self, fake_agent_root, monkeypatch):
+        """Idea with bare 'augerlink' bridges to learning with `[[augerlink]]`."""
+        from macf.ideas import build_knowledge_graph
+        from macf.utils import paths as paths_mod
+        monkeypatch.setattr(paths_mod, "find_agent_home", lambda: fake_agent_root)
+        self._write_idea(fake_agent_root, 3, ["augerlink"])
+        _write(
+            fake_agent_root / "agent" / "private" / "learnings" / "lA.md",
+            "# Learning A\n\n[[augerlink]]\n",
+        )
+        kg = build_knowledge_graph(scan_dirs=[
+            fake_agent_root / "agent" / "private" / "learnings",
+        ])
+        # The idea (int key 3) and the learning (str key 'learnings:lA') are
+        # both in wiki_index['augerlink']; the build_knowledge_graph edges
+        # construction should bridge them.
+        edges = kg["edges"]
+        assert "learnings:lA" in edges.get(3, set()) or 3 in edges.get("learnings:lA", set()), (
+            f"Expected bidirectional edge between idea#3 and learnings:lA; "
+            f"edges[3]={edges.get(3, set())} edges[learnings:lA]={edges.get('learnings:lA', set())}"
+        )
+
+    def test_empty_or_invalid_wiki_links_skipped_gracefully(self, fake_agent_root, monkeypatch):
+        """Non-string entries and empty strings don't crash the indexer."""
+        from macf.ideas import build_idea_graph
+        from macf.utils import paths as paths_mod
+        monkeypatch.setattr(paths_mod, "find_agent_home", lambda: fake_agent_root)
+        self._write_idea(fake_agent_root, 4, ["valid-concept", "", "   ", None, 42])
+        graph = build_idea_graph()
+        assert "valid-concept" in graph["wiki_index"]
+        assert 4 in graph["wiki_index"]["valid-concept"]


### PR DESCRIPTION
Closes #87.

`build_idea_graph()` only matched bracketed `[[concept]]` form in idea `links.wiki_links[]` arrays. Bare-concept entries (the natural JSON shape) silently skipped, breaking the idea↔learning bridge (`cross_ca_edges=0`).

Fix: accept both bracketed + bare; skip non-string/empty gracefully.

10/10 knowledge_graph tests pass (4 new regression tests covering bare form, bracketed back-compat, cross-CA bridge, malformed entries).