### PR TITLE
feat(deleg_drv): correlation_id + subagent_type propagation + Started telegram emission

### DIFF
--- a/macf/src/macf/event_queries.py
+++ b/macf/src/macf/event_queries.py
@@ -436,8 +436,15 @@ def get_active_dev_drv_start(session_id: str) -> tuple[float, str]:
     return (0.0, "")
 
 
-def get_active_deleg_drv_start(session_id: str) -> float:
-    """Get start time of active (unended) deleg_drv from events."""
+def get_active_deleg_drv_start(session_id: str) -> tuple[float, str]:
+    """Get start time + correlation_id of active (unended) deleg_drv from events.
+
+    Returns:
+        Tuple of (started_at, correlation_id). ``(0.0, "")`` when no
+        active drive exists (most recent event is an ended marker or
+        no drive events found). ``correlation_id`` may be empty if the
+        Start event didn't carry one (legacy callers).
+    """
     from .agent_events_log import read_events
     session_prefix = session_id[:8] if session_id else ""
 
@@ -449,10 +456,10 @@ def get_active_deleg_drv_start(session_id: str) -> float:
         if session_prefix and event_session and not event_session.startswith(session_prefix):
             continue
         if event_type == "deleg_drv_ended":
-            return 0.0  # Most recent is ended - no active drive
+            return (0.0, "")  # Most recent is ended - no active drive
         if event_type == "deleg_drv_started":
-            return data.get("timestamp", 0.0)
-    return 0.0
+            return (data.get("timestamp", 0.0), data.get("correlation_id", ""))
+    return (0.0, "")
 
 
 def get_current_session_id_from_events() -> str:

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -264,7 +264,36 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             subagent_type = tool_input.get("subagent_type", "unknown")
             description = tool_input.get("description", "")
             prompt = tool_input.get("prompt", "")
-            start_deleg_drv(session_id)
+            # Correlation ID: 6 chars from the CC tool_use_id, after the
+            # constant "toolu_" prefix. Lets a remote observer pair this
+            # Started event with its later Ended event in the Telegram
+            # stream. Empty if hook input doesn't carry tool_use_id —
+            # the drives layer treats empty as "no correlation".
+            tool_use_id = data.get("tool_use_id", "")
+            correlation_id = tool_use_id[6:12] if len(tool_use_id) >= 12 else ""
+            start_deleg_drv(
+                session_id,
+                subagent_type=subagent_type,
+                correlation_id=correlation_id,
+            )
+
+            # Notify Telegram of the delegation start so remote observers
+            # see the boundary in real time (the matching Complete fires
+            # from handle_subagent_stop when the SA returns).
+            try:
+                from macf.channels.telegram import send_telegram_notification
+                tag = f"[{subagent_type}@{correlation_id}]" if correlation_id else f"[{subagent_type}]"
+                desc_short = description[:60] + ("…" if len(description) > 60 else "")
+                send_telegram_notification(
+                    f"{tag}\n{desc_short}",
+                    prefix="\U0001f680 DELEG_DRV Started",
+                )
+            except (ImportError, OSError, ConnectionError) as _tg_e:
+                emit_warning(Warning(
+                    source="pre_tool_use",
+                    kind="deleg_drv_telegram_failed",
+                    detail=f"DELEG_DRV Started telegram notification failed (non-blocking): {_tg_e}",
+                ))
 
             # Truncate long fields for event log (similar to tool output handling)
             MAX_DESC_LEN = 100

--- a/macf/src/macf/hooks/handle_subagent_stop.py
+++ b/macf/src/macf/hooks/handle_subagent_stop.py
@@ -60,8 +60,12 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Get stats BEFORE completing (complete_deleg_drv clears current tracking!)
         stats = get_deleg_drv_stats(session_id)
 
