### PR TITLE
fix(deleg_drv): handle Agent tool name + resolve subagent_type from started event

### DIFF
--- a/macf/src/macf/event_queries.py
+++ b/macf/src/macf/event_queries.py
@@ -436,14 +436,16 @@ def get_active_dev_drv_start(session_id: str) -> tuple[float, str]:
     return (0.0, "")
 
 
-def get_active_deleg_drv_start(session_id: str) -> tuple[float, str]:
-    """Get start time + correlation_id of active (unended) deleg_drv from events.
+def get_active_deleg_drv_start(session_id: str) -> tuple[float, str, str]:
+    """Get start time + correlation_id + subagent_type of active (unended)
+    deleg_drv from events.
 
     Returns:
-        Tuple of (started_at, correlation_id). ``(0.0, "")`` when no
-        active drive exists (most recent event is an ended marker or
-        no drive events found). ``correlation_id`` may be empty if the
-        Start event didn't carry one (legacy callers).
+        Tuple of (started_at, correlation_id, subagent_type).
+        ``(0.0, "", "")`` when no active drive exists (most recent event
+        is an ended marker or no drive events found). Either string
+        field may be empty if the Start event didn't carry it (legacy
+        callers).
     """
     from .agent_events_log import read_events
     session_prefix = session_id[:8] if session_id else ""
@@ -456,10 +458,14 @@ def get_active_deleg_drv_start(session_id: str) -> tuple[float, str]:
         if session_prefix and event_session and not event_session.startswith(session_prefix):
             continue
         if event_type == "deleg_drv_ended":
-            return (0.0, "")  # Most recent is ended - no active drive
+            return (0.0, "", "")  # Most recent is ended - no active drive
         if event_type == "deleg_drv_started":
-            return (data.get("timestamp", 0.0), data.get("correlation_id", ""))
-    return (0.0, "")
+            return (
+                data.get("timestamp", 0.0),
+                data.get("correlation_id", ""),
+                data.get("subagent_type", ""),
+            )
+    return (0.0, "", "")
 
 
 def get_current_session_id_from_events() -> str:

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -258,8 +258,11 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                 f"📋 TaskGet #{task_id_str} | 💡 CLI shows MTMD: macf_tools task get #{task_id_str}"
             )
 
-        # Enhanced context based on tool type
-        elif tool_name == "Task":
+        # Enhanced context based on tool type. "Task" is the canonical
+        # CC tool name for subagent delegation in some versions; "Agent"
+        # is the name in current Claude Code. Both shapes the same
+        # tool_input fields (subagent_type, description, prompt).
+        elif tool_name in ("Task", "Agent"):
             # DELEG_DRV start tracking
             subagent_type = tool_input.get("subagent_type", "unknown")
             description = tool_input.get("description", "")

--- a/macf/src/macf/hooks/handle_subagent_stop.py
+++ b/macf/src/macf/hooks/handle_subagent_stop.py
@@ -60,12 +60,18 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Get stats BEFORE completing (complete_deleg_drv clears current tracking!)
         stats = get_deleg_drv_stats(session_id)
 
-        # Complete Delegation Drive. correlation_id is propagated from the
-        # matching Started event so the Complete message can reference the
-        # same opaque pair-key the user already saw on the Started side.
-        success, duration, correlation_id = complete_deleg_drv(
+        # Complete Delegation Drive. correlation_id AND subagent_type are
+        # propagated from the matching Started event so the Complete
+        # message can reference the same opaque pair-key the user already
+        # saw on the Started side AND carry the right subagent identity
+        # (CC's SubagentStop hook input doesn't always include
+        # subagent_type, so the started event is the source of truth).
+        success, duration, correlation_id, resolved_subagent_type = complete_deleg_drv(
             session_id, subagent_type=subagent_type,
         )
+        # Use the resolved value (started-event-derived) for display.
+        # Falls back to the hook_input fetch only if both are empty.
+        subagent_type = resolved_subagent_type or subagent_type
 
         # Append delegation_completed event
         append_event(

--- a/macf/src/macf/utils/drives.py
+++ b/macf/src/macf/utils/drives.py
@@ -163,38 +163,57 @@ def complete_deleg_drv(
     session_id: str,
     agent_id: Optional[str] = None,
     subagent_type: Optional[str] = None,
-) -> tuple[bool, float, str]:
+) -> tuple[bool, float, str, str]:
     """
     Mark Delegation Drive completion and update stats.
 
