### PR TITLE
fix(hooks): write absolute paths in hooks_install (closes #89)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -731,7 +731,15 @@ def cmd_hook_install(args: argparse.Namespace) -> int:
                 print(f"   Clearing hooks from local settings...")
                 _clear_hooks_from_settings(local_settings)
 
-        # Set paths based on mode and environment
+        # Set paths based on mode and environment.
+        #
+        # Hook commands MUST resolve to absolute paths in settings (cversek/MacEff#89).
+        # A bare `cd` in the agent's persistent Bash shell shifts CWD; if the
+        # hook command is relative (e.g. "python .claude/hooks/X.py"), every
+        # subsequent PreToolUse lookup resolves against the shifted CWD,
+        # fails with ENOENT, and blocks ALL tool calls including the
+        # de-escalation paths needed to recover. Only an external session
+        # restart unblocks the agent. Absolute paths sidestep this entirely.
         if mode == 'global':
             hooks_dir = Path.home() / ".claude" / "hooks"
             settings_file = Path.home() / ".claude" / "settings.json"
@@ -739,12 +747,17 @@ def cmd_hook_install(args: argparse.Namespace) -> int:
                 # Container: absolute venv Python + absolute hook paths (FP#27)
                 hooks_prefix = f"/opt/maceff-venv/bin/python {Path.home()}/.claude/hooks"
             else:
-                hooks_prefix = "python ~/.claude/hooks"
+                # Host global: write the absolute home path. ~ expansion is
+                # shell-dependent and CC's hook exec model isn't documented to
+                # guarantee it; absolute removes the assumption.
+                hooks_prefix = f"python {Path.home()}/.claude/hooks"
         else:
-            # Local mode (host only - container always uses global)
+            # Local mode (host only - container always uses global).
+            # Resolve to canonical absolute path so symlinked project trees,
+            # relative invocations, and CWD-shifts all hit the same hooks dir.
             hooks_dir = Path.cwd() / ".claude" / "hooks"
             settings_file = Path.cwd() / ".claude" / "settings.local.json"
-            hooks_prefix = "python .claude/hooks"
+            hooks_prefix = f"python {hooks_dir.resolve()}"
 
         # Create hooks directory
         hooks_dir.mkdir(parents=True, exist_ok=True)

--- a/macf/tests/test_hook_install_absolute_paths.py
+++ b/macf/tests/test_hook_install_absolute_paths.py
@@ -1,0 +1,135 @@
+"""Regression tests for cversek/MacEff#89 — hooks_install must write
+absolute paths into settings (.local.json or global), so a bare `cd`
+in agent Bash that shifts CWD doesn't break hook lookup and paralyze
+every subsequent tool call.
+
+The bug: previously local-mode wrote `python .claude/hooks/X.py` and
+host-global wrote `python ~/.claude/hooks/X.py`. Both can fail
+catastrophically: relative paths resolve against the shifted CWD, and
+~ expansion is shell-dependent and not documented to fire in CC's
+hook exec model.
+
+The fix: write absolute paths in both modes so hook lookup is
+CWD-independent and shell-expansion-independent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+
+# --- Helpers ---------------------------------------------------------------
+
+def _read_hook_commands(settings_path: Path) -> list[str]:
+    """Read all hook command strings from a settings JSON file."""
+    settings = json.loads(settings_path.read_text())
+    commands: list[str] = []
+    for hook_name, entries in settings.get("hooks", {}).items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command")
+                if cmd:
+                    commands.append(cmd)
+    return commands
+
+
+# --- Local-mode regression -------------------------------------------------
+
+def test_local_install_writes_absolute_hook_paths(tmp_path, monkeypatch):
+    """Local-mode install must write absolute paths to settings.local.json,
+    so a bare `cd` in agent Bash doesn't break hook lookup.
+    """
+    from macf.cli import cmd_hook_install
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "fakehome")
+    # Force host (not container) by intercepting the /.dockerenv check.
+    monkeypatch.setattr(
+        "pathlib.Path.exists",
+        lambda self: False if str(self) == "/.dockerenv" else Path.exists.__wrapped__(self) if hasattr(Path.exists, "__wrapped__") else Path(str(self)).is_file() or Path(str(self)).is_dir(),
+    )
+
+    args = argparse.Namespace(local_install=True, global_install=False)
+    rc = cmd_hook_install(args)
+    assert rc == 0, "Local install returned non-zero"
+
+    settings_path = tmp_path / ".claude" / "settings.local.json"
+    assert settings_path.exists(), "settings.local.json not written"
+
+    commands = _read_hook_commands(settings_path)
+    assert commands, "No hook commands found in settings"
+
+    expected_hooks_dir = (tmp_path / ".claude" / "hooks").resolve()
+    for cmd in commands:
+        assert ".claude/hooks" not in cmd or str(expected_hooks_dir) in cmd, (
+            f"Hook command should reference absolute hooks dir, got: {cmd}"
+        )
+        # Absolute path: starts with python <abs-path>
+        # Allow either resolved tmp_path prefix or the canonicalized macOS
+        # /private prefix (tmp_path on darwin can resolve via /private/var).
+        assert (
+            f"python {expected_hooks_dir}/" in cmd
+            or f"python {expected_hooks_dir}\\" in cmd  # Windows safety
+        ), f"Hook command not absolute: {cmd}"
+
+
+def test_local_install_no_relative_dot_claude_path(tmp_path, monkeypatch):
+    """The literal 'python .claude/hooks/' prefix must NEVER appear in
+    settings — that's the exact failure mode from #89.
+    """
+    from macf.cli import cmd_hook_install
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "fakehome")
+    monkeypatch.setattr(
+        "pathlib.Path.exists",
+        lambda self: False if str(self) == "/.dockerenv" else Path(str(self)).is_file() or Path(str(self)).is_dir(),
+    )
+
+    args = argparse.Namespace(local_install=True, global_install=False)
+    cmd_hook_install(args)
+
+    settings_path = tmp_path / ".claude" / "settings.local.json"
+    text = settings_path.read_text()
+    # The exact buggy prefix
+    assert "python .claude/hooks/" not in text, (
+        "Settings still contains the relative prefix that #89 fixes"
+    )
+
+
+# --- Global host-mode regression -------------------------------------------
+
+def test_global_host_install_writes_absolute_home_path(tmp_path, monkeypatch):
+    """Host-global install must write the absolute home path, not ~,
+    because shell-expansion is not guaranteed in CC's hook exec model.
+    """
+    from macf.cli import cmd_hook_install
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setattr(
+        "pathlib.Path.exists",
+        lambda self: False if str(self) == "/.dockerenv" else Path(str(self)).is_file() or Path(str(self)).is_dir(),
+    )
+
+    args = argparse.Namespace(local_install=False, global_install=True)
+    rc = cmd_hook_install(args)
+    assert rc == 0
+
+    settings_path = fake_home / ".claude" / "settings.json"
+    assert settings_path.exists()
+
+    text = settings_path.read_text()
+    assert "python ~/.claude/hooks/" not in text, (
+        "Host-global install still uses ~ (shell-expansion-dependent)"
+    )
+    commands = _read_hook_commands(settings_path)
+    for cmd in commands:
+        assert f"python {fake_home}/.claude/hooks/" in cmd, (
+            f"Host-global hook command not absolute-home: {cmd}"
+        )


### PR DESCRIPTION
## Summary

Hook commands written to `settings.local.json` (local mode) and `settings.json` (global host mode) now use absolute paths. Closes #89.

A bare `cd` in the agent's persistent Bash shell shifts CWD; the prior relative form (`python .claude/hooks/X.py`) then resolved against the shifted CWD, failed with `ENOENT`, and blocked every subsequent PreToolUse — including the de-escalation paths that would otherwise let the agent recover (`mode set MANUAL_MODE`, editing settings, Telegram MCP). External session restart was the only escape, and the reporter saw ~4.5 hours of agent paralysis in the wild.

The host-global form (`python ~/.claude/hooks/X.py`) is also rewritten for symmetry: `~` expansion is shell-dependent and CC's hook exec model isn't documented to guarantee it. Container-global already used absolute paths (FP#27) and is unchanged.

## Behavior change

Before:
```json
"command": "python .claude/hooks/pre_tool_use.py"
```

After (local on host):
```json
"command": "python /Users/me/myproject/.claude/hooks/pre_tool_use.py"
```

After (global on host):
```json
"command": "python /Users/me/.claude/hooks/pre_tool_use.py"
```

After (container global, unchanged):
```json
"command": "/opt/maceff-venv/bin/python /home/pa_x/.claude/hooks/pre_tool_use.py"
```

## Why this is the right fix

The bare-cd detector at `_is_bare_cd_command` (PreToolUse) has been hardened progressively (#82, PR #86) and remains useful — it discourages the pattern and informs the user. But it is fundamentally a heuristic on the agent's command string, and a heuristic miss has a catastrophic blast radius (whole-session paralysis). Absolutizing the hook paths sidesteps the heuristic entirely: even a successful bare-cd doesn't break hook lookup, because lookup no longer depends on CWD.

This is the verify-or-fail / substrate-hardening direction codified in cycle-515 — turn silent-success-with-catastrophic-followup failure modes into hardened invariants at the substrate layer.

## Migration

Existing installs migrate by re-running:
```bash
macf_tools framework install
# or
macf_tools hooks install --local
# or
macf_tools hooks install --global
```

`settings.local.json` is gitignored and per-user, so absolute paths introduce no new portability concerns.

## Files

- `macf/src/macf/cli.py` — `cmd_hook_install` writes absolute paths in both host-global and local modes (~17 lines including comment block citing #89)
- `macf/tests/test_hook_install_absolute_paths.py` (NEW) — 3 regression tests:
  - Local mode writes absolute hook paths
  - Local mode never writes the literal `python .claude/hooks/` prefix
  - Host-global writes absolute home path (no `~`)

## Test plan

- [x] 3 new regression tests pass
- [x] 43 adjacent tests still pass (`test_permissions_template_merge`, `test_framework_install_verification`, `test_claude_settings`)
- [ ] Post-merge: verify by re-running `macf_tools framework install` in a host project and checking `settings.local.json` contents

## Stacking note

This and PR #90 (recoverable-error gate) are independent — both branched off the same `main`. PR #90 turns recoverable Edit/Write/Tool errors into transparent retries via Stop-hook directives. This PR turns the worst non-recoverable error class (cwd-shift hook paralysis) into a non-event by making hook lookup CWD-independent. Together they harden two distinct substrate-level fragilities surfaced this cycle.