-        # Complete Delegation Drive
-        success, duration = complete_deleg_drv(session_id)
+        # Complete Delegation Drive. correlation_id is propagated from the
+        # matching Started event so the Complete message can reference the
+        # same opaque pair-key the user already saw on the Started side.
+        success, duration, correlation_id = complete_deleg_drv(
+            session_id, subagent_type=subagent_type,
+        )
 
         # Append delegation_completed event
         append_event(
@@ -101,8 +105,15 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         token_section = format_token_context_full(token_info)
         boundary_guidance = get_boundary_guidance(token_info['cl_level'], auto_mode)
 
-        # Format message with full timestamp and DELEG_DRV summary
-        message = f"""🏗️ MACF | DELEG_DRV Complete
+        # Format message with full timestamp and DELEG_DRV summary.
+        # `Total Delegations` was dropped — the aggregate count across a
+        # session doesn't carry actionable signal. Per-call duration plus
+        # session-aggregate duration remain.
+        tag_line = (
+            f"[{subagent_type}@{correlation_id}]"
+            if correlation_id else f"[{subagent_type}]"
+        )
+        message = f"""🏗️ MACF | DELEG_DRV Complete {tag_line}
 Current Time: {temporal_ctx['timestamp_formatted']}
 Day: {temporal_ctx['day_of_week']}
 Time of Day: {temporal_ctx['time_of_day']}
@@ -110,7 +121,6 @@ Breadcrumb: {breadcrumb}
 
 Delegation Drive Stats:
 - This Delegation: {duration_str}
-- Total Delegations: {stats['count']}
 - Total Duration: {total_duration_str}
 
 {token_section}
@@ -119,12 +129,18 @@ Delegation Drive Stats:
 
 {format_macf_footer()}"""
 
-        # Notify Telegram (non-blocking)
+        # Notify Telegram (non-blocking). Tag matches the format used by
+        # the matching Started message in handle_pre_tool_use so observers
+        # can visually pair the boundary in the channel.
         try:
             from macf.channels.telegram import send_telegram_notification
+            tag = (
+                f"[{subagent_type}@{correlation_id}]"
+                if correlation_id else f"[{subagent_type}]"
+            )
             send_telegram_notification(
-                f"Agent: {subagent_type}\nDuration: {duration_str}\nTotal delegations: {stats['count']}\nCL: {token_info.get('cl_level', 'N/A')}",
-                prefix="\U0001f4dc DELEG_DRV Complete"
+                f"{tag}\nDuration: {duration_str}\nCL: {token_info.get('cl_level', 'N/A')}",
+                prefix="\U0001f4dc DELEG_DRV Complete",
             )
         except (ImportError, OSError, ConnectionError) as e:
             emit_warning(Warning(source="subagent_stop", kind="deleg_drv_telegram_failed", detail=f"DELEG_DRV telegram notification failed (non-blocking): {e}"))

--- a/macf/src/macf/utils/drives.py
+++ b/macf/src/macf/utils/drives.py
@@ -122,7 +122,12 @@ def get_dev_drv_stats(session_id: str, agent_id: Optional[str] = None) -> dict:
             "from_snapshot": False
         }
 
-def start_deleg_drv(session_id: str, agent_id: Optional[str] = None, subagent_type: Optional[str] = None) -> bool:
+def start_deleg_drv(
+    session_id: str,
+    agent_id: Optional[str] = None,
+    subagent_type: Optional[str] = None,
+    correlation_id: str = "",
+) -> bool:
     """
     Mark Delegation Drive start.
 
@@ -133,6 +138,11 @@ def start_deleg_drv(session_id: str, agent_id: Optional[str] = None, subagent_ty
         session_id: Session identifier
         agent_id: Agent identifier (unused, kept for API compatibility)
         subagent_type: Type of subagent being delegated to (for event tracking)
+        correlation_id: Short opaque identifier (typically 6 chars from
+            the Task tool's tool_use_id) that allows a remote observer
+            to pair this Started event with its later Ended event.
+            Empty string disables correlation (legacy single-flight
+            matching by "most recent active start" still works).
 
     Returns:
         True if successful, False otherwise
@@ -143,35 +153,48 @@ def start_deleg_drv(session_id: str, agent_id: Optional[str] = None, subagent_ty
     _emit_event("deleg_drv_started", {
         "session_id": session_id,
         "subagent_type": subagent_type or "unknown",
-        "timestamp": started_at
+        "timestamp": started_at,
+        "correlation_id": correlation_id,
     })
 
     return True
 
-def complete_deleg_drv(session_id: str, agent_id: Optional[str] = None, subagent_type: Optional[str] = None) -> tuple[bool, float]:
+def complete_deleg_drv(
+    session_id: str,
+    agent_id: Optional[str] = None,
+    subagent_type: Optional[str] = None,
+) -> tuple[bool, float, str]:
     """
     Mark Delegation Drive completion and update stats.
 
+    Looks up the active drive's correlation_id from the most recent
+    deleg_drv_started event and propagates it into the emitted
+    deleg_drv_ended event so consumers (terminal, Telegram, forensic
+    queries) can pair the Started/Ended boundary.
+
     Returns:
-        Tuple of (success: bool, duration_seconds: float)
+        Tuple of (success: bool, duration_seconds: float,
+        correlation_id: str). ``correlation_id`` may be empty if the
+        original Start event didn't carry one (legacy callers).
     """
-    # EVENT-FIRST: Query events for active drive start time
+    # EVENT-FIRST: Query events for active drive start time + correlation_id
     from ..event_queries import get_active_deleg_drv_start
-    started_at = get_active_deleg_drv_start(session_id)
+    started_at, correlation_id = get_active_deleg_drv_start(session_id)
 
     if started_at == 0.0:
-        return (False, 0.0)  # No active drive
+        return (False, 0.0, "")  # No active drive
 
     duration = time.time() - started_at
 
-    # Emit deleg_drv_ended event
+    # Emit deleg_drv_ended event with the SAME correlation_id as the start
     _emit_event("deleg_drv_ended", {
         "session_id": session_id,
         "subagent_type": subagent_type or "unknown",
-        "duration": duration
+        "duration": duration,
+        "correlation_id": correlation_id,
     })
 
-    return (True, duration)
+    return (True, duration, correlation_id)
 
 def get_deleg_drv_stats(session_id: str, agent_id: Optional[str] = None) -> dict:
     """

--- a/macf/tests/test_deleg_drv_correlation.py
+++ b/macf/tests/test_deleg_drv_correlation.py
@@ -1,0 +1,108 @@
+"""Tests for DELEG_DRV Start/Complete correlation + subagent_type propagation.
+
+Verifies that:
+- start_deleg_drv emits the correlation_id and subagent_type in the
+  deleg_drv_started event.
+- complete_deleg_drv reads the correlation_id from the active start
+  event and emits it (matching) in the deleg_drv_ended event, returning
+  it as the third tuple element.
+- get_active_deleg_drv_start returns the (started_at, correlation_id)
+  tuple.
+- Subagent_type isn't lost between caller and event (the bug user
+  surfaced: it was being fetched in hooks but never passed to the
+  drives layer).
+"""
+from __future__ import annotations
+
+import time
+
+from macf.utils.drives import start_deleg_drv, complete_deleg_drv
+from macf.event_queries import get_active_deleg_drv_start
+from macf.agent_events_log import read_events
+
+
+SESSION = "test-correlation-roundtrip"
+
+
+def _events_of_type(event_name: str):
+    """Yield events from the isolated log matching ``event_name`` for our session."""
+    for ev in read_events(reverse=False):
+        if ev.get("event") == event_name and ev.get("data", {}).get("session_id") == SESSION:
+            yield ev
+
+
+def test_start_emits_correlation_id():
+    """correlation_id passed to start_deleg_drv appears in the started event."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="abc123")
+
+    events = list(_events_of_type("deleg_drv_started"))
+    assert len(events) == 1
+    data = events[0]["data"]
+    assert data["correlation_id"] == "abc123"
+    assert data["subagent_type"] == "DevOpsEng"
+
+
+def test_active_start_query_returns_started_at_and_correlation_id():
+    """get_active_deleg_drv_start returns (started_at, correlation_id) tuple."""
+    start_deleg_drv(SESSION, subagent_type="TestEng", correlation_id="xyz789")
+
+    started_at, correlation_id = get_active_deleg_drv_start(SESSION)
+    assert started_at > 0.0
+    assert correlation_id == "xyz789"
+
+
+def test_complete_propagates_correlation_id_into_ended_event():
+    """The correlation_id from the active start flows through to the ended event."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="def456")
+    time.sleep(0.01)  # ensure measurable duration
+
+    success, duration, correlation_id = complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
+
+    assert success is True
+    assert duration > 0.0
+    assert correlation_id == "def456"
+
+    # ended event also carries it
+    ended_events = list(_events_of_type("deleg_drv_ended"))
+    assert ended_events[-1]["data"]["correlation_id"] == "def456"
+
+
+def test_complete_returns_empty_correlation_when_start_had_none():
+    """Legacy start (no correlation_id) still works; complete returns ''."""
+    start_deleg_drv(SESSION, subagent_type="TestEng")  # no correlation_id arg
+    time.sleep(0.01)
+
+    success, _duration, correlation_id = complete_deleg_drv(SESSION)
+
+    assert success is True
+    assert correlation_id == ""
+
+
+def test_complete_returns_false_when_no_active_drive():
+    """No active start → complete returns (False, 0.0, '')."""
+    success, duration, correlation_id = complete_deleg_drv(SESSION)
+
+    assert success is False
+    assert duration == 0.0
+    assert correlation_id == ""
+
+
+def test_subagent_type_propagates_through_started_event():
+    """The subagent_type the caller passes appears in the started event,
+    not the legacy 'unknown' default."""
+    start_deleg_drv(SESSION, subagent_type="ClaudeReviewer")
+
+    data = next(_events_of_type("deleg_drv_started"))["data"]
+    assert data["subagent_type"] == "ClaudeReviewer"
+
+
+def test_subagent_type_propagates_through_ended_event():
+    """The subagent_type the caller passes to complete_deleg_drv appears
+    in the ended event (the bug user surfaced was that this was being
+    fetched in hooks but never propagated to the drives layer)."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="ghi")
+    time.sleep(0.01)
+    complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
+
+    data = list(_events_of_type("deleg_drv_ended"))[-1]["data"]
+    assert data["subagent_type"] == "DevOpsEng"

--- a/macf/tests/test_handle_subagent_stop.py
+++ b/macf/tests/test_handle_subagent_stop.py
@@ -12,7 +12,7 @@ def mock_dependencies():
          patch('macf.hooks.handle_subagent_stop.get_temporal_context') as mock_temporal:
 
         mock_session.return_value = "test-session-123"
-        mock_complete.return_value = (True, 65)  # (success, duration) tuple
+        mock_complete.return_value = (True, 65, "abc123")  # (success, duration, correlation_id)
         mock_stats.return_value = {
             'count': 3,
             'total_duration': 180
@@ -35,7 +35,7 @@ def test_deleg_drv_completion_tracking(mock_dependencies):
     """Test DELEG_DRV completion tracking in production mode."""
     from macf.hooks.handle_subagent_stop import run
 
-    mock_dependencies['complete'].return_value = (True, 65)
+    mock_dependencies['complete'].return_value = (True, 65, "abc123")
 
     result = run("")
 
@@ -58,11 +58,15 @@ def test_delegation_stats_display(mock_dependencies):
     assert "systemMessage" in result
     message = result["systemMessage"]
 
-    # Verify count
-    assert "Total Delegations: 3" in message or "3" in message
+    # "Total Delegations: N" line was dropped (meaningless aggregate);
+    # the per-call duration tag carries the meaningful signal.
+    assert "Total Delegations:" not in message
 
     # Verify duration (180s = 3m)
     assert "3m" in message
+
+    # Correlation tag should appear if mock provided one
+    assert "abc123" in message
 
 
 def test_temporal_context_included(mock_dependencies):
@@ -81,7 +85,7 @@ def test_duration_formatting(mock_dependencies):
     """Test duration is formatted correctly."""
     from macf.hooks.handle_subagent_stop import run
 
-    mock_dependencies['complete'].return_value = (True, 65)
+    mock_dependencies['complete'].return_value = (True, 65, "abc123")
     mock_dependencies['stats'].return_value = {
         'count': 1,
         'total_duration': 65


### PR DESCRIPTION
## Summary

Two related DELEG_DRV instrumentation gaps closed:

**1. `subagent_type` was being fetched but never propagated.** Both `PreToolUse` (line 264) and `SubagentStop` (line 53) read `subagent_type` from their respective hook inputs, but neither passed it to `start_deleg_drv()` / `complete_deleg_drv()`. Every event ended up with `subagent_type=\"unknown\"` (the drives-layer default), which is why the Telegram `DELEG_DRV Complete` message has been showing \"Agent: unknown\" for every delegation in practice. **Existing bug surfaced during this PR's review** — folded into the scope since it's thematically related.

**2. The DELEG_DRV stream was Complete-only.** Remote observers saw delegations end but never begin. With concurrent or overlapping subagents the stream became ambiguous: which Complete corresponded to which work?

## What changed

### `macf/utils/drives.py`

- `start_deleg_drv()` gains a `correlation_id: str = \"\"` parameter and emits it in the `deleg_drv_started` event.
- `complete_deleg_drv()` reads the correlation_id from the active start event, propagates it into the `deleg_drv_ended` event, and returns it as the third element: `(success, duration, correlation_id)`.

### `macf/event_queries.py`

- `get_active_deleg_drv_start()` now returns `tuple[float, str]` — `(started_at, correlation_id)` instead of just the start timestamp. The single caller (`complete_deleg_drv`) is updated.

### `macf/hooks/handle_pre_tool_use.py`

- When the Task tool fires, derive `correlation_id = tool_use_id[6:12]` (6 chars after the constant `toolu_` prefix) so each delegation has a stable opaque pair-key.
- Pass `subagent_type=subagent_type, correlation_id=correlation_id` to `start_deleg_drv()`.
- Emit a `🚀 DELEG_DRV Started` Telegram message with `[<subagent_type>@<correlation_id>]` tag and truncated description so remote observers see the boundary in real time.

### `macf/hooks/handle_subagent_stop.py`

- Pass `subagent_type=subagent_type` to `complete_deleg_drv()`.
- Use the third-element `correlation_id` from the return tuple.
- `📜 DELEG_DRV Complete` Telegram message now includes the matching `[<subagent_type>@<correlation_id>]` tag so observers can visually pair Start/Complete in the channel.
- `\"Total delegations: N\"` line removed from both the Telegram body and the user-visible `systemMessage`. The session-aggregate count carried no actionable signal. Per-call duration plus session-aggregate duration remain.

## Test plan

**New `test_deleg_drv_correlation.py`** (7 tests):

- `correlation_id` emitted in started event
- `get_active_deleg_drv_start` returns the tuple
- complete propagates correlation_id into ended event
- legacy start without correlation_id → complete returns empty
- no active drive → `(False, 0.0, '')`
- subagent_type propagates through started event
- subagent_type propagates through ended event

**Updated `test_handle_subagent_stop.py`**: mock return updated to 3-tuple shape; assertion that \"Total Delegations:\" line is GONE and that the correlation_id appears in the message.

**Regression sweep (187/187 green)**:

```
pytest macf/tests/test_deleg_drv_correlation.py \
       macf/tests/test_handle_subagent_stop.py \
       macf/tests/test_handle_stop.py \
       macf/tests/test_event_queries.py \
       macf/tests/test_event_first_reads.py \
       macf/tests/test_recoverable_errors.py \
       macf/tests/test_observability_warnings.py \
       macf/tests/test_observability_messages.py \
       macf/tests/test_observability_tool_metadata.py \
       macf/tests/test_telegram_warning_integration.py \
       macf/tests/test_scope_and_stop.py \
       macf/tests/test_streaming.py
# 187 passed
```

## Diff scope

6 files, +216 / -29.

- `macf/src/macf/utils/drives.py` — correlation_id parameter + 3-tuple return
- `macf/src/macf/event_queries.py` — tuple return shape
- `macf/src/macf/hooks/handle_pre_tool_use.py` — wire correlation_id + subagent_type, emit Started telegram
- `macf/src/macf/hooks/handle_subagent_stop.py` — wire subagent_type, use 3-tuple, update Complete telegram
- `macf/tests/test_handle_subagent_stop.py` — mock return updated, dropped-line asserted
- `macf/tests/test_deleg_drv_correlation.py` (new — 108 lines)

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>