### PR TITLE
feat(stop-hook): generic recoverable-error auto-recovery

### DIFF
--- a/macf/src/macf/hooks/handle_stop.py
+++ b/macf/src/macf/hooks/handle_stop.py
@@ -182,6 +182,44 @@ Development Drive Stats:
         stop_reason = input_data.get('stop_reason', '')
         is_error_stop = 'error' in stop_reason.lower() if stop_reason else False
 
+        # --- Recoverable-error auto-recovery gate (ANY mode) ---
+        # If the most recent tool result is a known-recoverable error pattern
+        # AND we're not already in a recovery loop (stop_hook_active=False),
+        # block the stop with a pattern-specific directive. The agent retries
+        # with the obvious fix instead of stopping with an apology.
+        # See macf/hooks/recoverable_errors.py for the pattern registry.
+        transcript_path = input_data.get('transcript_path')
+        stop_hook_active = input_data.get('stop_hook_active', False)
+        if transcript_path and not stop_hook_active:
+            try:
+                from macf.hooks.recoverable_errors import scan_last_tool_error
+                recovery = scan_last_tool_error(transcript_path)
+                if recovery is not None:
+                    pattern_name, directive = recovery
+                    try:
+                        append_event(
+                            event="recoverable_error_blocked",
+                            data={
+                                "session_id": session_id,
+                                "pattern": pattern_name,
+                            },
+                            hook_input=input_data,
+                        )
+                    except (OSError, IOError) as _e:
+                        print(f"⚠️ MACF: recoverable_error_blocked event log failed: {_e}", file=sys.stderr)
+                    return {
+                        "continue": True,
+                        "decision": "block",
+                        "reason": (
+                            f"🔧 RECOVERABLE ERROR — {pattern_name}\n\n"
+                            f"{directive}\n\n"
+                            f"Apply the recovery and retry the original tool call. "
+                            f"Do not apologize and stop — the fix is mechanical."
+                        ),
+                    }
+            except (ImportError, OSError, ValueError) as _e:
+                print(f"⚠️ MACF: recoverable-error gate error: {_e}", file=sys.stderr)
+
         # --- Scope gate: block stop if active scoped tasks remain ---
         try:
             from macf.task.scope import get_scope_check

