### PR TITLE
feat(streaming): seek-from-end line iterators — fix Stop-hook OOM (closes #94)

### DIFF
--- a/macf/src/macf/agent_events_log.py
+++ b/macf/src/macf/agent_events_log.py
@@ -24,6 +24,7 @@ from .utils import (
     get_breadcrumb,
     parse_breadcrumb,
 )
+from .utils.streaming import iter_lines_forward, iter_lines_reverse
 
 
 # Global log path override for testing
@@ -164,6 +165,15 @@ def read_events(
     """
     Read events from log (generator for memory efficiency).
 
+    Both directions stream — the reverse path uses ``iter_lines_reverse``
+    (seek-from-end, fixed-chunk) and the forward path uses
+    ``iter_lines_forward`` (line-by-line). Neither materializes the full
+    file, so memory is O(chunk_size + max_line_size) regardless of log size.
+
+    Callers that only need the most recent N events SHOULD pass an explicit
+    ``limit`` so the generator stops early. ``limit=None`` still works but
+    will scan the whole file if no early break.
+
     Args:
         limit: Maximum events to yield (None = all)
         reverse: If True, read from end (most recent first)
@@ -181,15 +191,13 @@ def read_events(
         if not log_path.exists():
             return
 
-        with open(log_path, 'r') as f:
-            lines = f.readlines()
-
-        # Reverse if requested
         if reverse:
-            lines = reversed(lines)
+            line_iter = iter_lines_reverse(log_path)
+        else:
+            line_iter = iter_lines_forward(log_path)
 
         count = 0
-        for line in lines:
+        for line in line_iter:
             line = line.strip()
             if not line:
                 continue

--- a/macf/src/macf/hooks/recoverable_errors.py
+++ b/macf/src/macf/hooks/recoverable_errors.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from ..utils.streaming import iter_lines_reverse
+
 # --- Pattern registry ------------------------------------------------------
 #
 # Each entry: (name, compiled-regex, directive-template)
@@ -180,15 +182,16 @@ def scan_last_tool_error(transcript_path: str) -> Optional[Tuple[str, str]]:
     if not p.exists() or not p.is_file():
         return None
 
+    # JSONL transcripts can be >1 GB at high context use. Stream lines
+    # from EOF instead of materializing the file (which OOM-killed the
+    # Stop hook — closes GH cversek/MacEff#94). For the typical case we
+    # find the answer in the last 1–3 lines, so this is also cheap.
     try:
-        # JSONL transcripts can be large; read in full but iterate reversed.
-        # For the typical agent-stop case we'll find the answer in the last
-        # 1–3 lines so this is cheap in practice.
-        lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+        line_iter = iter_lines_reverse(p)
     except (OSError, IOError):
         return None
 
-    for line in reversed(lines):
+    for line in line_iter:
         if '"tool_result"' not in line:
             # Quick reject — not a tool result line. Avoids JSON parse cost.
             continue

--- a/macf/src/macf/utils/streaming.py
+++ b/macf/src/macf/utils/streaming.py
@@ -1,0 +1,121 @@
+"""Streaming I/O utilities — read large files without materialization.
+
+The Stop hook scans event logs and CC transcript JSONLs to find the most
+recent matching event (e.g. ``scope_timer_set``, a tool error). The naive
+implementation ``f.readlines()`` materializes the entire file into a list.
+For event logs that grow to hundreds of MB and transcripts that can be
+~1 GB, this OOM-kills the hook at high context use.
+
+This module provides a generator that reads a file backwards in fixed-size
+chunks, yielding decoded lines newest-first. Memory bound: roughly
+``chunk_size + max_line_size`` bytes at any moment, independent of file
+size.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator, Union
+
+
+def iter_lines_forward(
+    path: Union[str, Path],
+    encoding: str = "utf-8",
+) -> Generator[str, None, None]:
+    """Yield decoded lines from ``path`` in file order (oldest-first).
+
+    Streams line-by-line via Python's default text-mode file iteration —
+    no materialization, O(max_line_size) memory regardless of file size.
+    Provided as the forward-direction peer of ``iter_lines_reverse`` so
+    callers can pick a direction without leaving the streaming module.
+
+    Args:
+        path: File path to read.
+        encoding: Text encoding for decoded output (default ``utf-8``).
+
+    Yields:
+        Lines as str, NEWLINE INCLUDED (matches Python's native ``for line
+        in f`` behavior). Callers typically strip via ``line.strip()`` or
+        ``line.rstrip('\\n')`` as needed.
+
+    Example:
+        >>> for line in iter_lines_forward("events.jsonl"):
+        ...     event = json.loads(line)
+        ...     process(event)
+    """
+    with open(path, "r", encoding=encoding) as f:
+        for line in f:
+            yield line
+
+
+def iter_lines_reverse(
+    path: Union[str, Path],
+    chunk_size: int = 65536,
+    encoding: str = "utf-8",
+) -> Generator[str, None, None]:
+    """Yield decoded lines from ``path`` in reverse order (newest first).
+
+    Reads the file backwards from EOF in ``chunk_size`` byte chunks. Within
+    each chunk, lines are split on ``b'\\n'``. The trailing fragment of a
+    line that started in an earlier (older) chunk is carried over as a
+    ``remainder`` so cross-chunk lines reassemble correctly.
+
+    UTF-8 safety: decoding happens AFTER reassembly, with ``errors='replace'``
+    as a defensive fallback when input contains malformed bytes (it should
+    never happen for well-formed JSONL, but the alternative — crashing —
+    is worse than emitting a U+FFFD).
+
+    Args:
+        path: File path to read.
+        chunk_size: Bytes per read. Default 64 KB. Larger = fewer syscalls,
+            higher transient memory; smaller = more syscalls, lower memory.
+        encoding: Text encoding for decoded output (default ``utf-8``).
+
+    Yields:
+        Lines as str, NEWLINE STRIPPED, newest-first. Empty lines (from a
+        trailing newline or blank lines in the source) are yielded as ``""``
+        so callers can filter via ``if not line: continue``.
+
+    Memory: O(chunk_size + max_line_size) regardless of file size.
+
+    Example:
+        >>> for line in iter_lines_reverse("events.jsonl"):
+        ...     if not line:
+        ...         continue
+        ...     if marker in line:
+        ...         print(line)
+        ...         break
+    """
+    p = Path(path)
+    with open(p, "rb") as f:
+        f.seek(0, 2)  # SEEK_END
+        position = f.tell()
+        if position == 0:
+            return
+
+        # remainder holds the partial leading line from the current chunk,
+        # whose continuation lives in the next (older) chunk we'll read.
+        remainder = b""
+
+        while position > 0:
+            read_size = min(chunk_size, position)
+            position -= read_size
+            f.seek(position)
+            chunk = f.read(read_size)
+
+            # The remainder from the previous iteration represents the START
+            # of a line whose REST is at the END of THIS (older) chunk.
+            # Concatenate so the split below produces complete lines.
+            data = chunk + remainder
+            lines = data.split(b"\n")
+
+            if position > 0:
+                # First piece may be incomplete — its prefix lives in an
+                # even earlier chunk. Save it as the new remainder.
+                remainder = lines[0]
+                # Yield the rest newest-first (last index is most recent).
+                for line in reversed(lines[1:]):
+                    yield line.decode(encoding, errors="replace")
+            else:
+                # No more chunks; every piece is complete.
+                for line in reversed(lines):
+                    yield line.decode(encoding, errors="replace")

--- a/macf/tests/test_streaming.py
+++ b/macf/tests/test_streaming.py
@@ -1,0 +1,169 @@
+"""Unit tests for macf.utils.streaming line iterators.
+
+Covers correctness (line ordering, cross-chunk reassembly, UTF-8, edge
+cases) plus a memory-bound regression test that demonstrates the
+seek-from-end reader doesn't materialize the file (closes the OOM bug
+fixed in cversek/MacEff#94).
+"""
+from __future__ import annotations
+
+import os
+import resource
+import sys
+from pathlib import Path
+
+import pytest
+
+from macf.utils.streaming import iter_lines_forward, iter_lines_reverse
+
+
+# --- iter_lines_reverse: happy paths and edge cases ----------------------
+
+def test_reverse_yields_lines_newest_first(tmp_path: Path):
+    """Multi-line file: yielded in reverse order with empty trailing-newline element."""
+    p = tmp_path / "f.txt"
+    p.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    lines = list(iter_lines_reverse(p))
+
+    # Trailing newline produces an empty final element when splitting.
+    # Reverse-iteration yields that empty string FIRST (most recent EOL),
+    # then "gamma", "beta", "alpha".
+    assert lines == ["", "gamma", "beta", "alpha"]
+
+
+def test_reverse_no_trailing_newline(tmp_path: Path):
+    """File without trailing newline: last line yielded first, no empty element."""
+    p = tmp_path / "f.txt"
+    p.write_text("alpha\nbeta\ngamma", encoding="utf-8")
+
+    lines = list(iter_lines_reverse(p))
+
+    assert lines == ["gamma", "beta", "alpha"]
+
+
+def test_reverse_empty_file_yields_nothing(tmp_path: Path):
+    """Zero-byte file: generator terminates without yielding."""
+    p = tmp_path / "empty.txt"
+    p.touch()
+
+    assert list(iter_lines_reverse(p)) == []
+
+
+def test_reverse_single_line_no_newline(tmp_path: Path):
+    """File containing one line with no newline: yielded as the sole element."""
+    p = tmp_path / "f.txt"
+    p.write_text("solitary", encoding="utf-8")
+
+    assert list(iter_lines_reverse(p)) == ["solitary"]
+
+
+def test_reverse_reassembles_across_chunk_boundary(tmp_path: Path):
+    """Line that spans a chunk boundary must be reassembled correctly.
+
+    We force the line in question to straddle a chunk by picking a small
+    chunk_size and a line longer than that.
+    """
+    p = tmp_path / "f.txt"
+    # 100-char line, with shorter ones bracketing it, written as JSONL-style
+    long_line = "X" * 100
+    p.write_text(f"first\n{long_line}\nlast\n", encoding="utf-8")
+
+    # chunk_size=32 forces long_line to straddle multiple chunks
+    lines = list(iter_lines_reverse(p, chunk_size=32))
+
+    # Drop empty trailing-newline artifact for clarity
+    non_empty = [line for line in lines if line]
+    assert non_empty == ["last", long_line, "first"]
+
+
+def test_reverse_utf8_multibyte_across_chunk_boundary(tmp_path: Path):
+    """Multi-byte UTF-8 char split mid-codepoint by chunk boundary still decodes."""
+    p = tmp_path / "f.txt"
+    # "ééééé" is 5 chars × 2 bytes each = 10 bytes per "éééé" group.
+    # Mix with ASCII to force boundary placement.
+    p.write_bytes(b"hello\n" + ("é" * 50).encode("utf-8") + b"\nworld\n")
+
+    # Small chunk_size guarantees a multi-byte char gets split
+    lines = list(iter_lines_reverse(p, chunk_size=17))
+    non_empty = [line for line in lines if line]
+
+    assert non_empty == ["world", "é" * 50, "hello"]
+
+
+# --- iter_lines_forward ---------------------------------------------------
+
+def test_forward_yields_in_order_with_newlines_included(tmp_path: Path):
+    """Forward iteration preserves order and keeps the trailing newline on each line."""
+    p = tmp_path / "f.txt"
+    p.write_text("one\ntwo\nthree\n", encoding="utf-8")
+
+    lines = list(iter_lines_forward(p))
+
+    assert lines == ["one\n", "two\n", "three\n"]
+
+
+def test_forward_empty_file(tmp_path: Path):
+    """Forward read of empty file yields nothing."""
+    p = tmp_path / "empty.txt"
+    p.touch()
+
+    assert list(iter_lines_forward(p)) == []
+
+
+# --- Memory-bound regression (production-path validation) ----------------
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="ru_maxrss semantics differ on Windows; test is unix-only."
+)
+def test_reverse_does_not_materialize_large_file(tmp_path: Path):
+    """Closes cversek/MacEff#94: scanning a large JSONL backwards must not
+    materialize the file. We write a 30 MB JSONL and verify peak RSS growth
+    during a backward scan stays well under the file size.
+
+    We can't assert an exact RSS number portably (RSS depends on Python
+    object overhead, page granularity, prior allocations) so we assert the
+    growth from a baseline taken AFTER allocation of the iterator is
+    bounded by a small multiple of chunk_size + max_line_size.
+    """
+    p = tmp_path / "big.jsonl"
+    # 30 MB of repeating ~300-byte lines (event-log shape).
+    line = '{"timestamp": 1778700000, "event": "fake", "data": {"k": "' + "x" * 200 + '"}}'
+    line_size = len(line) + 1  # +1 for newline
+    target_bytes = 30 * 1024 * 1024
+    num_lines = target_bytes // line_size
+    with open(p, "w", encoding="utf-8") as f:
+        for _ in range(num_lines):
+            f.write(line + "\n")
+
+    file_size = p.stat().st_size
+    assert file_size >= 25 * 1024 * 1024, "test fixture should be ~30 MB"
+
+    # Baseline RSS AFTER fixture write (so we measure only the read cost).
+    rss_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    # Stream the file backwards, consume a handful of lines, then break.
+    count = 0
+    for _line in iter_lines_reverse(p, chunk_size=65536):
+        count += 1
+        if count >= 50:
+            break
+
+    rss_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # On macOS ru_maxrss is bytes; on Linux it's KB. Either way, the growth
+    # should be a tiny fraction of the file size. Allow 2 MB of slop for
+    # interpreter/import-time allocations unrelated to the read.
+    growth = rss_after - rss_before
+    # Convert growth to bytes if we're on Linux (assume KB if growth looks
+    # small enough to be a KB delta on a multi-MB file).
+    growth_bytes = growth if sys.platform == "darwin" else growth * 1024
+
+    # Bound: chunk_size + interpreter slop. Pick 4 MB.
+    assert growth_bytes < 4 * 1024 * 1024, (
+        f"RSS growth {growth_bytes} bytes exceeded streaming bound — "
+        f"file size was {file_size} bytes (suggests materialization)."
+    )
+
+    # Sanity: we actually read something.
+    assert count == 50


### PR DESCRIPTION
## Problem

The Stop hook OOM-killed at high context use because two readers materialized whole files:

- `recoverable_errors.scan_last_tool_error()` did `p.read_text().splitlines()` on the CC transcript JSONL (~1 GB at high context).
- `agent_events_log.read_events()` did `f.readlines()` on the event log (Manny's was ~582 MB).

When the Stop hook ran and the kernel had no room, both readers were the killable path. This closes cversek/MacEff#94.

## Fix

New `macf/utils/streaming.py` exposes two complementary line iterators:

- `iter_lines_forward(path)` — line-by-line forward iteration, no materialization (Python's default text-mode file iteration).
- `iter_lines_reverse(path, chunk_size=65536)` — seek-from-end backward iteration. Reads fixed-size chunks from EOF; cross-chunk line fragments reassemble via a `remainder` buffer; UTF-8 multi-byte codepoints split across chunk boundaries decode correctly via post-reassembly decoding with `errors='replace'` as defensive fallback.

Memory bound: O(chunk_size + max_line_size) regardless of file size.

Both helpers are imported from `macf.utils.streaming`. The two existing callers were refactored:

- `agent_events_log.read_events(limit, reverse=...)` — both directions now stream. `limit=None` is now safe at every call site, so existing callers (handle_stop.py:464 and three others) need no change.
- `recoverable_errors.scan_last_tool_error(path)` — uses `iter_lines_reverse` instead of full-file materialization.

## Test plan

**New tests (9 in `test_streaming.py`):**
- newest-first ordering with and without trailing newline
- empty file / single-line edge cases
- multi-chunk-spanning long lines reassemble correctly
- UTF-8 multi-byte char split across chunks decodes intact
- forward iteration preserves order with embedded newlines
- memory-bound regression: 30 MB synthetic JSONL, backward scan, RSS growth under 4 MB (proves no materialization — this is the #94 regression test)

**Regression sweep (101/101 green):**
- test_event_first_reads.py
- test_event_queries.py
- test_recoverable_errors.py
- test_handle_stop.py
- test_scope_and_stop.py

```
pytest macf/tests/test_streaming.py macf/tests/test_recoverable_errors.py macf/tests/test_handle_stop.py macf/tests/test_scope_and_stop.py macf/tests/test_event_first_reads.py macf/tests/test_event_queries.py
# 110 passed
```

## Out of scope (follow-ups)

- `session.py:117` has the same `f.readlines()` pattern on CC transcripts and warrants the same fix in a separate PR.
- `tokens.py` and `environment.py` already use the seek-from-end idiom for their own scans, so they're fine.

## Phase context

Phase 1 of MISSION #1100 (MacEff Hook Observability Hardening). Ships first alone per the MQI sequencing — urgent safety fix before the framework work in Phases 2/3.

## Diff scope

4 files, +312 / -11.

- `macf/src/macf/utils/streaming.py` (new — 121 lines)
- `macf/tests/test_streaming.py` (new — 169 lines)
- `macf/src/macf/agent_events_log.py` (refactor read_events to use streaming helpers)
- `macf/src/macf/hooks/recoverable_errors.py` (refactor scan_last_tool_error to use iter_lines_reverse)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>