-    Looks up the active drive's correlation_id from the most recent
-    deleg_drv_started event and propagates it into the emitted
-    deleg_drv_ended event so consumers (terminal, Telegram, forensic
-    queries) can pair the Started/Ended boundary.
+    Looks up the active drive's correlation_id AND subagent_type from
+    the most recent deleg_drv_started event so the Ended event carries
+    matching metadata even when the caller's own subagent_type fetch
+    came up empty (e.g. SubagentStop hook input that doesn't include
+    the subagent_type field).
+
+    Args:
+        session_id: Session identifier.
+        agent_id: Unused, kept for API compatibility.
+        subagent_type: Optional override. When provided AND not empty/
+            "unknown", takes precedence over the started event's value.
+            Otherwise the started event's subagent_type is used.
 
     Returns:
-        Tuple of (success: bool, duration_seconds: float,
-        correlation_id: str). ``correlation_id`` may be empty if the
-        original Start event didn't carry one (legacy callers).
+        Tuple of (success, duration_seconds, correlation_id,
+        resolved_subagent_type). ``correlation_id`` may be empty if
+        the original Start event didn't carry one. ``resolved_subagent_type``
+        is the value emitted into the ended event — callers should use
+        this for downstream display (it's the source of truth).
     """
-    # EVENT-FIRST: Query events for active drive start time + correlation_id
+    # EVENT-FIRST: Query events for active drive start time + metadata
     from ..event_queries import get_active_deleg_drv_start
-    started_at, correlation_id = get_active_deleg_drv_start(session_id)
+    started_at, correlation_id, started_subagent_type = get_active_deleg_drv_start(session_id)
 
     if started_at == 0.0:
-        return (False, 0.0, "")  # No active drive
+        return (False, 0.0, "", "")  # No active drive
 
     duration = time.time() - started_at
 
-    # Emit deleg_drv_ended event with the SAME correlation_id as the start
+    # Resolve subagent_type: caller override (if informative) wins,
+    # otherwise fall back to the started event's value, otherwise "unknown".
+    if subagent_type and subagent_type != "unknown":
+        resolved_subagent_type = subagent_type
+    elif started_subagent_type:
+        resolved_subagent_type = started_subagent_type
+    else:
+        resolved_subagent_type = "unknown"
+
+    # Emit deleg_drv_ended event with the matched correlation_id + subagent_type
     _emit_event("deleg_drv_ended", {
         "session_id": session_id,
-        "subagent_type": subagent_type or "unknown",
+        "subagent_type": resolved_subagent_type,
         "duration": duration,
         "correlation_id": correlation_id,
     })
 
-    return (True, duration, correlation_id)
+    return (True, duration, correlation_id, resolved_subagent_type)
 
 def get_deleg_drv_stats(session_id: str, agent_id: Optional[str] = None) -> dict:
     """

--- a/macf/tests/test_deleg_drv_correlation.py
+++ b/macf/tests/test_deleg_drv_correlation.py
@@ -42,13 +42,14 @@ def test_start_emits_correlation_id():
     assert data["subagent_type"] == "DevOpsEng"
 
 
-def test_active_start_query_returns_started_at_and_correlation_id():
-    """get_active_deleg_drv_start returns (started_at, correlation_id) tuple."""
+def test_active_start_query_returns_started_at_correlation_id_and_subagent_type():
+    """get_active_deleg_drv_start returns (started_at, correlation_id, subagent_type) tuple."""
     start_deleg_drv(SESSION, subagent_type="TestEng", correlation_id="xyz789")
 
-    started_at, correlation_id = get_active_deleg_drv_start(SESSION)
+    started_at, correlation_id, subagent_type = get_active_deleg_drv_start(SESSION)
     assert started_at > 0.0
     assert correlation_id == "xyz789"
+    assert subagent_type == "TestEng"
 
 
 def test_complete_propagates_correlation_id_into_ended_event():
@@ -56,7 +57,7 @@ def test_complete_propagates_correlation_id_into_ended_event():
     start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="def456")
     time.sleep(0.01)  # ensure measurable duration
 
-    success, duration, correlation_id = complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
+    success, duration, correlation_id, _ = complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
 
     assert success is True
     assert duration > 0.0