--- a/macf/src/macf/hooks/recoverable_errors.py
+++ b/macf/src/macf/hooks/recoverable_errors.py
@@ -1,0 +1,221 @@
+"""recoverable_errors - Stop-hook auto-recovery for common tool-error friction.
+
+When a tool call fails with an obviously-recoverable error (file not Read
+before Edit, deferred tool not loaded, stale Read after file change, etc.)
+the agent often stops with an apology rather than retrying. The Stop hook
+imports `scan_last_tool_error` from this module to detect such errors in
+the most recent tool result and emit `decision:'block' + reason:<directive>`
+back to Claude Code, forcing the agent to apply the obvious recovery and
+retry rather than stopping.
+
+Registry shape:
+    (name, regex, directive_template)
+
+Templates may reference named regex groups via `{group_name}`.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# --- Pattern registry ------------------------------------------------------
+#
+# Each entry: (name, compiled-regex, directive-template)
+# `name` is a short stable identifier used in event logs.
+# `regex` matches the tool_result content text (the <tool_use_error>...</...>
+# wrapper is included so patterns are explicit about the surface they target).
+# `template` is rendered with named-group substitution; missing optional groups
+# are filled with empty strings.
+#
+# Patterns are evaluated in order; first match wins.
+
+_PATTERN_SOURCES: List[Tuple[str, str, str]] = [
+    (
+        "file_not_read",
+        r"<tool_use_error>File has not been read yet\.",
+        "The Edit/Write tool requires a prior Read of the file in this turn. "
+        "Read the target file again, then retry the original Edit/Write."
+    ),
+    (
+        "file_modified_since_read",
+        r"<tool_use_error>File has been modified since read",
+        "The file changed since your last Read (linter, user, or sibling tool). "
+        "Re-Read it to see current content, then retry the Edit with old_string "
+        "matching the new contents."
+    ),
+    (
+        "old_string_not_found",
+        r"<tool_use_error>String to replace not found in file",
+        "old_string did not match. The file likely changed since your last Read, "
+        "or the literal contains characters that need escaping. Re-Read the file "
+        "and retry with the exact current text."
+    ),
+    (
+        "replace_all_mismatch",
+        r"<tool_use_error>Found (?P<found>\d+) matches?.*?expected (?P<expected>\d+)",
+        "Edit found {found} matches but expected {expected}. Either: (a) make "
+        "old_string more specific by including surrounding context, OR (b) set "
+        "replace_all=true to replace every occurrence."
+    ),
+    (
+        "tool_not_in_registry",
+        r"<tool_use_error>Error: No such tool available: (?P<tool>[\w_]+)</tool_use_error>",
+        "Tool '{tool}' is not loaded. If it is a deferred tool, run "
+        "ToolSearch with query='select:{tool}' to load its schema, then retry. "
+        "If it was removed, choose a different approach."
+    ),
+    (
+        "input_validation_error",
+        r"<tool_use_error>InputValidationError: (?P<tool>\w+) failed due to the following issue:\s*(?P<details>[^<]+?)</tool_use_error>",
+        "{tool} got bad parameters: {details}. Re-check the tool schema "
+        "(parameter names, types, required vs optional) and retry."
+    ),
+    (
+        "path_does_not_exist",
+        r"<tool_use_error>Path does not exist:\s*(?P<path>[^<]+?)</tool_use_error>",
+        "Path missing: {path}. Verify with `ls`, `Glob`, or `find` before "
+        "retrying — the path may be in a different repo, a sibling submodule, "
+        "or you may need to create parent directories first."
+    ),
+    (
+        "file_does_not_exist",
+        r"<tool_use_error>File does not exist\.(?:\s*Did you mean (?P<suggestion>[^?]+)\?)?</tool_use_error>",
+        "File not found. {suggestion_hint}Verify the path with `ls` or `Glob` "
+        "before retrying."
+    ),
+]
+
+
+def _compile_pattern(name: str, regex: str, template: str):
+    return (name, re.compile(regex, re.DOTALL), template)
+
+
+PATTERNS = [_compile_pattern(*p) for p in _PATTERN_SOURCES]
+
+
+def format_directive(template: str, groups: dict) -> str:
+    """Render a directive template with named-group substitution.
+
+    Optional groups that didn't match are passed through as empty strings.
+    A `{name_hint}` reference renders as ``Did you mean: <value>. `` when the
+    base group `{name}` matched, else empty — used by `path_does_not_exist`
+    to fold the optional "Did you mean X?" CC suggestion into the directive.
+    """
+    safe_groups = {k: (v or "") for k, v in groups.items()}
+    safe_groups.setdefault("suggestion", "")
+    safe_groups["suggestion_hint"] = (
+        f"Did you mean: {safe_groups['suggestion']}. "
+        if safe_groups.get("suggestion") else ""
+    )
+    try:
+        return template.format(**safe_groups)
+    except KeyError as e:
+        # Unknown placeholder — fall back to template raw rather than crash.
+        return template + f"  [template-render-error: {e}]"
+
+
+def match_error_text(text: str) -> Optional[Tuple[str, str]]:
+    """Match a tool-error text against the registry.
+
+    Args:
+        text: The tool_result content string (typically wrapped in
+              `<tool_use_error>...</tool_use_error>`).
+
+    Returns:
+        (pattern_name, formatted_directive) on first match, else None.
+    """
+    if not text:
+        return None
+    for name, regex, template in PATTERNS:
+        m = regex.search(text)
+        if not m:
+            continue
+        directive = format_directive(template, m.groupdict())
+        return (name, directive)
+    return None
+
+
+def _extract_tool_result_text(content) -> Optional[str]:
+    """Pull a string out of a tool_result `content` field.
+
+    The CC transcript stores tool_result content as either a plain string
+    OR a list of content blocks. Concatenate text blocks if list-shaped.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if isinstance(b, dict):
+                t = b.get("text") or b.get("content") or ""
+                parts.append(str(t))
+        return " ".join(parts) if parts else None
+    return None
+
+
+def scan_last_tool_error(transcript_path: str) -> Optional[Tuple[str, str]]:
+    """Scan the transcript JSONL for the most recent tool error.
+
+    Reads the file backwards (memory-efficient via reversed line list);
+    finds the most recent user message containing a `tool_result` with
+    `is_error=True`; matches that error against the pattern registry.
+
+    Args:
+        transcript_path: Absolute path to the session JSONL transcript.
+
+    Returns:
+        (pattern_name, directive) if a recoverable error is found AND it
+        is the most recent tool result. Returns None if:
+          - transcript missing or unreadable
+          - no tool errors found
+          - the most recent tool result is NOT an error (agent already
+            recovered — successful tool call after the error)
+          - the error doesn't match any registered pattern
+    """
+    if not transcript_path:
+        return None
+    p = Path(transcript_path)
+    if not p.exists() or not p.is_file():
+        return None
+
+    try:
+        # JSONL transcripts can be large; read in full but iterate reversed.
+        # For the typical agent-stop case we'll find the answer in the last
+        # 1–3 lines so this is cheap in practice.
+        lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+    except (OSError, IOError):
+        return None
+
+    for line in reversed(lines):
+        if '"tool_result"' not in line:
+            # Quick reject — not a tool result line. Avoids JSON parse cost.
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        msg = entry.get("message") or {}
+        if msg.get("role") != "user":
+            continue
+        content_blocks = msg.get("content")
+        if not isinstance(content_blocks, list):
+            continue
+        # Walk the content blocks; first tool_result wins (a single user
+        # message can contain multiple tool_results from parallel calls,
+        # but the most recent stop is naturally tied to the last block).
+        for block in reversed(content_blocks):
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_result":
+                continue
+            # Found the most recent tool_result. If it's not an error,
+            # the agent already recovered — bail.
+            if not block.get("is_error"):
+                return None
+            text = _extract_tool_result_text(block.get("content"))
+            if text is None:
+                return None
+            return match_error_text(text)
+    return None

