### PR TITLE
feat(observability): warnings framework — dual-channel structured emission (closes #92)

### DIFF
--- a/macf/src/macf/observability/__init__.py
+++ b/macf/src/macf/observability/__init__.py
@@ -1,0 +1,29 @@
+"""macf.observability — structured warnings, hook messages, tool metadata.
+
+Cross-cutting visibility primitives for code paths that need to tell BOTH
+the user and the agent about something — an error, a status change, a
+warning. Replaces hand-rolled ``print(..., file=sys.stderr)`` plus an
+ad-hoc ``systemMessage`` build with a single audit point that handles
+formatting, deduplication, and (future) remote-observer routing.
+
+Current contents:
+
+- ``warnings`` — :class:`Warning` dataclass + :func:`emit_warning` for
+  structured, dual-channel (user + agent) diagnostic emission with
+  per-process deduplication.
+
+Planned siblings (separate modules within this namespace):
+
+- ``messages`` — non-warning content (status, mode markers, completion
+  summaries) with CLI-terminal ↔ Telegram parity for remote observers.
+- ``tool_metadata`` — concise per-tool metadata formatters used by
+  PreToolUse hook output (tool name + target/argument summary).
+
+Producers expected: hook handlers in ``macf.hooks.*``, channel modules
+in ``macf.channels.*``, and CLI commands in ``macf.cli``.
+"""
+from __future__ import annotations
+
+from .warnings import Warning, emit_warning, reset_dedup_registry
+
+__all__ = ["Warning", "emit_warning", "reset_dedup_registry"]

--- a/macf/src/macf/observability/warnings.py
+++ b/macf/src/macf/observability/warnings.py
@@ -1,0 +1,166 @@
+"""Generic hook-warning framework with dual-channel delivery.
+
+Replaces ad-hoc ``except Exception as e: print(f'⚠️ MACF: ...',
+file=sys.stderr)`` patterns scattered through hook handlers in
+``macf.hooks.*`` and channel modules in ``macf.channels.*``.
+
+Design intent:
+
+1. Carry enough STRUCTURE (source, kind, detail, cause, remediation,
+   full-trace pointer, severity) for any consumer to render the warning
+   well — user-facing terminal, agent-facing systemMessage, and future
+   remote-observer routing.
+2. Deliver to BOTH channels by default with at-least-once semantics:
+   stderr emits unconditionally as the failure-safe default, and the
+   agent-channel contribution is returned for the caller to merge into
+   the hook's return dict.
+3. Deduplicate by ``source:kind`` fingerprint within a process so a
+   chatty inner loop doesn't paper the terminal with identical lines.
+   First occurrence is verbatim; subsequent occurrences get a ``(×N)``
+   suffix.
+
+Consumers call :func:`emit_warning` and merge its return dict into their
+own hook return dict::
+
+    return {**emit_warning(w), "continue": True, ...}
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Dict, Literal, Optional
+
+
+Severity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class Warning:
+    """Structured warning suitable for dual-channel emission.
+
+    ``frozen=True`` makes instances hashable + immutable so they're safe
+    to pass through callbacks and store in registries without aliasing
+    hazards. New fields can be added as ``Optional`` without breaking
+    callers — dataclass is additive-friendly.
+
+    Attributes:
+        source: Short identifier for the producing subsystem.
+            Examples: ``"telegram"``, ``"config"``, ``"stop_hook"``.
+        kind: Short identifier for the warning category within
+            ``source``. Examples: ``"api_unreachable"``,
+            ``"missing_required_field"``. ``source:kind`` is the dedup
+            fingerprint — pick a kind narrow enough to NOT collapse
+            genuinely-distinct issues but broad enough to deduplicate
+            the chatty case.
+        detail: One-line technical detail. NEVER a full stack trace —
+            keep the trace at ``full_trace_path`` if useful. Goes
+            verbatim into the stderr line and into the agent's
+            systemMessage.
+        likely_cause: Plain-language explanation of why this likely
+            happened. Aimed at a human reader of the terminal, not the
+            agent. Optional but recommended.
+        user_remediation: Concrete action the user can take. Same
+            audience and intent as ``likely_cause``. Optional.
+        full_trace_path: Filesystem path where a longer trace, log, or
+            dump was written if the warning needed one. ``None`` if
+            ``detail`` is enough.
+        severity: One of ``"info"``, ``"warning"``, ``"error"``. Used by
+            future severity filters and by terminals that distinguish
+            (colour, prefix).
+    """
+
+    source: str
+    kind: str
+    detail: str
+    likely_cause: str = ""
+    user_remediation: str = ""
+    full_trace_path: Optional[str] = None
+    severity: Severity = "warning"
+
+    def fingerprint(self) -> str:
+        """``source:kind`` — the dedup key. Stable across instances with
+        the same source+kind, distinct otherwise."""
+        return f"{self.source}:{self.kind}"
+
+
+# Per-process dedup registry. Hook processes are short-lived so
+# per-process is effectively per-invocation. Longer-lived processes
+# (proxy, CLI repls) can pass an explicit registry via the ``_registry``
+# arg to emit_warning if they want per-context dedup semantics.
+_DEDUP_COUNTS: Dict[str, int] = {}
+
+
+def reset_dedup_registry() -> None:
+    """Empty the module-level dedup registry.
+
+    Intended for tests and for long-lived processes that want a clean
+    boundary at a specific point (e.g. a CLI repl between commands).
+    Production hook code does not need to call this — the hook process
+    exits, taking the registry with it.
+    """
+    _DEDUP_COUNTS.clear()
+
+
+def emit_warning(
+    w: Warning,
+    *,
+    dedupe: bool = True,
+    _registry: Optional[Dict[str, int]] = None,
+) -> dict:
+    """Emit ``w`` to BOTH the user (stderr) and the agent (systemMessage).
+
+    Stderr is written unconditionally as the failure-safe default — if
+    the caller forgets to merge the returned dict, the agent loses the
+    message but the user still sees it on the terminal.
+
+    Args:
+        w: The Warning to emit.
+        dedupe: When True (default), increments a per-process counter
+            keyed on ``w.fingerprint()`` and appends ``(×N)`` to both
+            the stderr line and the systemMessage for ``N > 1``. Pass
+            ``False`` for callers that want every occurrence emitted
+            verbatim.
+        _registry: Optional injected dedup registry (dict mapping
+            fingerprint → count). Defaults to the module-level registry.
+            Tests use this to isolate state; long-lived processes use
+            it to scope dedup to a context. Underscore-prefixed because
+            normal callers should never need to touch it.
+
+    Returns:
+        A dict slice intended to be merged into the hook's return dict::
+
+            return {**emit_warning(w), "continue": True, ...}
+
+        Currently the dict contains ``{"systemMessage": <str>}``. Future
+        fields (e.g. ``hookSpecificOutput.additionalContext`` for hooks
+        that support it) can be added without breaking existing callers.
+    """
+    registry = _registry if _registry is not None else _DEDUP_COUNTS
+
+    suffix = ""
+    if dedupe:
+        fp = w.fingerprint()
+        registry[fp] = registry.get(fp, 0) + 1
+        count = registry[fp]
+        if count > 1:
+            suffix = f" (×{count})"
+
+    # User channel: stderr (unconditional).
+    cause_part = f" (cause: {w.likely_cause})" if w.likely_cause else ""
+    stderr_line = f"⚠️ MACF {w.source}: {w.detail}{cause_part}{suffix}"
+    print(stderr_line, file=sys.stderr)
+
+    # Agent channel: systemMessage.
+    parts = [
+        f"⚠️ Warning from {w.source}: {w.kind}{suffix}",
+        f"Details: {w.detail}",
+    ]
+    if w.likely_cause:
+        parts.append(f"Cause: {w.likely_cause}")
+    if w.user_remediation:
+        parts.append(f"Recovery: {w.user_remediation}")
+    if w.full_trace_path:
+        parts.append(f"Full trace: {w.full_trace_path}")
+    agent_msg = "\n".join(parts)
+
+    return {"systemMessage": agent_msg}

--- a/macf/tests/test_observability_warnings.py
+++ b/macf/tests/test_observability_warnings.py
@@ -1,0 +1,212 @@
+"""Unit tests for macf.observability.warnings.
+
+Covers the dual-channel contract (stderr + systemMessage), the dedup
+fingerprint behavior, dataclass construction defaults, and the optional
+field rendering rules.
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from macf.observability import Warning, emit_warning, reset_dedup_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dedup_registry():
+    """Each test gets a clean module-level registry.
+
+    Tests that pass their own ``_registry`` ignore this; tests that
+    exercise the module-level state get isolation for free.
+    """
+    reset_dedup_registry()
+    yield
+    reset_dedup_registry()
+
+
+def _capture_stderr(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    return buf
+
+
+def _make_warning(**overrides) -> Warning:
+    """Build a Warning with sensible defaults; override per test."""
+    defaults = dict(
+        source="telegram",
+        kind="api_unreachable",
+        detail="connection refused on api.telegram.org",
+        likely_cause="network blocked or DNS failure",
+        user_remediation="check connectivity and retry",
+    )
+    defaults.update(overrides)
+    return Warning(**defaults)
+
+
+# --- Dataclass shape ------------------------------------------------------
+
+def test_warning_construction_with_defaults():
+    """Required fields populate; optional fields use documented defaults."""
+    w = Warning(source="config", kind="missing_key", detail="ANTHROPIC_API_KEY not set")
+
+    assert w.source == "config"
+    assert w.kind == "missing_key"
+    assert w.detail == "ANTHROPIC_API_KEY not set"
+    assert w.likely_cause == ""
+    assert w.user_remediation == ""
+    assert w.full_trace_path is None
+    assert w.severity == "warning"
+
+
+def test_warning_is_frozen():
+    """frozen=True: attempting to mutate raises FrozenInstanceError."""
+    w = _make_warning()
+    with pytest.raises(Exception):  # dataclasses.FrozenInstanceError
+        w.source = "different"  # type: ignore[misc]
+
+
+def test_fingerprint_is_source_colon_kind():
+    """Fingerprint format is stable + predictable."""
+    w = Warning(source="redis", kind="connection_timeout", detail="x")
+    assert w.fingerprint() == "redis:connection_timeout"
+
+
+def test_fingerprint_is_stable_across_instances():
+    """Two Warnings with same source+kind produce the same fingerprint."""
+    a = Warning(source="telegram", kind="api_unreachable", detail="reason a")
+    b = Warning(source="telegram", kind="api_unreachable", detail="reason b")
+    assert a.fingerprint() == b.fingerprint()
+
+
+# --- Dual-channel emission ------------------------------------------------
+
+def test_emit_writes_to_stderr(monkeypatch: pytest.MonkeyPatch):
+    """First emission writes a stderr line containing source + detail + cause."""
+    buf = _capture_stderr(monkeypatch)
+    w = _make_warning()
+
+    emit_warning(w)
+
+    output = buf.getvalue()
+    assert "telegram" in output
+    assert "connection refused on api.telegram.org" in output
+    assert "network blocked or DNS failure" in output
+
+
+def test_emit_returns_system_message_in_dict():
+    """Return dict carries the agent-visible systemMessage with all populated fields."""
+    w = _make_warning()
+
+    result = emit_warning(w)
+
+    assert "systemMessage" in result
+    msg = result["systemMessage"]
+    assert "telegram" in msg
+    assert "api_unreachable" in msg
+    assert "connection refused on api.telegram.org" in msg
+    assert "network blocked or DNS failure" in msg
+    assert "check connectivity and retry" in msg
+
+
+def test_emit_omits_empty_optional_fields_from_system_message(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Empty likely_cause / user_remediation produce no corresponding lines."""
+    _capture_stderr(monkeypatch)  # suppress stderr noise
+    w = Warning(source="stop_hook", kind="recovered", detail="restored from snapshot")
+
+    result = emit_warning(w)
+
+    msg = result["systemMessage"]
+    assert "Cause:" not in msg
+    assert "Recovery:" not in msg
+    assert "restored from snapshot" in msg
+
+
+def test_emit_includes_full_trace_path_when_set(monkeypatch: pytest.MonkeyPatch):
+    """full_trace_path appears in systemMessage if provided."""
+    _capture_stderr(monkeypatch)
+    w = _make_warning(full_trace_path="/tmp/macf/proxy_captures/trace.log")
+
+    result = emit_warning(w)
+
+    assert "/tmp/macf/proxy_captures/trace.log" in result["systemMessage"]
+
+
+# --- Deduplication --------------------------------------------------------
+
+def test_dedup_appends_count_suffix_on_repeat(monkeypatch: pytest.MonkeyPatch):
+    """Second emission with same fingerprint adds (×2); third adds (×3)."""
+    buf = _capture_stderr(monkeypatch)
+    w = _make_warning()
+
+    emit_warning(w)
+    emit_warning(w)
+    emit_warning(w)
+
+    lines = buf.getvalue().splitlines()
+    assert len(lines) == 3
+    assert "(×" not in lines[0]
+    assert "(×2)" in lines[1]
+    assert "(×3)" in lines[2]
+
+
+def test_dedup_disabled_suppresses_suffix(monkeypatch: pytest.MonkeyPatch):
+    """dedupe=False: every emission is verbatim, no count suffix."""
+    buf = _capture_stderr(monkeypatch)
+    w = _make_warning()
+
+    emit_warning(w, dedupe=False)
+    emit_warning(w, dedupe=False)
+
+    lines = buf.getvalue().splitlines()
+    assert len(lines) == 2
+    assert "(×" not in lines[0]
+    assert "(×" not in lines[1]
+
+
+def test_dedup_registry_is_per_fingerprint(monkeypatch: pytest.MonkeyPatch):
+    """Two distinct fingerprints don't cross-pollute counts."""
+    buf = _capture_stderr(monkeypatch)
+    w_telegram = _make_warning()
+    w_redis = Warning(source="redis", kind="connection_timeout", detail="timed out")
+
+    emit_warning(w_telegram)
+    emit_warning(w_redis)
+    emit_warning(w_telegram)  # second telegram
+
+    lines = buf.getvalue().splitlines()
+    # First two emissions are first-of-fingerprint, no suffix.
+    assert "(×" not in lines[0]
+    assert "(×" not in lines[1]
+    # Third is the second telegram — gets (×2).
+    assert "(×2)" in lines[2]
+
+
+def test_emit_accepts_injected_registry(monkeypatch: pytest.MonkeyPatch):
+    """Caller-provided registry isolates dedup state from module-level."""
+    _capture_stderr(monkeypatch)
+    w = _make_warning()
+    registry: dict = {}
+
+    emit_warning(w, _registry=registry)
+    emit_warning(w, _registry=registry)
+
+    assert registry[w.fingerprint()] == 2
+
+
+def test_reset_dedup_registry_clears_module_state(monkeypatch: pytest.MonkeyPatch):
+    """reset_dedup_registry() makes the next emission first-of-fingerprint again."""
+    buf = _capture_stderr(monkeypatch)
+    w = _make_warning()
+
+    emit_warning(w)
+    emit_warning(w)  # (×2)
+    reset_dedup_registry()
+    emit_warning(w)  # back to first-of-fingerprint
+
+    lines = buf.getvalue().splitlines()
+    assert "(×2)" in lines[1]
+    assert "(×" not in lines[2]


### PR DESCRIPTION
## Summary

Adds the `macf.observability` namespace, starting with the warnings framework. Replaces ad-hoc `except Exception: print('⚠️ MACF: ...', file=sys.stderr)` patterns scattered through hook handlers and channel modules with a single structured primitive:

- `Warning` dataclass (frozen, hashable) carrying `source`, `kind`, `detail`, `likely_cause`, `user_remediation`, `full_trace_path`, `severity` so consumers can render the same warning appropriately for the terminal, the agent's `systemMessage`, and future remote observers.
- `emit_warning(w)` delivers to **both** channels by default with at-least-once semantics: stderr writes unconditionally as the failure-safe default; the agent contribution is returned for the caller to merge into the hook's return dict via `return {**emit_warning(w), "continue": True, ...}`.
- Per-process deduplication by `source:kind` fingerprint so a chatty inner loop doesn't paper the terminal with identical lines. First occurrence verbatim; subsequent occurrences get `(×N)`. Caller can opt out with `dedupe=False` or inject a custom registry for tests / long-lived processes.

Foundation only — no callers in this PR. The first consumer (Telegram notify) follows in a separate PR.

## Why

`grep -rn 'print(.*⚠️.*sys.stderr' macf/src/macf/hooks/ macf/src/macf/channels/` finds ~64 sites of the hand-rolled dual-channel pattern. Each one is slightly different: some include the exception message, some don't; some build a parallel systemMessage block, most just write to stderr; none deduplicate, so a thrashing inner loop spams the terminal. The framework gives us one audit point, consistent formatting, and an obvious place to add severity filtering and remote routing without touching every hook.

## Test plan

13 focused tests in `test_observability_warnings.py`:

- Dataclass shape: required fields, defaults, `frozen=True` immutability
- Fingerprint stability and format (`source:kind`)
- Stderr emission contains `source`, `detail`, and `cause`
- Return dict carries the full `systemMessage` with all populated fields
- Empty optional fields elide their corresponding lines
- `full_trace_path` appears when set
- Dedup counter appends `(×2)`, `(×3)` on repeat fingerprints
- `dedupe=False` bypasses the counter
- Distinct fingerprints don't cross-pollute counts
- Injected `_registry` isolates dedup state
- `reset_dedup_registry()` re-arms the module-level state

```
pytest macf/tests/test_observability_warnings.py -v
# 13 passed in 0.04s
```

## Diff scope

3 files, +407 / 0.

- `macf/src/macf/observability/__init__.py` (new — namespace + re-exports)
- `macf/src/macf/observability/warnings.py` (new — Warning + emit_warning + dedup)
- `macf/tests/test_observability_warnings.py` (new — 13 tests)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>