@@ -72,19 +73,45 @@ def test_complete_returns_empty_correlation_when_start_had_none():
     start_deleg_drv(SESSION, subagent_type="TestEng")  # no correlation_id arg
     time.sleep(0.01)
 
-    success, _duration, correlation_id = complete_deleg_drv(SESSION)
+    success, _duration, correlation_id, _ = complete_deleg_drv(SESSION)
 
     assert success is True
     assert correlation_id == ""
 
 
 def test_complete_returns_false_when_no_active_drive():
-    """No active start → complete returns (False, 0.0, '')."""
-    success, duration, correlation_id = complete_deleg_drv(SESSION)
+    """No active start → complete returns (False, 0.0, '', '')."""
+    success, duration, correlation_id, subagent_type = complete_deleg_drv(SESSION)
 
     assert success is False
     assert duration == 0.0
     assert correlation_id == ""
+    assert subagent_type == ""
+
+
+def test_complete_resolves_subagent_type_from_started_event():
+    """When caller passes no subagent_type, complete returns the value from
+    the started event (covers the SubagentStop case where hook_input
+    doesn't carry subagent_type)."""
+    start_deleg_drv(SESSION, subagent_type="Explore", correlation_id="zzz999")
+    time.sleep(0.01)
+
+    success, _duration, correlation_id, sa_type = complete_deleg_drv(SESSION)
+
+    assert success is True
+    assert correlation_id == "zzz999"
+    assert sa_type == "Explore"
+
+
+def test_complete_resolves_subagent_type_when_caller_passed_unknown():
+    """Caller passing the literal 'unknown' is treated as no info — the
+    started event's subagent_type wins."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="abc")
+    time.sleep(0.01)
+
+    _, _, _, sa_type = complete_deleg_drv(SESSION, subagent_type="unknown")
+
+    assert sa_type == "DevOpsEng"
 
 
 def test_subagent_type_propagates_through_started_event():

--- a/macf/tests/test_handle_subagent_stop.py
+++ b/macf/tests/test_handle_subagent_stop.py
@@ -12,7 +12,7 @@ def mock_dependencies():
          patch('macf.hooks.handle_subagent_stop.get_temporal_context') as mock_temporal:
 
         mock_session.return_value = "test-session-123"
-        mock_complete.return_value = (True, 65, "abc123")  # (success, duration, correlation_id)
+        mock_complete.return_value = (True, 65, "abc123", "Explore")  # (success, duration, correlation_id, subagent_type)
         mock_stats.return_value = {
             'count': 3,
             'total_duration': 180
@@ -35,7 +35,7 @@ def test_deleg_drv_completion_tracking(mock_dependencies):
     """Test DELEG_DRV completion tracking in production mode."""
     from macf.hooks.handle_subagent_stop import run
 
-    mock_dependencies['complete'].return_value = (True, 65, "abc123")
+    mock_dependencies['complete'].return_value = (True, 65, "abc123", "Explore")
 
     result = run("")
 
@@ -85,7 +85,7 @@ def test_duration_formatting(mock_dependencies):
     """Test duration is formatted correctly."""
     from macf.hooks.handle_subagent_stop import run
 
-    mock_dependencies['complete'].return_value = (True, 65, "abc123")
+    mock_dependencies['complete'].return_value = (True, 65, "abc123", "Explore")
     mock_dependencies['stats'].return_value = {
         'count': 1,
         'total_duration': 65


### PR DESCRIPTION
Two demo-round-trip follow-ups to PR #105:

1. The PreToolUse DELEG_DRV branch matched only `tool_name == 'Task'` but current Claude Code uses `tool_name == 'Agent'` — the new Started telegram emission + correlation_id wiring never fired. Fix: `elif tool_name in ('Task', 'Agent')`.

2. SubagentStop's hook input doesn't carry `subagent_type` in current CC, so even with the prior fix the Complete telegram message read `[unknown]`. Fix: complete_deleg_drv now also resolves subagent_type from the active started event (which IS the source of truth — PreToolUse stored it there), and the resolved value is returned as a 4th tuple element. handle_subagent_stop uses that for display.

Net effect: Telegram now actually shows `[Explore@a3f4b9]` on both Started and Complete sides with matching correlation IDs, regardless of CC's hook-input quirks.

47/47 tests green.

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>