--- a/macf/tests/test_handle_stop.py
+++ b/macf/tests/test_handle_stop.py
@@ -157,6 +157,85 @@ def test_exception_handling(mock_dependencies):
     assert "error" in result["systemMessage"].lower()
 
 
+def test_recoverable_error_gate_blocks_stop(mock_dependencies, tmp_path):
+    """When the last tool result is a recoverable error, the Stop hook
+    returns decision:'block' with a recovery directive instead of
+    letting the agent stop with an apology."""
+    import json as _json
+    from macf.hooks.handle_stop import run
+
+    # Write a minimal transcript with a recoverable error as the last
+    # tool result.
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(_json.dumps({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_test",
+                "content": "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+                "is_error": True,
+            }],
+        },
+    }) + "\n")
+
+    stdin = _json.dumps({
+        "transcript_path": str(transcript),
+        "stop_hook_active": False,
+    })
+    result = run(stdin)
+
+    assert result.get("decision") == "block", \
+        f"Expected decision:'block' on recoverable error, got: {result}"
+    assert "RECOVERABLE ERROR" in result.get("reason", "")
+    assert "file_not_read" in result.get("reason", "")
+
+
+def test_recoverable_error_gate_skipped_when_stop_hook_active(mock_dependencies, tmp_path):
+    """Circuit-breaker: if Claude Code is re-invoking the Stop hook
+    after a previous block (stop_hook_active=True), don't re-fire the
+    gate even when the same error is still the most recent. Lets the
+    stop succeed so the agent escapes a same-error loop."""
+    import json as _json
+    from unittest.mock import patch
+    from macf.hooks.handle_stop import run
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(_json.dumps({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_test",
+                "content": "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+                "is_error": True,
+            }],
+        },
+    }) + "\n")
+
+    stdin = _json.dumps({
+        "transcript_path": str(transcript),
+        "stop_hook_active": True,  # circuit-breaker active
+    })
+    # Mock through enough of the post-gate flow that we don't hit the
+    # scope/timer gate plumbing in this minimal test.
+    with patch('macf.hooks.handle_stop.get_temporal_context') as m_temporal, \
+         patch('macf.hooks.handle_stop.get_rich_environment_string', return_value=''), \
+         patch('macf.hooks.handle_stop.get_breadcrumb', return_value='s/c/g/p/t'), \
+         patch('macf.hooks.handle_stop.get_token_info', return_value={'cl_level': 50, 'tokens_used': 1000, 'tokens_remaining': 100000}), \
+         patch('macf.hooks.handle_stop.detect_auto_mode', return_value=(False, 'default', 0.0)), \
+         patch('macf.hooks.handle_stop.format_token_context_full', return_value=''), \
+         patch('macf.hooks.handle_stop.get_boundary_guidance', return_value=''), \
+         patch('macf.hooks.handle_stop.format_macf_footer', return_value=''):
+        m_temporal.return_value = {'timestamp_formatted': 'now', 'day_of_week': 'Sat', 'time_of_day': 'Evening'}
+        result = run(stdin)
+
+    assert result.get("decision") != "block", \
+        f"Expected gate to be skipped under stop_hook_active=True, got: {result}"
+
+
 def test_saves_session_end_time_to_project_state(mock_dependencies):
     """Test Stop hook saves end time to project state for cross-session tracking."""
     from macf.hooks.handle_stop import run

