### PR TITLE
feat(observability): format_tool_metadata for concise tool-invocation summaries

### DIFF
--- a/macf/src/macf/observability/__init__.py
+++ b/macf/src/macf/observability/__init__.py
@@ -16,11 +16,10 @@ Current contents:
   with CLI-terminal ↔ Telegram parity for remote observers. Carries
   optional ``originating_agent`` attribution for messages produced
   under a SubAgent's session.
-
-Planned siblings (separate modules within this namespace):
-
-- ``tool_metadata`` — concise per-tool metadata formatters used by
-  PreToolUse hook output (tool name + target/argument summary).
+- ``tool_metadata`` — :func:`format_tool_metadata` produces a concise
+  one-line summary per tool invocation (tool name + key argument
+  like skill name, file path, command prefix) for inclusion in
+  PreToolUse hook output.
 
 Producers expected: hook handlers in ``macf.hooks.*``, channel modules
 in ``macf.channels.*``, and CLI commands in ``macf.cli``.
@@ -28,6 +27,7 @@ in ``macf.channels.*``, and CLI commands in ``macf.cli``.
 from __future__ import annotations
 
 from .messages import HookMessage, emit_message
+from .tool_metadata import format_tool_metadata
 from .warnings import Warning, emit_warning, reset_dedup_registry
 
 __all__ = [
@@ -35,5 +35,6 @@ __all__ = [
     "Warning",
     "emit_message",
     "emit_warning",
+    "format_tool_metadata",
     "reset_dedup_registry",
 ]

--- a/macf/src/macf/observability/tool_metadata.py
+++ b/macf/src/macf/observability/tool_metadata.py
@@ -1,0 +1,175 @@
+"""Tool-invocation metadata formatters.
+
+The PreToolUse hook fires for every tool invocation. Without metadata
+the Telegram-routed observation reduces to "🎯 Skill" or "📄 Read" —
+the *kind* of action but not its *target*. This module formats a
+concise one-line summary per tool type so that remote observers see
+"🎯 Skill: maceff-delegation" or "📄 Read: foo.py" instead of generic
+labels.
+
+Producers expected: PreToolUse hook in
+``macf.hooks.handle_pre_tool_use``. Consumers: any code path that
+constructs a Telegram-routed tool-invocation message.
+
+Design notes:
+- The formatter is data-only — it inspects ``tool_input`` dicts and
+  returns strings. No I/O, no side effects.
+- Each per-tool formatter uses ``.get(...)`` everywhere, never raising
+  on missing fields. Tools evolve and add new input keys; missing
+  fields produce sensible degraded output, not crashes.
+- Unknown tools fall through to ``tool_name`` as the metadata, so the
+  helper is safe to call indiscriminately.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+
+# Maximum characters in the metadata payload before truncation. Picked
+# to keep the full prefix + metadata under ~120 chars so Telegram messages
+# stay scannable.
+_MAX_METADATA_CHARS = 100
+
+
+def _truncate(s: str, limit: int = _MAX_METADATA_CHARS) -> str:
+    """Single-line truncation with ellipsis. Returns ``s`` unchanged if
+    it fits, otherwise ``s[:limit-1] + "…"`` (Unicode single-char
+    ellipsis to avoid the 3-byte cost of ``...``)."""
+    if s is None:
+        return ""
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "…"
+
+
+def _basename(path_str: str) -> str:
+    """Best-effort filename extraction. Falls back to the original
+    string if ``Path`` rejects it (rare but possible with weird inputs)."""
+    if not path_str:
+        return ""
+    try:
+        return Path(path_str).name or path_str
+    except (TypeError, ValueError):
+        return path_str
+
+
+def _domain(url: str) -> str:
+    """Best-effort hostname extraction from a URL."""
+    try:
+        parsed = urlparse(url)
+        return parsed.netloc or url
+    except (TypeError, ValueError):
+        return url
+
+
+# Per-tool formatters. Each takes ``tool_input`` and returns the
+# metadata segment (without the tool name — the dispatcher prepends it).
+# Returning empty string means "no useful detail to add"; the
+# dispatcher emits just the tool name in that case.
+
+def _fmt_skill(tool_input: Dict[str, Any]) -> str:
+    return tool_input.get("skill", "") or ""
+
+
+def _fmt_bash(tool_input: Dict[str, Any]) -> str:
+    cmd = tool_input.get("command", "")
+    return _truncate(cmd, 80)
+
+
+def _fmt_read(tool_input: Dict[str, Any]) -> str:
+    return _basename(tool_input.get("file_path", ""))
+
+
+def _fmt_edit_or_write(tool_input: Dict[str, Any]) -> str:
+    return _basename(tool_input.get("file_path", ""))
+
+
+def _fmt_task(tool_input: Dict[str, Any]) -> str:
+    sa = tool_input.get("subagent_type", "?") or "?"
+    desc = tool_input.get("description", "") or ""
+    if desc:
+        return f"[{sa}] {_truncate(desc, 60)}"
+    return f"[{sa}]"
+
+
+def _fmt_webfetch(tool_input: Dict[str, Any]) -> str:
+    return _domain(tool_input.get("url", "") or "")
+
+
+def _fmt_grep_or_glob(tool_input: Dict[str, Any]) -> str:
+    pattern = tool_input.get("pattern", "") or tool_input.get("query", "")
+    return _truncate(pattern, 60)
+
+
+def _fmt_taskcreate(tool_input: Dict[str, Any]) -> str:
+    return _truncate(tool_input.get("subject", "") or "", 60)
+
+
+def _fmt_taskupdate(tool_input: Dict[str, Any]) -> str:
+    task_id = tool_input.get("taskId", "?")
+    status = tool_input.get("status", "")
+    return f"#{task_id}" + (f" → {status}" if status else "")
+
+
+def _fmt_taskget(tool_input: Dict[str, Any]) -> str:
+    return f"#{tool_input.get('taskId', '?')}"
+
+
+# Dispatch map. Keys are tool names exactly as Claude Code emits them.
+_FORMATTERS = {
+    "Skill": _fmt_skill,
+    "Bash": _fmt_bash,
+    "Read": _fmt_read,
+    "Edit": _fmt_edit_or_write,
+    "Write": _fmt_edit_or_write,
+    "Task": _fmt_task,
+    "WebFetch": _fmt_webfetch,
+    "Grep": _fmt_grep_or_glob,
+    "Glob": _fmt_grep_or_glob,
+    "TaskCreate": _fmt_taskcreate,
+    "TaskUpdate": _fmt_taskupdate,
+    "TaskGet": _fmt_taskget,
+}
+
+
+def format_tool_metadata(tool_name: str, tool_input: Dict[str, Any]) -> str:
+    """Return a concise one-line metadata summary for ``tool_name``.
+
+    The output shape is ``"<tool_name>: <details>"`` when the tool has
+    a per-tool formatter and produces non-empty details, otherwise
+    just ``tool_name``.
+
+    Args:
+        tool_name: Tool identifier as emitted by Claude Code
+            (e.g. ``"Skill"``, ``"Bash"``, ``"Read"``).
+        tool_input: The tool's input dict. May be missing fields the
+            formatter expects — formatters degrade gracefully.
+
+    Returns:
+        Metadata string suitable for a single-line Telegram message
+        segment or terminal display. Bounded length: the formatter
+        truncates long fields (commands, descriptions, patterns) so
+        the result fits comfortably alongside a prefix tag.
+
+    Examples:
+        >>> format_tool_metadata("Skill", {"skill": "maceff-delegation"})
+        'Skill: maceff-delegation'
+        >>> format_tool_metadata("Read", {"file_path": "/abs/path/foo.py"})
+        'Read: foo.py'
+        >>> format_tool_metadata("UnknownTool", {"anything": 1})
+        'UnknownTool'
+    """
+    if not isinstance(tool_input, dict):
+        # Defensive: callers should pass a dict but typecheck just in case.
+        tool_input = {}
+
+    formatter = _FORMATTERS.get(tool_name)
+    if formatter is None:
+        return tool_name
+
+    details = formatter(tool_input).strip()
+    if not details:
+        return tool_name
+    return f"{tool_name}: {details}"

--- a/macf/tests/test_observability_tool_metadata.py
+++ b/macf/tests/test_observability_tool_metadata.py
@@ -1,0 +1,167 @@
+"""Unit tests for macf.observability.tool_metadata.
+
+Covers each per-tool formatter (Skill, Bash, Read, Edit, Write, Task,
+WebFetch, Grep, Glob, TaskCreate, TaskUpdate, TaskGet) plus the
+default-fallback behavior for unknown tools and the graceful-
+degradation case when expected fields are absent.
+"""
+from __future__ import annotations
+
+from macf.observability import format_tool_metadata
+
+
+# --- Skill ---------------------------------------------------------------
+
+def test_skill_includes_skill_name():
+    assert format_tool_metadata("Skill", {"skill": "maceff-delegation"}) == \
+        "Skill: maceff-delegation"
+
+
+def test_skill_missing_skill_falls_back_to_bare_name():
+    assert format_tool_metadata("Skill", {}) == "Skill"
+
+
+# --- Bash ----------------------------------------------------------------
+
+def test_bash_shows_command_prefix():
+    assert format_tool_metadata("Bash", {"command": "pytest tests/"}) == \
+        "Bash: pytest tests/"
+
+
+def test_bash_truncates_long_commands():
+    long_cmd = "x" * 200
+    out = format_tool_metadata("Bash", {"command": long_cmd})
+    # 80 char body limit + "Bash: " prefix
+    assert out.startswith("Bash: ")
+    assert len(out) <= len("Bash: ") + 80
+
+
+def test_bash_missing_command_falls_back():
+    assert format_tool_metadata("Bash", {}) == "Bash"
+
+
+# --- Read / Edit / Write -------------------------------------------------
+
+def test_read_shows_basename_only():
+    assert format_tool_metadata(
+        "Read", {"file_path": "/abs/path/to/module.py"}
+    ) == "Read: module.py"
+
+
+def test_edit_shows_basename_only():
+    assert format_tool_metadata(
+        "Edit", {"file_path": "/some/file.txt"}
+    ) == "Edit: file.txt"
+
+
+def test_write_shows_basename_only():
+    assert format_tool_metadata(
+        "Write", {"file_path": "/x/y/z.md"}
+    ) == "Write: z.md"
+
+
+def test_read_missing_path_falls_back():
+    assert format_tool_metadata("Read", {}) == "Read"
+
+
+# --- Task (subagent delegation) ------------------------------------------
+
+def test_task_with_subagent_type_and_description():
+    out = format_tool_metadata(
+        "Task",
+        {
+            "subagent_type": "DevOpsEng",
+            "description": "migrate stderr sites to emit_warning",
+        },
+    )
+    assert out.startswith("Task: [DevOpsEng]")
+    assert "migrate stderr sites" in out
+
+
+def test_task_with_only_subagent_type():
+    assert format_tool_metadata(
+        "Task", {"subagent_type": "TestEng"}
+    ) == "Task: [TestEng]"
+
+
+def test_task_missing_subagent_type_uses_placeholder():
+    out = format_tool_metadata("Task", {"description": "do thing"})
+    assert "[?]" in out
+
+
+# --- WebFetch ------------------------------------------------------------
+
+def test_webfetch_shows_domain():
+    assert format_tool_metadata(
+        "WebFetch", {"url": "https://example.com/foo/bar"}
+    ) == "WebFetch: example.com"
+
+
+def test_webfetch_missing_url_falls_back():
+    assert format_tool_metadata("WebFetch", {}) == "WebFetch"
+
+
+# --- Grep / Glob ---------------------------------------------------------
+
+def test_grep_shows_pattern():
+    assert format_tool_metadata(
+        "Grep", {"pattern": "TODO"}
+    ) == "Grep: TODO"
+
+
+def test_glob_shows_pattern():
+    assert format_tool_metadata(
+        "Glob", {"pattern": "**/*.py"}
+    ) == "Glob: **/*.py"
+
+
+# --- Task* (CLI surfaces) ------------------------------------------------
+
+def test_taskcreate_shows_subject():
+    assert format_tool_metadata(
+        "TaskCreate", {"subject": "fix bug"}
+    ) == "TaskCreate: fix bug"
+
+
+def test_taskupdate_shows_id_and_status():
+    assert format_tool_metadata(
+        "TaskUpdate", {"taskId": 42, "status": "in_progress"}
+    ) == "TaskUpdate: #42 → in_progress"
+
+
+def test_taskupdate_without_status_shows_id_only():
+    assert format_tool_metadata(
+        "TaskUpdate", {"taskId": 42}
+    ) == "TaskUpdate: #42"
+
+
+def test_taskget_shows_id():
+    assert format_tool_metadata(
+        "TaskGet", {"taskId": 99}
+    ) == "TaskGet: #99"
+
+
+# --- Default fallback ----------------------------------------------------
+
+def test_unknown_tool_returns_bare_name():
+    assert format_tool_metadata(
+        "UnknownTool", {"anything": "ignored"}
+    ) == "UnknownTool"
+
+
+def test_non_dict_tool_input_does_not_crash():
+    """Defensive: even if tool_input arrives as a non-dict, formatter
+    returns sensible output without raising."""
+    # None
+    assert format_tool_metadata("Bash", None) == "Bash"  # type: ignore[arg-type]
+    # String
+    assert format_tool_metadata("Read", "not a dict") == "Read"  # type: ignore[arg-type]
+
+
+# --- Edge cases ----------------------------------------------------------
+
+def test_empty_strings_treated_as_missing():
+    """Empty string in a field should fall through to the bare tool
+    name, not produce an empty trailing colon."""
+    assert format_tool_metadata("Skill", {"skill": ""}) == "Skill"
+    assert format_tool_metadata("Bash", {"command": ""}) == "Bash"


### PR DESCRIPTION
## Summary

Adds `format_tool_metadata(tool_name, tool_input)` — a single-line per-tool formatter that produces concise metadata summaries for tool invocations. The current `PreToolUse` hook output shows generic labels like `🎯 Skill` or `📄 Read`; with this formatter it can show `Skill: maceff-delegation` or `Read: module.py` so remote observers see *what* is happening, not just *that* something is.

## Per-tool coverage

| Tool | Format | Example |
|------|--------|---------|
| Skill | skill name | `Skill: maceff-delegation` |
| Bash | command (truncated 80) | `Bash: pytest tests/...` |
| Read / Edit / Write | file basename | `Read: module.py` |
| Task | `[<sa>] <description>` | `Task: [DevOpsEng] migrate stderr sites` |
| WebFetch | URL domain | `WebFetch: example.com` |
| Grep / Glob | pattern | `Grep: TODO` |
| TaskCreate | subject (truncated) | `TaskCreate: fix bug` |
| TaskUpdate | `#<id> → <status>` | `TaskUpdate: #42 → in_progress` |
| TaskGet | `#<id>` | `TaskGet: #99` |
| Default | bare tool name | `UnknownTool` |

## Defensive design

- Every formatter uses `.get(...)` and tolerates missing keys.
- Empty strings in expected fields are treated as missing (no trailing colon in output).
- Non-dict `tool_input` falls through cleanly to the bare tool name.
- Long fields truncated with a Unicode ellipsis to keep results scannable.

## Foundation only

This PR adds the formatter + tests. The PreToolUse hook has scattered per-tool special-cases (lines ~158-300 in `handle_pre_tool_use.py`) that could be consolidated through this formatter — that wire-in is a follow-up.

## Test plan

23 tests in `test_observability_tool_metadata.py` covering each formatter's happy path + missing-field fallback, unknown-tool default, non-dict input defense, and empty-string-as-missing edge case.

```
pytest macf/tests/test_observability_tool_metadata.py -v
# 23 passed in 0.05s
```

## Diff scope

3 files, +348 / -5.

- `macf/src/macf/observability/__init__.py` — re-export `format_tool_metadata`
- `macf/src/macf/observability/tool_metadata.py` (new — 169 lines)
- `macf/tests/test_observability_tool_metadata.py` (new — 184 lines)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>