### PR TITLE
fix(deleg_drv): purge correlation_id; type-preference + recency + uniform tag format

### DIFF
--- a/macf/src/macf/event_queries.py
+++ b/macf/src/macf/event_queries.py
@@ -437,21 +437,20 @@ def get_active_dev_drv_start(session_id: str) -> tuple[float, str]:
 
 
 def get_active_deleg_drv_start(session_id: str) -> tuple[float, str, str]:
-    """Get start time + correlation_id + subagent_type of active (unended)
+    """Get start time + tool_use_id_short + subagent_type of active (unended)
     deleg_drv from events.
 
     Returns:
-        Tuple of (started_at, correlation_id, subagent_type).
-        ``(0.0, "", "")`` when no active drive exists (most recent event
-        is an ended marker or no drive events found). Either string
-        field may be empty if the Start event didn't carry it (legacy
-        callers).
+        Tuple of (started_at, tool_use_id_short, subagent_type).
+        ``(0.0, "", "")`` when no active drive exists.
     """
     from .agent_events_log import read_events
     session_prefix = session_id[:8] if session_id else ""
 
-    # Read in reverse - find most recent started/ended first
-    for event in read_events(limit=100, reverse=True):
+    # Reverse stream — first started/ended event for this session
+    # wins. Phase 1 streaming readers make this O(events-to-answer),
+    # not O(total-events), so no cap is needed.
+    for event in read_events(reverse=True):
         event_type = event.get("event")
         data = event.get("data", {})
         event_session = data.get("session_id", "")
@@ -462,29 +461,44 @@ def get_active_deleg_drv_start(session_id: str) -> tuple[float, str, str]:
         if event_type == "deleg_drv_started":
             return (
                 data.get("timestamp", 0.0),
-                data.get("correlation_id", ""),
+                data.get("tool_use_id_short", ""),
                 data.get("subagent_type", ""),
             )
     return (0.0, "", "")
 
 
-def get_oldest_unbridged_deleg_drv_started(session_id: str) -> tuple:
-    """Find the oldest deleg_drv_started event without a matching booted event.
+def get_oldest_unbridged_deleg_drv_started(
+    session_id: str,
+    preferred_subagent_type: str = "",
+) -> tuple:
+    """Find the best-match deleg_drv_started event without a matching booted event.
 
-    Parallel-safe bridge primitive: when SubagentStart fires for a new
-    subagent, the FIFO-oldest unbridged started event in this parent
-    session is its match (because CC dispatches Agent tool calls
-    serially within a turn, so the started ordering matches the
-    SubagentStart ordering).
+    Bridge primitive that survives parallel-delegation out-of-order
+    SubagentStart firing:
 
-    Walks forward through events for this session, counting starteds
-    and matching them against subagent_booted events (which carry
-    tool_use_id). The first started whose tool_use_id has no matching
-    booted is the answer.
+    1. Filter starteds to unbridged + within the 120s recency window.
+    2. If ``preferred_subagent_type`` is supplied AND any candidate
+       matches it, return the OLDEST matching one. This handles
+       parallel same-type-pair delegations where SubagentStart fires
+       in an order that differs from PreToolUse:Agent dispatch order.
+    3. Otherwise fall back to the oldest unbridged candidate (FIFO).
+
+    The type-preference step makes the bridge robust to out-of-order
+    SubagentStart firing as long as the parallel SAs have distinct
+    subagent_types — which is the common practical case. Same-type
+    parallel pairs (two Explore SAs at once) still fall back to FIFO,
+    which is the best available signal given CC's hook payload.
+
+    Args:
+        session_id: Parent session UUID.
+        preferred_subagent_type: When non-empty, prefer a started whose
+            ``subagent_type`` matches. Pass this from SubagentStart's
+            ``agent_type`` field to disambiguate parallel different-type
+            delegations.
 
     Returns:
         Tuple of (started_at, tool_use_id, tool_use_id_short, subagent_type).
-        ``(0.0, "", "", "")`` when no unbridged started exists.
+        ``(0.0, "", "", "")`` when no unbridged started exists in window.
     """
     from .agent_events_log import read_events
     session_prefix = session_id[:8] if session_id else ""