--- a/macf/tests/test_recoverable_errors.py
+++ b/macf/tests/test_recoverable_errors.py
@@ -1,0 +1,239 @@
+"""Unit tests for recoverable-error pattern registry and transcript scanner.
+
+Covers:
+  - Each pattern in the registry produces a useful directive on a real
+    error string sampled from CC tool-result transcripts.
+  - The scanner correctly walks the JSONL backwards and identifies the
+    most recent tool_result.
+  - Self-gating behavior: if the most recent tool_result is a SUCCESS
+    (agent already recovered), the scanner returns None even if there
+    are older errors in the transcript.
+  - Robustness: missing transcript, malformed JSON lines, unknown error
+    text — none crash the scanner.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from macf.hooks.recoverable_errors import (
+    PATTERNS,
+    match_error_text,
+    scan_last_tool_error,
+)
+
+
+# --- Per-pattern matching --------------------------------------------------
+
+@pytest.mark.parametrize(
+    "expected_name, error_text",
+    [
+        (
+            "file_not_read",
+            "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>",
+        ),
+        (
+            "file_modified_since_read",
+            "<tool_use_error>File has been modified since read, either by the user or by a linter. Read it again before attempting to write it.</tool_use_error>",
+        ),
+        (
+            "old_string_not_found",
+            "<tool_use_error>String to replace not found in file.\nString: foo bar</tool_use_error>",
+        ),
+        (
+            "replace_all_mismatch",
+            "<tool_use_error>Found 5 matches of the string to replace, but expected 1 occurrence. Use replace_all=true or make old_string more specific.</tool_use_error>",
+        ),
+        (
+            "tool_not_in_registry",
+            "<tool_use_error>Error: No such tool available: WebFetch</tool_use_error>",
+        ),
+        (
+            "input_validation_error",
+            "<tool_use_error>InputValidationError: Read failed due to the following issue:\nThe parameter `offset` type is expected as `number` but provided as `string`</tool_use_error>",
+        ),
+        (
+            "path_does_not_exist",
+            "<tool_use_error>Path does not exist: /Users/cversek/gitwork/cversek/MacEff/macf_tools</tool_use_error>",
+        ),
+        (
+            "file_does_not_exist",
+            "<tool_use_error>File does not exist.</tool_use_error>",
+        ),
+        (
+            "file_does_not_exist",  # variant with "Did you mean" suggestion
+            "<tool_use_error>File does not exist. Did you mean utils?</tool_use_error>",
+        ),
+    ],
+)
+def test_pattern_matches_real_error(expected_name: str, error_text: str):
+    """Each registered pattern matches a real error string sampled from
+    CC transcripts and produces a non-empty directive.
+    """
+    result = match_error_text(error_text)
+    assert result is not None, f"Pattern {expected_name!r} did not match: {error_text}"
+    name, directive = result
+    assert name == expected_name
+    assert directive and len(directive) > 20  # non-trivial directive
+    # Sanity: directive shouldn't contain raw {placeholder} markers
+    assert "{" not in directive or "[template-render-error:" in directive
+
+
+def test_replace_all_mismatch_extracts_counts():
+    """replace_all_mismatch directive should mention the actual numbers."""
+    text = "<tool_use_error>Found 7 matches of the string to replace, but expected 1 occurrence.</tool_use_error>"
+    result = match_error_text(text)
+    assert result is not None
+    name, directive = result
+    assert name == "replace_all_mismatch"
+    assert "7" in directive and "1" in directive
+
+
+def test_tool_not_in_registry_extracts_name():
+    text = "<tool_use_error>Error: No such tool available: WebSearch</tool_use_error>"
+    result = match_error_text(text)
+    assert result is not None
+    name, directive = result
+    assert name == "tool_not_in_registry"
+    assert "WebSearch" in directive
+    assert "select:WebSearch" in directive
+
+
+def test_path_suggestion_folded_into_directive():
+    """When CC includes a 'Did you mean X?' suggestion, the directive
+    surfaces it explicitly so the agent can act on it directly."""
+    text = "<tool_use_error>File does not exist. Did you mean utils?</tool_use_error>"
+    result = match_error_text(text)
+    assert result is not None
+    name, directive = result
+    assert name == "file_does_not_exist"
+    assert "Did you mean: utils" in directive
+
+
+def test_path_does_not_exist_extracts_path():
+    text = "<tool_use_error>Path does not exist: /Users/cversek/gitwork/cversek/MacEff/macf_tools</tool_use_error>"
+    result = match_error_text(text)
+    assert result is not None
+    name, directive = result
+    assert name == "path_does_not_exist"
+    assert "/Users/cversek/gitwork/cversek/MacEff/macf_tools" in directive
+
+
+# --- Non-matches (must return None) ----------------------------------------
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        None,
+        "<tool_use_error>Cannot create new file - file already exists.</tool_use_error>",
+        "<tool_use_error>Cancelled: parallel tool call Bash(...) errored</tool_use_error>",
+        "[Request interrupted by user for tool use]",
+        "Some random non-error text",
+    ],
+)
+def test_unknown_or_unrecoverable_returns_none(text):
+    """Errors NOT in the registry must return None — the gate stays
+    out of the way for unrecoverable or user-induced cancellations.
+    """
+    assert match_error_text(text) is None
+
+
+# --- Pattern catalog integrity ---------------------------------------------
+
+def test_pattern_names_unique():
+    names = [p[0] for p in PATTERNS]
+    assert len(names) == len(set(names)), f"Duplicate pattern names: {names}"
+
+
+def test_all_patterns_compile():
+    """Sanity: every pattern compiled at import time."""
+    for name, regex, template in PATTERNS:
+        assert regex is not None
+        assert template
+
+
+# --- Transcript scanner ----------------------------------------------------
+
+def _write_transcript(path: Path, lines: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+
+
+def _user_tool_result(error_text: str, is_error: bool = True) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_test",
+                    "content": error_text,
+                    "is_error": is_error,
+                }
+            ],
+        },
+    }
+
+
+def _user_text(text: str) -> dict:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": text},
+    }
+
+
+def test_scanner_finds_most_recent_error(tmp_path: Path):
+    """Most recent tool_result is an error → return matched directive."""
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(transcript, [
+        _user_text("hello"),
+        _user_tool_result("<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>"),
+    ])
+    result = scan_last_tool_error(str(transcript))
+    assert result is not None
+    name, directive = result
+    assert name == "file_not_read"
+    assert "Read" in directive
+
+
+def test_scanner_self_gates_on_successful_recovery(tmp_path: Path):
+    """If the agent already recovered (most recent tool_result is success),
+    the scanner returns None even when older errors exist."""
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(transcript, [
+        # Older error (agent saw, then fixed)
+        _user_tool_result("<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>"),
+        # More recent success
+        _user_tool_result("File contents OK", is_error=False),
+    ])
+    assert scan_last_tool_error(str(transcript)) is None
+
+
+def test_scanner_handles_missing_transcript():
+    assert scan_last_tool_error("/nonexistent/path.jsonl") is None
+    assert scan_last_tool_error("") is None
+
+
+def test_scanner_skips_malformed_json(tmp_path: Path):
+    """A malformed line in the middle should not crash the scanner."""
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(
+        "not valid json\n"
+        + json.dumps(_user_tool_result("<tool_use_error>File has not been read yet. Read it.</tool_use_error>"))
+        + "\n"
+    )
+    result = scan_last_tool_error(str(transcript))
+    assert result is not None
+    assert result[0] == "file_not_read"
+
+
+def test_scanner_returns_none_when_no_match(tmp_path: Path):
+    """Tool error that doesn't match any registry pattern → None."""
+    transcript = tmp_path / "session.jsonl"
+    _write_transcript(transcript, [
+        _user_tool_result("<tool_use_error>Some unrecognized error text</tool_use_error>"),
+    ])
+    assert scan_last_tool_error(str(transcript)) is None


