### PR TITLE
fix(utils): set_terminal_title — use OSC 0 instead of OSC 2 (Terminal.app compat)

### DIFF
--- a/macf/src/macf/utils/terminal.py
+++ b/macf/src/macf/utils/terminal.py
@@ -2,7 +2,7 @@
 
 Currently exposes one function:
 
-- ``set_terminal_title(title)`` — write an OSC 2 escape to set the terminal
+- ``set_terminal_title(title)`` — write an OSC 0 escape to set the terminal
   window title (e.g. so multi-agent terminal layouts can be told apart at a
   glance).
 
@@ -18,7 +18,13 @@ __all__ = ["set_terminal_title"]
 
 
 def set_terminal_title(title: str) -> bool:
-    """Set the terminal window title via an OSC 2 escape sequence.
+    """Set the terminal window title via an OSC 0 escape sequence.
+
+    OSC 0 sets both the icon name and the window title in one go. We chose
+    OSC 0 over OSC 2 (window-title only) because empirical testing on
+    Terminal.app showed OSC 2 was silently ignored while OSC 0 worked. OSC 0
+    is the most broadly supported of the title-setting escapes across
+    terminal emulators in practice.
 
     The escape is written to ``sys.stderr`` (never stdout) so it does not
     contaminate downstream data pipelines such as
@@ -36,7 +42,7 @@ def set_terminal_title(title: str) -> bool:
         is empty after stripping).
 
     Terminal support:
-        OSC 2 + BEL terminator is respected by Terminal.app, iTerm2, xterm,
+        OSC 0 + BEL terminator is respected by Terminal.app, iTerm2, xterm,
         gnome-terminal / Konsole / other VTE-based terminals, Windows Terminal
         and VS Code's integrated terminal. Plain ``ssh`` sessions pass the
         sequence through.
@@ -66,9 +72,11 @@ def set_terminal_title(title: str) -> bool:
     if not term or term == "dumb":
         return False
 
-    # OSC 2: set window title only. BEL terminator (universally accepted).
+    # OSC 0: set icon name AND window title. BEL terminator (universally
+    # accepted). OSC 0 is empirically more reliable than OSC 2 across
+    # terminal emulators (Terminal.app in particular ignores OSC 2).
     try:
-        sys.stderr.write(f"\x1b]2;{cleaned}\x07")
+        sys.stderr.write(f"\x1b]0;{cleaned}\x07")
         sys.stderr.flush()
     except (OSError, IOError, ValueError):
         # Write to closed stderr or pipe in a weird state — non-fatal.

--- a/macf/tests/test_terminal_title.py
+++ b/macf/tests/test_terminal_title.py
@@ -28,8 +28,8 @@ def _force_tty(monkeypatch: pytest.MonkeyPatch, isatty: bool) -> None:
 
 # --- Happy path -----------------------------------------------------------
 
-def test_happy_path_writes_osc2_to_stderr(monkeypatch: pytest.MonkeyPatch):
-    """Interactive TTY + sane $TERM: writes the OSC 2 escape to stderr."""
+def test_happy_path_writes_osc0_to_stderr(monkeypatch: pytest.MonkeyPatch):
+    """Interactive TTY + sane $TERM: writes the OSC 0 escape to stderr."""
     _force_tty(monkeypatch, True)
     monkeypatch.setenv("TERM", "xterm-256color")
     buf = _capture_stderr(monkeypatch)
@@ -37,7 +37,7 @@ def test_happy_path_writes_osc2_to_stderr(monkeypatch: pytest.MonkeyPatch):
     ok = set_terminal_title("Hello")
 
     assert ok is True
-    assert buf.getvalue() == "\x1b]2;Hello\x07"
+    assert buf.getvalue() == "\x1b]0;Hello\x07"
 
 
 # --- Safety guards (each returns False without writing) -------------------
@@ -108,4 +108,4 @@ def test_strips_bel_and_esc_bytes(monkeypatch: pytest.MonkeyPatch):
     # appear in the emitted OSC sequence — only the wrapper's own BEL
     # terminator at the very end is allowed.
     emitted = buf.getvalue()
-    assert emitted == "\x1b]2;evilinjectedvalue\x07"
+    assert emitted == "\x1b]0;evilinjectedvalue\x07"


### PR DESCRIPTION
## Problem

The terminal-title helper from PR #95 emitted OSC 2 (set window title only). On Terminal.app the title silently didn't update. User verified empirically by running the two forms back-to-back from a real shell:

```
python3 -c "import sys; sys.stderr.write('\x1b]0;OSC0\x07'); sys.stderr.flush()"  # works
python3 -c "import sys; sys.stderr.write('\x1b]2;OSC2\x07'); sys.stderr.flush()"  # silent no-op
```

Only OSC 0 updated the title.

## Fix

Switch the emitted byte sequence from `\x1b]2;...\x07` to `\x1b]0;...\x07`. OSC 0 sets both icon name and window title and is the most broadly supported of the title-setting escapes across terminal emulators in practice. Stream stays as stderr (preserves the no-pipeline-pollution property documented in the helper).

One-line behavioral change. Docstring and tests updated accordingly.

## Test plan

- [x] `pytest macf/tests/test_terminal_title.py -v` — 6/6 green
- [x] Manual: real `macf_tools env set-term-title "probe"` from a Terminal.app session updates the title (verified by user before this PR was opened)

## Diff scope

2 files, 17 insertions / 9 deletions.

- `macf/src/macf/utils/terminal.py` — bytes change + docstring rationale
- `macf/tests/test_terminal_title.py` — assertion bytes + one test name (`osc2` → `osc0`)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>