### PR TITLE
feat(channels/telegram): structured network warnings via observability framework (closes #93)

### DIFF
--- a/macf/src/macf/channels/telegram.py
+++ b/macf/src/macf/channels/telegram.py
@@ -7,16 +7,64 @@ Config resolution (first match wins):
 Required files in config dir:
 - .env: contains TELEGRAM_BOT_TOKEN=...
 - access.json: contains allowFrom list with chat IDs
+
+Failure model: network-family exceptions during send are caught and
+translated into a structured :class:`~macf.observability.Warning`. The
+helper returns a :class:`NotifyResult` whose ``__bool__`` preserves the
+``True``/``False`` semantics existing callers depend on, while
+``result.warning`` carries the structured diagnostic for hooks that want
+to emit it via :func:`macf.observability.emit_warning`.
 """
 
 import io
 import json
 import os
+import ssl
 import sys
+import urllib.error
 import urllib.request
 import urllib.parse
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Tuple
+
+from ..observability import Warning
+
+
+# Network exception family that maps to recoverable / user-actionable
+# warnings. Anything outside this family is a logic error and is allowed
+# to propagate so the caller's exception handler sees it as a real bug.
+NETWORK_EXCEPTIONS = (
+    urllib.error.URLError,
+    ssl.SSLError,
+    OSError,
+    TimeoutError,
+)
+
+
+@dataclass(frozen=True)
+class NotifyResult:
+    """Return type for :func:`send_telegram_notification`.
+
+    Attributes:
+        success: True if the message was delivered (or no network attempt
+            was made because Telegram is not configured — see note below).
+        warning: Structured :class:`Warning` when a network failure
+            translated cleanly; ``None`` otherwise. Existence of a
+            ``warning`` implies ``success is False``, but ``success is
+            False`` does NOT imply a warning (e.g. Telegram not
+            configured produces ``success=False, warning=None`` for
+            backward compatibility with the previous ``bool`` API).
+
+    Truthiness mirrors ``success`` so existing callers that did
+    ``if send_telegram_notification(...)`` continue to work unchanged.
+    """
+
+    success: bool
+    warning: Optional[Warning] = None
+
+    def __bool__(self) -> bool:  # noqa: D401
+        return self.success
 
 
 def _html_escape(text: str) -> str:
@@ -81,32 +129,117 @@ def resolve_telegram_config() -> Optional[Tuple[str, str]]:
     return None
 
 
+def _classify_network_exception(e: BaseException) -> Tuple[str, str, str]:
+    """Classify a network exception into (kind, likely_cause, user_remediation).
+
+    Falls back to a generic ``"network_error"`` kind when the exception
+    doesn't match a more specific case.
+    """
+    # HTTPError is the most informative — has .code with HTTP status.
+    if isinstance(e, urllib.error.HTTPError):
+        code = e.code
+        if code == 401:
+            return (
+                "auth_failed",
+                "bot token rejected by Telegram API",
+                "verify TELEGRAM_BOT_TOKEN in .env and that the bot is not revoked",
+            )
+        if code == 403:
+            return (
+                "forbidden",
+                "bot was blocked by the chat or kicked from the group",
+                "re-add the bot to the chat or check chat_id in access.json",
+            )
+        if 500 <= code < 600:
+            return (
+                "telegram_api_5xx",
+                f"Telegram API returned HTTP {code}",
+                "transient server-side issue — retry later; check api.telegram.org status",
+            )
+        return (
+            f"http_{code}",
+            f"unexpected HTTP {code} from Telegram API",
+            "inspect the response body for details",
+        )
+
+    if isinstance(e, ssl.SSLError):
+        return (
+            "ssl_handshake_failed",
+            "TLS handshake to api.telegram.org failed",
+            "check system trust store, proxy interception, or network filtering",
+        )
+
+    if isinstance(e, TimeoutError):
+        return (
+            "request_timeout",
+            "request to api.telegram.org timed out",
+            "network is slow or unreachable — retry; check connectivity",
+        )
+
+    if isinstance(e, urllib.error.URLError):
+        # Bare URLError (DNS failure, connection refused, etc.)
+        reason = getattr(e, "reason", e)
+        return (
+            "api_unreachable",
+            f"could not reach api.telegram.org ({reason})",
+            "check internet connectivity and DNS",
+        )
+
+    # Generic OSError fallback (broken pipe, network down, etc.)
+    return (
+        "network_error",
+        type(e).__name__,
+        "transient network issue — retry; check connectivity",
+    )
+
+
+def _build_network_warning(e: BaseException, page: int, total: int) -> Warning:
+    """Translate a caught network exception into a structured Warning."""
+    kind, likely_cause, user_remediation = _classify_network_exception(e)
+    page_tag = f" (page {page}/{total})" if total > 1 else ""
+    return Warning(
+        source="telegram",
+        kind=kind,
+        detail=f"{type(e).__name__}: {e}{page_tag}",
+        likely_cause=likely_cause,
+        user_remediation=user_remediation,
+    )
+
+
 def send_telegram_notification(text: str, prefix: str = "",
                                page_size: int = 4000,
-                               parse_mode: Optional[str] = None) -> bool:
+                               parse_mode: Optional[str] = None) -> NotifyResult:
     """Send a message to the configured Telegram chat, paginating if needed.
 
-    Returns False silently if Telegram is not configured.
-    Logs to stderr on API errors (visible but non-fatal).
-
     Long messages are split into multiple pages. When paginated, the prefix
-    is augmented with (page/total) on each message.
+    is augmented with (page/total) on each message. On the first network
+    failure the function bails — subsequent pages are skipped and the
+    structured warning for the failed page is returned.
 
     Args:
         text: Message body text.
         prefix: Optional prefix line (e.g. emoji + "Agent stopped").
             Placed before body on each page.
-        page_size: Max chars per Telegram message (API limit 4096, default 4000 for safety).
+        page_size: Max chars per Telegram message (API limit 4096, default
+            4000 for safety).
         parse_mode: Optional Telegram parse mode ("HTML" or "MarkdownV2").
             Default None sends plain text. When using HTML, caller must
             escape content with _html_escape().
 
     Returns:
-        True if all pages sent successfully, False if not configured or failed.
+        :class:`NotifyResult`. ``result.success`` mirrors the original
+        ``bool`` semantics (``if send_telegram_notification(...):`` still
+        works via ``__bool__``). ``result.warning`` carries the structured
+        diagnostic when delivery fails on a recognized network exception
+        — callers should merge it into their hook return dict via
+        ``return {**emit_warning(result.warning), ...}``.
     """
     config = resolve_telegram_config()
     if not config:
-        return False
+        # Not-configured is neither success nor a warning — it's an
+        # absence. Preserve the historical "silently False" behavior for
+        # callers that treat Telegram as opt-in.
+        return NotifyResult(success=False)
 
     token, chat_id = config
 
@@ -126,7 +259,6 @@ def send_telegram_notification(text: str, prefix: str = "",
 
     total = len(pages)
     url = f"https://api.telegram.org/bot{token}/sendMessage"
-    success = True
 
     for i, page_body in enumerate(pages, 1):
         if prefix:
@@ -152,12 +284,13 @@ def send_telegram_notification(text: str, prefix: str = "",
 
         try:
             urllib.request.urlopen(url, data, timeout=5)
-        except Exception as e:
-            print(f"MACF: Telegram notification failed (page {i}/{total}): {e}",
-                  file=sys.stderr)
-            success = False
+        except NETWORK_EXCEPTIONS as e:
+            return NotifyResult(
+                success=False,
+                warning=_build_network_warning(e, page=i, total=total),
+            )
 
-    return success
+    return NotifyResult(success=True)
 
 
 def send_telegram_document(content: str, filename: str,

--- a/macf/tests/test_telegram_warning_integration.py
+++ b/macf/tests/test_telegram_warning_integration.py
@@ -1,0 +1,228 @@
+"""Integration tests: macf.channels.telegram + observability.Warning.
+
+Verifies the network-failure path translates into a structured Warning
+that flows cleanly through emit_warning to both channels (stderr +
+systemMessage). Also exercises NotifyResult backward-compat semantics so
+existing ``bool()`` callers keep working.
+"""
+from __future__ import annotations
+
+import io
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+import pytest
+
+from macf.channels.telegram import (
+    NotifyResult,
+    _build_network_warning,
+    _classify_network_exception,
+    send_telegram_notification,
+)
+from macf.observability import Warning, emit_warning, reset_dedup_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_dedup():
+    reset_dedup_registry()
+    yield
+    reset_dedup_registry()
+
+
+def _fake_config(monkeypatch: pytest.MonkeyPatch, configured: bool = True):
+    """Stub ``resolve_telegram_config`` so tests don't depend on a real
+    Telegram setup."""
+    if configured:
+        monkeypatch.setattr(
+            "macf.channels.telegram.resolve_telegram_config",
+            lambda: ("FAKE_TOKEN", "12345"),
+        )
+    else:
+        monkeypatch.setattr(
+            "macf.channels.telegram.resolve_telegram_config",
+            lambda: None,
+        )
+
+
+def _capture_stderr(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    return buf
+
+
+# --- NotifyResult shape ---------------------------------------------------
+
+def test_notifyresult_truthiness_matches_success():
+    """bool(result) follows result.success — preserves the legacy bool API."""
+    assert bool(NotifyResult(success=True)) is True
+    assert bool(NotifyResult(success=False)) is False
+    assert bool(NotifyResult(success=False, warning=Warning(
+        source="telegram", kind="x", detail="y"
+    ))) is False
+
+
+# --- Classification helpers ----------------------------------------------
+
+def test_classify_httperror_401_is_auth_failed():
+    """HTTP 401 maps to a token-rejected diagnostic."""
+    e = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+    kind, cause, remediation = _classify_network_exception(e)
+    assert kind == "auth_failed"
+    assert "token" in cause.lower()
+    assert "TELEGRAM_BOT_TOKEN" in remediation
+
+
+def test_classify_httperror_500_is_telegram_5xx():
+    """HTTP 5xx maps to a Telegram-side outage diagnostic."""
+    e = urllib.error.HTTPError("url", 503, "Service Unavailable", {}, None)
+    kind, _, _ = _classify_network_exception(e)
+    assert kind == "telegram_api_5xx"
+
+
+def test_classify_ssl_error_is_handshake_failed():
+    """ssl.SSLError maps to TLS handshake diagnostic."""
+    kind, cause, _ = _classify_network_exception(ssl.SSLError("handshake failed"))
+    assert kind == "ssl_handshake_failed"
+    assert "TLS" in cause
+
+
+def test_classify_timeout_is_request_timeout():
+    """TimeoutError maps to request_timeout."""
+    kind, _, _ = _classify_network_exception(TimeoutError("slow"))
+    assert kind == "request_timeout"
+
+
+def test_classify_url_error_is_api_unreachable():
+    """Bare URLError (DNS, conn refused, etc.) maps to api_unreachable."""
+    kind, cause, _ = _classify_network_exception(
+        urllib.error.URLError("name resolution failed")
+    )
+    assert kind == "api_unreachable"
+    assert "api.telegram.org" in cause
+
+
+def test_build_warning_includes_page_tag_when_paginated():
+    """Multi-page failure includes 'page N/M' in detail."""
+    w = _build_network_warning(ssl.SSLError("x"), page=2, total=3)
+    assert "page 2/3" in w.detail
+
+
+def test_build_warning_omits_page_tag_when_single_page():
+    """Single-page failure omits the page tag."""
+    w = _build_network_warning(ssl.SSLError("x"), page=1, total=1)
+    assert "page" not in w.detail.lower()
+
+
+# --- End-to-end: send_telegram_notification --------------------------------
+
+def test_send_returns_success_when_urlopen_succeeds(monkeypatch: pytest.MonkeyPatch):
+    """Happy path: urlopen returns, NotifyResult.success is True, no warning."""
+    _fake_config(monkeypatch)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **kw: None
+    )
+
+    result = send_telegram_notification("hello")
+
+    assert result.success is True
+    assert result.warning is None
+    assert bool(result) is True
+
+
+def test_send_returns_warning_on_ssl_error(monkeypatch: pytest.MonkeyPatch):
+    """SSL failure: NotifyResult carries a structured Warning with the right kind."""
+    _fake_config(monkeypatch)
+
+    def _raise(*a, **kw):
+        raise ssl.SSLError("handshake error")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raise)
+
+    result = send_telegram_notification("hello")
+
+    assert result.success is False
+    assert result.warning is not None
+    assert result.warning.source == "telegram"
+    assert result.warning.kind == "ssl_handshake_failed"
+    assert "handshake error" in result.warning.detail
+
+
+def test_send_returns_warning_on_http_401(monkeypatch: pytest.MonkeyPatch):
+    """HTTP 401 from the API: NotifyResult.warning.kind is auth_failed."""
+    _fake_config(monkeypatch)
+
+    def _raise(*a, **kw):
+        raise urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raise)
+
+    result = send_telegram_notification("hello")
+
+    assert result.success is False
+    assert result.warning.kind == "auth_failed"
+
+
+def test_send_returns_falsy_when_telegram_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """No Telegram config: NotifyResult(success=False, warning=None)."""
+    _fake_config(monkeypatch, configured=False)
+
+    result = send_telegram_notification("hello")
+
+    assert result.success is False
+    assert result.warning is None
+    assert bool(result) is False
+
+
+def test_send_bails_on_first_page_failure_with_correct_page_tag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Multi-page send fails on page 1 → warning carries 'page 1/N'."""
+    _fake_config(monkeypatch)
+
+    def _raise(*a, **kw):
+        raise ssl.SSLError("x")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raise)
+
+    # Force pagination: text longer than page_size.
+    result = send_telegram_notification("X" * 9000, page_size=4000)
+
+    assert result.warning is not None
+    assert "page 1/" in result.warning.detail
+
+
+# --- Integration: emit_warning consumes the returned Warning -------------
+
+def test_warning_from_send_flows_through_emit_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End-to-end: send fails → caller passes Warning to emit_warning → both
+    stderr and systemMessage carry the framed diagnostic."""
+    _fake_config(monkeypatch)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **kw: (_ for _ in ()).throw(ssl.SSLError("certificate verify failed")),
+    )
+    stderr_buf = _capture_stderr(monkeypatch)
+
+    result = send_telegram_notification("hello")
+    assert result.warning is not None
+
+    emission = emit_warning(result.warning)
+
+    # Stderr line
+    stderr_output = stderr_buf.getvalue()
+    assert "telegram" in stderr_output
+    assert "certificate verify failed" in stderr_output
+    assert "TLS handshake" in stderr_output
+
+    # systemMessage
+    msg = emission["systemMessage"]
+    assert "ssl_handshake_failed" in msg
+    assert "TLS handshake" in msg
+    assert "trust store" in msg  # remediation


### PR DESCRIPTION
## Summary

Replaces the broad `except Exception` in `send_telegram_notification` with a narrow catch on the network-exception family and translates each failure into a structured `observability.Warning`. The function now returns a `NotifyResult` wrapper instead of a bare `bool`; `NotifyResult.__bool__` mirrors `success` so existing `if send_telegram_notification(...)` callers keep working unchanged. New callers can opt into structured failure handling:

```python
result = send_telegram_notification(text, prefix=prefix)
if result.warning:
    return {**emit_warning(result.warning), "continue": True, ...}
```

## Classification

| Exception | `Warning.kind` | Notes |
|-----------|----------------|-------|
| `HTTPError(401)` | `auth_failed` | bot token rejected |
| `HTTPError(403)` | `forbidden` | bot blocked or kicked |
| `HTTPError(5xx)` | `telegram_api_5xx` | Telegram-side outage |
| Other `HTTPError` | `http_<code>` | generic non-2xx surface |
| `ssl.SSLError` | `ssl_handshake_failed` | TLS handshake |
| `TimeoutError` | `request_timeout` | request timed out |
| `URLError` (bare) | `api_unreachable` | DNS / connection refused |
| Other `OSError` | `network_error` | fallback |

Each Warning carries a plain-language `likely_cause` and `user_remediation` so operators see actionable framing in the terminal AND the agent sees structured context in `systemMessage`.

Multi-page sends bail on first failure with a `page N/M` tag in the detail so the operator knows which page failed.

## Why the broad-except is gone

Per the `no_silent_failures` policy, broad `except Exception` is the silent-failure anti-pattern. The old code logged to stderr, so it wasn't silent — but it also swallowed real bugs (e.g. `TypeError` from a caller passing the wrong shape), masking them as generic Telegram failures. Now non-network exceptions propagate so the caller's outer handler sees them as real bugs.

## Test plan

14 new integration tests in `test_telegram_warning_integration.py`:

- NotifyResult truthiness preserves legacy bool API
- Per-kind classifier mapping (401 / 5xx / SSL / timeout / URLError)
- Page tag included for paginated failures, omitted for single-page
- Happy path: success → success=True, warning=None
- SSL failure path: warning.kind == ssl_handshake_failed
- HTTP 401 path: warning.kind == auth_failed
- Not-configured: success=False, warning=None (backward compat)
- Multi-page bail on first failure with correct page tag
- End-to-end: warning flows through emit_warning to both stderr + systemMessage

Regression sweep on bool() back-compat:

```
pytest macf/tests/test_handle_stop.py \
       macf/tests/test_handle_subagent_stop.py \
       macf/tests/test_observability_warnings.py \
       macf/tests/test_telegram_warning_integration.py \
       macf/tests/test_scope_and_stop.py
# 67 passed
```

Existing hook callers (handle_stop, handle_subagent_stop, etc.) use `if send_telegram_notification(...):` patterns and pass unchanged via `NotifyResult.__bool__`.

## Out of scope

- `send_telegram_document` still has the broad-except + hand-rolled stderr pattern. Gets the same treatment in the upcoming stderr-sites migration so this PR stays focused on the notification path.
- Hook call sites in `handle_*.py` that already call `send_telegram_notification` continue to use the bool semantics. Migrating them to consume `result.warning` is a separate sweep.

## Diff scope

2 files, +375 / -14.

- `macf/src/macf/channels/telegram.py` — NotifyResult dataclass, NETWORK_EXCEPTIONS tuple, `_classify_network_exception` helper, `_build_network_warning` helper, refactored `send_telegram_notification`
- `macf/tests/test_telegram_warning_integration.py` (new — 14 tests)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>