### PR DESCRIPTION
## Summary

Adds a Stop-hook gate that detects common recoverable tool errors and blocks the stop with a pattern-specific recovery directive — turning interrupt-class friction (agent stops + apologizes + waits for user redirect) into transparent-retry-class friction (agent retries with the obvious fix).

The gate runs early in `handle_stop.run()` (before scope/timer gates), reads the transcript JSONL backwards via `scan_last_tool_error()`, matches the most recent `tool_result` against a registry of regex patterns, and on a hit returns `decision: 'block'` with a tailored directive.

## Initial pattern catalog

Registry lives in `macf/src/macf/hooks/recoverable_errors.py`. New patterns land as 3-line additions: name + regex + directive template.

| Name | Trigger |
|------|---------|
| `file_not_read` | Edit/Write without prior Read in this turn |
| `file_modified_since_read` | File changed by linter/user/sibling tool since last Read |
| `old_string_not_found` | Edit's `old_string` doesn't match current file content |
| `replace_all_mismatch` | `replace_all=False` but found ≠ expected occurrence count |
| `tool_not_in_registry` | Deferred tool referenced without ToolSearch load |
| `input_validation_error` | Bad parameter type/name on a tool call |
| `path_does_not_exist` | Explicit `Path does not exist: <path>` |
| `file_does_not_exist` | `File does not exist[. Did you mean X?]` (suggestion folded into directive) |