@@ -506,20 +520,53 @@ def get_oldest_unbridged_deleg_drv_started(session_id: str) -> tuple:
             if tuid:
                 bridged_tool_use_ids.add(tuid)
 
-    # First started whose tool_use_id isn't already bridged wins
+    # Build the list of bridgeable candidates:
+    # - has tool_use_id (skip pre-schema starteds — not bridgeable)
+    # - not already bridged
+    # - within 120s recency window (CC's PreToolUse:Agent → SubagentStart
+    #   latency is sub-second; anything older is a stale unmatched
+    #   started from a prior demo / failed delegation and would yield
+    #   nonsense duration on the eventual SubagentStop).
+    import time
+    now = time.time()
+    max_age = 120.0
+
+    candidates = []
     for data in started_events:
         tuid = data.get("tool_use_id", "")
-        # Skip explicitly bridged ones. Legacy starteds without tool_use_id
-        # match by the absence of any bridge for empty string — i.e. only
-        # ONE legacy started can be unbridged at a time. Reasonable for
-        # the migration window.
+        if not tuid:
+            continue
         if tuid in bridged_tool_use_ids:
             continue
-        return (
-            data.get("timestamp", 0.0),
-            tuid,
-            data.get("tool_use_id_short", "") or data.get("correlation_id", ""),
-            data.get("subagent_type", ""),
+        ts = data.get("timestamp", 0.0)
+        if ts == 0.0 or (now - ts) > max_age:
+            continue
+        candidates.append(data)
+
+    if not candidates:
+        return (0.0, "", "", "")
+
+    # Type-preference step: if caller supplied a preferred_subagent_type
+    # AND any candidate matches, return the OLDEST matching one. This
+    # survives out-of-order SubagentStart firing for parallel SAs of
+    # distinct types. Same-type parallel pairs still fall back to FIFO.
+    if preferred_subagent_type:
+        for data in candidates:
+            if data.get("subagent_type", "") == preferred_subagent_type:
+                return (
+                    data.get("timestamp", 0.0),
+                    data.get("tool_use_id", ""),
+                    data.get("tool_use_id_short", ""),
+                    data.get("subagent_type", ""),
+                )
+
+    # FIFO fallback: oldest unbridged candidate.
+    data = candidates[0]
+    return (
+        data.get("timestamp", 0.0),
+        data.get("tool_use_id", ""),
+        data.get("tool_use_id_short", ""),
+        data.get("subagent_type", ""),
         )
     return (0.0, "", "", "")
 

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -273,20 +273,19 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             # stream. Empty if hook input doesn't carry tool_use_id —
             # the drives layer treats empty as "no correlation".
             tool_use_id = data.get("tool_use_id", "")
-            correlation_id = tool_use_id[6:12] if len(tool_use_id) >= 12 else ""
+            tool_use_id_short = tool_use_id[6:12] if len(tool_use_id) >= 12 else ""
             start_deleg_drv(
                 session_id,
                 subagent_type=subagent_type,
-                correlation_id=correlation_id,
                 tool_use_id=tool_use_id,
             )
 
             # Notify Telegram of the delegation start so remote observers
-            # see the boundary in real time (the matching Complete fires
-            # from handle_subagent_stop when the SA returns).
+            # see the boundary in real time (the matching Booted +
+            # Complete fire later from SubagentStart + SubagentStop).
             try:
                 from macf.channels.telegram import send_telegram_notification
-                tag = f"[{subagent_type}@{correlation_id}]" if correlation_id else f"[{subagent_type}]"
+                tag = f"[{subagent_type}@{tool_use_id_short}]" if tool_use_id_short else f"[{subagent_type}]"
                 desc_short = description[:60] + ("…" if len(description) > 60 else "")
                 send_telegram_notification(
                     f"{tag}\n{desc_short}",

--- a/macf/src/macf/hooks/handle_subagent_start.py
+++ b/macf/src/macf/hooks/handle_subagent_start.py
@@ -30,8 +30,34 @@ from macf.utils import (
     get_current_session_id,
     bridge_deleg_drv_to_agent,
 )
+from macf.event_queries import get_deleg_drv_bridge_by_agent_id
 from macf.hooks.hook_logging import log_hook_event
 from macf.observability import Warning, emit_warning
+
+
+def _format_deleg_drv_tag(
+    subagent_type: str,
+    tool_use_id_short: str,
+    agent_id_short: str,
+) -> str:
+    """Uniform tag format used across all three DELEG_DRV Telegram messages.
+
+    Order: subagent_type @ tool_use_id_short | agent_id_short. Each
+    segment is omitted when its value is empty so partial-information
+    states (Started before bridge: no agent_id yet) degrade gracefully.
+
+    Examples:
+        format("Explore", "01SoJX", "")            → "[Explore@01SoJX]"
+        format("Explore", "01SoJX", "ad38b33c")    → "[Explore@01SoJX|ad38b33c]"
+        format("Explore", "", "ad38b33c")          → "[Explore|ad38b33c]"
+        format("Explore", "", "")                  → "[Explore]"
+    """
+    parts = [subagent_type or "unknown"]
+    if tool_use_id_short:
+        parts.append(f"@{tool_use_id_short}")
+    if agent_id_short:
+        parts.append(f"|{agent_id_short}")
+    return f"[{''.join(parts)}]"
 
 
 def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
@@ -67,11 +93,16 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Complete (subagent-side).
         try:
             from macf.channels.telegram import send_telegram_notification
-            tag = f"[{agent_type}|{agent_id[:8]}]" if agent_id else f"[{agent_type}]"
+            # Look up the bridge we just emitted to recover the
+            # tool_use_id_short for tag consistency with Started + Complete.
+            bridge_data = get_deleg_drv_bridge_by_agent_id(session_id, agent_id) or {}
+            tool_use_id_short = bridge_data.get("tool_use_id_short", "")
+            agent_short = agent_id[:8] if agent_id else ""
+            tag = _format_deleg_drv_tag(agent_type, tool_use_id_short, agent_short)
             note = "bridged" if bridged else "no matching started (orphan)"
             send_telegram_notification(
                 f"{tag}\n{note}",
-                prefix="\U0001f9ea DELEG_DRV Booted",
+                prefix="\U0001f4dc DELEG_DRV Booted",
             )
         except (ImportError, OSError, ConnectionError) as e:
             emit_warning(Warning(

--- a/macf/src/macf/hooks/handle_subagent_stop.py
+++ b/macf/src/macf/hooks/handle_subagent_stop.py
@@ -77,7 +77,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Falls back to the legacy by-most-recent path if agent_id is empty
         # (extremely old CC, or transient hook-input issue).
         if agent_id:
-            success, duration, tool_use_id, correlation_id, resolved_subagent_type = (
+            success, duration, tool_use_id, tool_use_id_short, resolved_subagent_type = (
                 complete_deleg_drv_by_agent(
                     session_id,
                     agent_id=agent_id,
@@ -87,7 +87,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             )
         else:
             # Legacy fallback (no agent_id in hook input).
-            success, duration, correlation_id, resolved_subagent_type = complete_deleg_drv(
+            success, duration, tool_use_id_short, resolved_subagent_type = complete_deleg_drv(
                 session_id, subagent_type=agent_type_from_hook or "unknown",
             )
             tool_use_id = ""
@@ -140,8 +140,11 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # session doesn't carry actionable signal. Per-call duration plus
         # session-aggregate duration remain.
         tag_line = (
-            f"[{subagent_type}@{correlation_id}]"
-            if correlation_id else f"[{subagent_type}]"
+            f"[{subagent_type}@{tool_use_id_short}|{agent_id[:8]}]"
+            if tool_use_id_short and agent_id else
+            f"[{subagent_type}@{tool_use_id_short}]" if tool_use_id_short else
+            f"[{subagent_type}|{agent_id[:8]}]" if agent_id else
+            f"[{subagent_type}]"
         )
         message = f"""🏗️ MACF | DELEG_DRV Complete {tag_line}
 Current Time: {temporal_ctx['timestamp_formatted']}
@@ -167,9 +170,9 @@ Delegation Drive Stats:
         try:
             from macf.channels.telegram import send_telegram_notification
             tag = (
-                f"[{subagent_type}@{correlation_id}|{agent_id[:8]}]"
-                if correlation_id and agent_id else
-                f"[{subagent_type}@{correlation_id}]" if correlation_id else
+                f"[{subagent_type}@{tool_use_id_short}|{agent_id[:8]}]"
+                if tool_use_id_short and agent_id else
+                f"[{subagent_type}@{tool_use_id_short}]" if tool_use_id_short else
                 f"[{subagent_type}|{agent_id[:8]}]" if agent_id else
                 f"[{subagent_type}]"
             )

--- a/macf/src/macf/utils/drives.py
+++ b/macf/src/macf/utils/drives.py
@@ -140,7 +140,6 @@ def start_deleg_drv(
     session_id: str,
     agent_id: Optional[str] = None,
     subagent_type: Optional[str] = None,
-    correlation_id: str = "",
     tool_use_id: str = "",
 ) -> bool:
     """
@@ -155,30 +154,24 @@ def start_deleg_drv(
         agent_id: Unused, kept for API compatibility.
         subagent_type: Type of subagent being delegated to
             (e.g. ``"Explore"``, ``"DevOpsEng"``).
-        correlation_id: Legacy 6-char display slice. If supplied
-            alongside ``tool_use_id``, the new emission honors the
-            longer ``tool_use_id`` as the primary key.
         tool_use_id: Full Claude Code tool_use_id (``toolu_<24+ chars>``)
             of the Agent tool invocation. Primary cross-surface join
             key — grep this value in the parent's transcript JSONL to
             find the assistant turn that invoked the SA and the user
             turn that received its result. The 6-char display slice is
-            derived automatically. New schema field; preferred input.
+            derived automatically.
 
     Returns:
         True if the event was emitted.
     """
     started_at = time.time()
 
-    short = _tool_use_id_short(tool_use_id) if tool_use_id else correlation_id
-
     _emit_event("deleg_drv_started", {
         "session_id": session_id,
         "subagent_type": subagent_type or "unknown",
         "timestamp": started_at,
-        "correlation_id": short,  # back-compat — kept until callers migrate
         "tool_use_id": tool_use_id,
-        "tool_use_id_short": short,
+        "tool_use_id_short": _tool_use_id_short(tool_use_id),
     })
 
     return True
@@ -214,7 +207,10 @@ def bridge_deleg_drv_to_agent(
     from ..event_queries import get_oldest_unbridged_deleg_drv_started
 
     started_at, tool_use_id, tool_use_id_short, started_subagent_type = (
-        get_oldest_unbridged_deleg_drv_started(session_id)
+        get_oldest_unbridged_deleg_drv_started(
+            session_id,
+            preferred_subagent_type=agent_type or "",
+        )
     )
 
     found_match = started_at > 0.0
@@ -272,7 +268,6 @@ def complete_deleg_drv_by_agent(
             "duration": 0.0,
             "tool_use_id": "",
             "tool_use_id_short": "",
-            "correlation_id": "",  # back-compat
             "agent_transcript_path": agent_transcript_path,
             "last_assistant_message_preview": last_assistant_message[:200],
             "bridged": False,
@@ -294,7 +289,6 @@ def complete_deleg_drv_by_agent(
         "duration": duration,
         "tool_use_id": tool_use_id,
         "tool_use_id_short": tool_use_id_short,
-        "correlation_id": tool_use_id_short,  # back-compat
         "agent_transcript_path": agent_transcript_path,
         "last_assistant_message_preview": last_assistant_message[:200],
         "bridged": True,
@@ -308,13 +302,13 @@ def complete_deleg_drv(
     subagent_type: Optional[str] = None,
 ) -> tuple[bool, float, str, str]:
     """
-    Mark Delegation Drive completion and update stats.
+    Mark Delegation Drive completion and update stats (legacy path).
 
-    Looks up the active drive's correlation_id AND subagent_type from
-    the most recent deleg_drv_started event so the Ended event carries
-    matching metadata even when the caller's own subagent_type fetch
-    came up empty (e.g. SubagentStop hook input that doesn't include
-    the subagent_type field).
+    The preferred path is :func:`complete_deleg_drv_by_agent`, which
+    uses the SubagentStart-emitted bridge event to match SubagentStop
+    to the right started by agent_id. This function uses the
+    "most recent active started" heuristic — adequate for serial
+    delegations but unsafe for parallel/concurrent.
 
     Args:
         session_id: Session identifier.
@@ -324,23 +318,18 @@ def complete_deleg_drv(
             Otherwise the started event's subagent_type is used.
 
     Returns:
-        Tuple of (success, duration_seconds, correlation_id,
-        resolved_subagent_type). ``correlation_id`` may be empty if
-        the original Start event didn't carry one. ``resolved_subagent_type``
-        is the value emitted into the ended event — callers should use
-        this for downstream display (it's the source of truth).
+        Tuple of (success, duration_seconds, tool_use_id_short,
+        resolved_subagent_type). ``tool_use_id_short`` may be empty if
+        the original Start event didn't carry a ``tool_use_id``.
     """
-    # EVENT-FIRST: Query events for active drive start time + metadata
     from ..event_queries import get_active_deleg_drv_start
-    started_at, correlation_id, started_subagent_type = get_active_deleg_drv_start(session_id)
+    started_at, tool_use_id_short, started_subagent_type = get_active_deleg_drv_start(session_id)
 
     if started_at == 0.0:
         return (False, 0.0, "", "")  # No active drive
 
     duration = time.time() - started_at
 
-    # Resolve subagent_type: caller override (if informative) wins,
-    # otherwise fall back to the started event's value, otherwise "unknown".
     if subagent_type and subagent_type != "unknown":
         resolved_subagent_type = subagent_type
     elif started_subagent_type:
@@ -348,15 +337,14 @@ def complete_deleg_drv(
     else:
         resolved_subagent_type = "unknown"
 
-    # Emit deleg_drv_ended event with the matched correlation_id + subagent_type
     _emit_event("deleg_drv_ended", {
         "session_id": session_id,
         "subagent_type": resolved_subagent_type,
         "duration": duration,
-        "correlation_id": correlation_id,
+        "tool_use_id_short": tool_use_id_short,
     })
 
-    return (True, duration, correlation_id, resolved_subagent_type)
+    return (True, duration, tool_use_id_short, resolved_subagent_type)
 
 def get_deleg_drv_stats(session_id: str, agent_id: Optional[str] = None) -> dict:
     """

--- a/macf/tests/test_deleg_drv_correlation.py
+++ b/macf/tests/test_deleg_drv_correlation.py
@@ -1,12 +1,12 @@
 """Tests for DELEG_DRV Start/Complete correlation + subagent_type propagation.
 
 Verifies that:
-- start_deleg_drv emits the correlation_id and subagent_type in the
+- start_deleg_drv emits the tool_use_id_short and subagent_type in the
   deleg_drv_started event.
-- complete_deleg_drv reads the correlation_id from the active start
+- complete_deleg_drv reads the tool_use_id_short from the active start
   event and emits it (matching) in the deleg_drv_ended event, returning
   it as the third tuple element.
-- get_active_deleg_drv_start returns the (started_at, correlation_id)
+- get_active_deleg_drv_start returns the (started_at, tool_use_id_short)
   tuple.
 - Subagent_type isn't lost between caller and event (the bug user
   surfaced: it was being fetched in hooks but never passed to the
@@ -40,61 +40,61 @@ def _events_of_type(event_name: str):
             yield ev
 
 
-def test_start_emits_correlation_id():
-    """correlation_id passed to start_deleg_drv appears in the started event."""
-    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="abc123")
+def test_start_emits_tool_use_id_short():
+    """tool_use_id_short passed to start_deleg_drv appears in the started event."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", tool_use_id="toolu_abc123dummyXXXX")
 
     events = list(_events_of_type("deleg_drv_started"))
     assert len(events) == 1
     data = events[0]["data"]
-    assert data["correlation_id"] == "abc123"
+    assert data["tool_use_id_short"] == "abc123"
     assert data["subagent_type"] == "DevOpsEng"
 
 
-def test_active_start_query_returns_started_at_correlation_id_and_subagent_type():
-    """get_active_deleg_drv_start returns (started_at, correlation_id, subagent_type) tuple."""
-    start_deleg_drv(SESSION, subagent_type="TestEng", correlation_id="xyz789")
+def test_active_start_query_returns_started_at_tool_use_id_short_and_subagent_type():
+    """get_active_deleg_drv_start returns (started_at, tool_use_id_short, subagent_type) tuple."""
+    start_deleg_drv(SESSION, subagent_type="TestEng", tool_use_id="toolu_xyz789dummyXXXX")
 
-    started_at, correlation_id, subagent_type = get_active_deleg_drv_start(SESSION)
+    started_at, tool_use_id_short, subagent_type = get_active_deleg_drv_start(SESSION)
     assert started_at > 0.0
-    assert correlation_id == "xyz789"
+    assert tool_use_id_short == "xyz789"
     assert subagent_type == "TestEng"
 
 
-def test_complete_propagates_correlation_id_into_ended_event():
-    """The correlation_id from the active start flows through to the ended event."""
-    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="def456")
+def test_complete_propagates_tool_use_id_short_into_ended_event():
+    """The tool_use_id_short from the active start flows through to the ended event."""
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", tool_use_id="toolu_def456dummyXXXX")
     time.sleep(0.01)  # ensure measurable duration
 
-    success, duration, correlation_id, _ = complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
+    success, duration, tool_use_id_short, _ = complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
 
     assert success is True
     assert duration > 0.0
-    assert correlation_id == "def456"
+    assert tool_use_id_short == "def456"
 
     # ended event also carries it
     ended_events = list(_events_of_type("deleg_drv_ended"))
-    assert ended_events[-1]["data"]["correlation_id"] == "def456"
+    assert ended_events[-1]["data"]["tool_use_id_short"] == "def456"
 
 
 def test_complete_returns_empty_correlation_when_start_had_none():
-    """Legacy start (no correlation_id) still works; complete returns ''."""
-    start_deleg_drv(SESSION, subagent_type="TestEng")  # no correlation_id arg
+    """Legacy start (no tool_use_id_short) still works; complete returns ''."""
+    start_deleg_drv(SESSION, subagent_type="TestEng")  # no tool_use_id_short arg
     time.sleep(0.01)
 
-    success, _duration, correlation_id, _ = complete_deleg_drv(SESSION)
+    success, _duration, tool_use_id_short, _ = complete_deleg_drv(SESSION)
 
     assert success is True
-    assert correlation_id == ""
+    assert tool_use_id_short == ""
 
 
 def test_complete_returns_false_when_no_active_drive():
     """No active start → complete returns (False, 0.0, '', '')."""
-    success, duration, correlation_id, subagent_type = complete_deleg_drv(SESSION)
+    success, duration, tool_use_id_short, subagent_type = complete_deleg_drv(SESSION)
 
     assert success is False
     assert duration == 0.0
-    assert correlation_id == ""
+    assert tool_use_id_short == ""
     assert subagent_type == ""
 
 
@@ -102,20 +102,20 @@ def test_complete_resolves_subagent_type_from_started_event():
     """When caller passes no subagent_type, complete returns the value from
     the started event (covers the SubagentStop case where hook_input
     doesn't carry subagent_type)."""
-    start_deleg_drv(SESSION, subagent_type="Explore", correlation_id="zzz999")
+    start_deleg_drv(SESSION, subagent_type="Explore", tool_use_id="toolu_zzz999dummyXXXX")
     time.sleep(0.01)
 
-    success, _duration, correlation_id, sa_type = complete_deleg_drv(SESSION)
+    success, _duration, tool_use_id_short, sa_type = complete_deleg_drv(SESSION)
 
     assert success is True
-    assert correlation_id == "zzz999"
+    assert tool_use_id_short == "zzz999"
     assert sa_type == "Explore"
 
 
 def test_complete_resolves_subagent_type_when_caller_passed_unknown():
     """Caller passing the literal 'unknown' is treated as no info — the
     started event's subagent_type wins."""
-    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="abc")
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", tool_use_id="toolu_abc000dummyXXXX")
     time.sleep(0.01)
 
     _, _, _, sa_type = complete_deleg_drv(SESSION, subagent_type="unknown")
@@ -136,7 +136,7 @@ def test_subagent_type_propagates_through_ended_event():
     """The subagent_type the caller passes to complete_deleg_drv appears
     in the ended event (the bug user surfaced was that this was being
     fetched in hooks but never propagated to the drives layer)."""
-    start_deleg_drv(SESSION, subagent_type="DevOpsEng", correlation_id="ghi")
+    start_deleg_drv(SESSION, subagent_type="DevOpsEng", tool_use_id="toolu_ghi000dummyXXXX")
     time.sleep(0.01)
     complete_deleg_drv(SESSION, subagent_type="DevOpsEng")
 

--- a/macf/tests/test_handle_subagent_stop.py
+++ b/macf/tests/test_handle_subagent_stop.py
@@ -12,7 +12,7 @@ def mock_dependencies():
          patch('macf.hooks.handle_subagent_stop.get_temporal_context') as mock_temporal:
 
         mock_session.return_value = "test-session-123"
-        mock_complete.return_value = (True, 65, "abc123", "Explore")  # (success, duration, correlation_id, subagent_type)
+        mock_complete.return_value = (True, 65, "abc123", "Explore")  # (success, duration, tool_use_id_short, subagent_type)
         mock_stats.return_value = {
             'count': 3,
             'total_duration': 180


### PR DESCRIPTION
Follow-up to PR #107 (SubagentStart bridge) after live demo surfaced four issues:

1. **Bridge picked up STALE legacy starteds** from months ago (correlation_id field existed in legacy events with empty tool_use_id; bridge considered them "unbridgeable" but still returned them in some paths). Result: 100-day duration on the eventual ended event.
2. **No type-preference matching** for parallel SAs — FIFO only.
3. **`correlation_id` field was a transitional rename artifact** that should have been just `tool_use_id_short` from the start.
4. **Inconsistent tag format** — Booted message missing the `@<tool_use_id_short>` segment that observers needed to scan-pair with the matching Started.

## Changes

**Schema purge**: removed `correlation_id` from event payloads (`deleg_drv_started`, `deleg_drv_ended`) and from `start_deleg_drv` parameters. Events now carry `tool_use_id` (full) + `tool_use_id_short` only.

**Recency window**: `get_oldest_unbridged_deleg_drv_started` skips starteds older than 120s. CC's PreToolUse:Agent → SubagentStart latency is sub-second; anything older is stale and would yield nonsense durations.

**Type-preference**: `get_oldest_unbridged_deleg_drv_started` gains optional `preferred_subagent_type` parameter. When supplied (from SubagentStart's `agent_type`), prefers a candidate matching that type before falling back to FIFO. Makes the bridge robust to out-of-order SubagentStart firing for parallel SAs of distinct types.

**Dropped limit=100 cap**: in `get_active_deleg_drv_start` — Phase-1-era band-aid that silently returned "no active drive" when the relevant event was older than 100 events back. Phase 1 streaming readers make the cap unnecessary. Other limit=100 sites in event_queries.py tracked as BUG #1112.

**Uniform tag format**: `_format_deleg_drv_tag(subagent_type, tool_use_id_short, agent_id_short)` helper produces `[<subagent_type>@<tool_use_id_short>|<agent_id_short>]` consistently across Started / Booted / Complete. Convention captured in memory `feedback_deleg_drv_tag_format_consistency.md`.

**Booted emoji**: test-tube → scroll for visual consistency with Complete.

## Parallel-safe verification

Live demo dispatched Explore + DevOpsEng within 1s of each other. Each got correctly bridged to its OWN started via type-preference:

| | Explore | DevOpsEng |
|---|---|---|
| tool_use_id_short | 01KpM5 | 01HB6a |
| agent_id | adbc11417d2d9c3d6 | a9d71a01ece5d6b01 |
| Duration | 8.09s | 7.95s |
| bridged | ✓ | ✓ |

## Tests

30/30 green across `test_deleg_drv_correlation`, `test_handle_subagent_stop`, `test_handle_stop`. Test inputs updated from short slices to full tool_use_ids (e.g. `"abc123"` → `"toolu_abc123dummyXXXX"`) so the new `tool_use_id` parameter accepts realistic values and the short-slice assertions still match.

## Diff scope

7 files, +173 / -105.

🔧 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>