The first six come from the BUG #1088 spec; the last two were added after empirical scan of 34 recent transcripts surfaced them as common variants.

## Behavioral guarantees

- **Self-gating**: scanner walks the JSONL backwards from the end. If the MOST RECENT `tool_result` is a success (agent already recovered), the gate returns None even if older errors are present.
- **Loop protection**: respects CC's `stop_hook_active` flag. If the gate already fired and the agent retried without success, the next stop is allowed through rather than re-firing the same directive into a loop.
- **Mode-independent**: fires in AUTO_MODE and MANUAL_MODE. Recoverable-error friction is the same in either mode; the scope/timer gates remain AUTO_MODE-only.
- **Earliest gate position**: runs before scope/timer gates because a failed Edit is more urgent than "you have scoped tasks remaining."
- **Event-logged**: each block emits a `recoverable_error_blocked` event with the pattern name so registry effectiveness can be tuned empirically.

## Files

- `macf/src/macf/hooks/recoverable_errors.py` (NEW) — registry, scanner, directive formatter
- `macf/src/macf/hooks/handle_stop.py` — adds the gate (~40 lines, before existing scope/timer gates)
- `macf/tests/test_recoverable_errors.py` (NEW) — 26 unit tests: per-pattern matching, scanner self-gating, malformed-JSON robustness, registry integrity
- `macf/tests/test_handle_stop.py` — 2 integration tests: gate fires on error, circuit-breaker skips when `stop_hook_active=True`

## Out of scope (for follow-ups)

- Tool-input extraction for richer directives ("Re-Read /path/to/foo.py" vs generic "Re-Read the file")
- Per-pattern opt-out via env var
- `--dry-run` mode for canary testing
- i18n (English-only patterns)

## Test plan

- [x] All 26 registry/scanner unit tests pass
- [x] Both integration tests through `handle_stop.run()` pass
- [x] All existing handle_stop tests still pass (10/10)