### PR TITLE
fix(cli): unblock CLI startup on clean installs + modern Python (config subparser dup + pydantic core dep)

### DIFF
--- a/macf/pyproject.toml
+++ b/macf/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 authors = [{ name = "Craig Versek" }]
 dependencies = [
     "PyYAML>=6.0.0",  # Required for task system YAML parsing
+    "pydantic>=2.0.0",  # Core: task/agent/project model validation, imported at CLI startup
 ]
 
 [project.optional-dependencies]

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1147,40 +1147,6 @@ def cmd_config_init(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_config_show(args: argparse.Namespace) -> int:
-    """Display current configuration."""
-    config = ConsciousnessConfig()
-
-    print(f"Agent ID: {config.agent_id}")
-    print(f"Agent Name: {config.agent_name}")
-    print(f"Agent Root: {config.agent_root}")
-
-    # Determine context
-    if config._is_container():
-        context = "container"
-    elif config._is_host():
-        context = "host"
-    else:
-        context = "fallback"
-    print(f"Detection Context: {context}")
-
-    # Load and display full config if available
-    config_data = config.load_config()
-    if config_data:
-        print("\nFull configuration:")
-        print(json.dumps(config_data, indent=2))
-    else:
-        print("\nNo .macf/config.json found (using defaults)")
-
-    # Show computed paths
-    print(f"\nComputed paths:")
-    print(f"  Checkpoints: {config.get_checkpoints_path()}")
-    print(f"  Reflections: {config.get_reflections_path()}")
-    print(f"  Logs: /tmp/macf_hooks/{config.agent_id}/{{session_id}}/")
-
-    return 0
-
-
 def cmd_claude_config_init(args: argparse.Namespace) -> int:
     """Initialize .claude.json with recommended defaults."""
     try:
@@ -7645,7 +7611,14 @@ def _build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--force", action="store_true", help="overwrite existing config")
     init_parser.set_defaults(func=cmd_config_init)
 
-    config_sub.add_parser("show", help="show current configuration").set_defaults(func=cmd_config_show)
+    config_show = config_sub.add_parser(
+        "show", help="show resolved value + source for every registered setting"
+    )
+    config_show.add_argument(
+        "--json", dest="json_output", action="store_true",
+        help="output as JSON array",
+    )
+    config_show.set_defaults(func=cmd_config_show)
 
     # Claude Code configuration commands
     claude_config_parser = sub.add_parser("claude-config", help="Claude Code settings management")
@@ -7719,20 +7692,6 @@ def _build_parser() -> argparse.ArgumentParser:
                                help="output as JSON")
     context_parser.add_argument("--session", help="specific session ID (default: current)")
     context_parser.set_defaults(func=cmd_context)
-
-    # `macf_tools config show` — enumerate every unified-config setting +
-    # its resolved value + the source label (env / config / default). Closes
-    # cversek/MacEff#96 Phases 2-4 (visible CLI portion).
-    config_parser = sub.add_parser("config", help="unified config layer operations")
-    config_sub = config_parser.add_subparsers(dest="config_cmd")
-    config_show = config_sub.add_parser(
-        "show", help="show resolved value + source for every registered setting"
-    )
-    config_show.add_argument(
-        "--json", dest="json_output", action="store_true",
-        help="output as JSON array",
-    )
-    config_show.set_defaults(func=cmd_config_show)
 
     # Statusline command with subcommands
     statusline_parser = sub.add_parser("statusline", help="statusline operations for Claude Code")

--- a/macf/tests/test_session.py
+++ b/macf/tests/test_session.py
@@ -254,11 +254,14 @@ def mock_multiple_projects(tmp_path):
     }
     recent_file.write_text(json.dumps(recent_data) + "\n")
 
-    # Touch old file first, then recent file to ensure recent has newer mtime
-    import time
-    old_file.touch()
-    time.sleep(0.01)
-    recent_file.touch()
+    # Set explicit, well-separated mtimes so the recent file is unambiguously
+    # newer regardless of CI filesystem mtime granularity. A touch() + sleep(0.01)
+    # gap was flaky on coarse-granularity / loaded runners (files could tie or
+    # invert), making the mtime fallback select nondeterministically.
+    import os
+    now = datetime.now().timestamp()
+    os.utime(old_file, (now - 3600, now - 3600))
+    os.utime(recent_file, (now, now))
 
     yield tmp_path  # Return tmp_path for Path.home() mocking
 


### PR DESCRIPTION
Two startup-blocking packaging bugs, both surfaced by running on modern Python. main CI has been red since 15ee4e2 (2026-06-08) because of the first; the second breaks plain end-user installs.

Closes #120
Closes #121

## 1. Duplicate `config` subparser (#120)

`_build_parser()` registered the `config` subparser twice — once for agent config management (`init` + `show`), once for the unified config layer (`show --json`). On Python 3.11+/3.12 argparse rejects the duplicate (`conflicting subparser: config`), so every `macf_tools` invocation crashed at parser-build time. Older argparse silently let the second registration shadow the first, which masked it in local dev.

Fix: merge into a single `config` parser keeping `init` and `show`, with `show` gaining `--json`; remove the now-dead shadowed `cmd_config_show`. `config` was verified to be the only true top-level duplicate.

## 2. pydantic declared only as a test extra (#121)

pydantic is imported at module load (task + agent/project model validation) but lived only in the `test` extra, so a clean `pip install macf` produced a `macf_tools` that crashed with `ModuleNotFoundError: No module named 'pydantic'`. CI masked it by installing `.[test]`. Fix: move `pydantic>=2.0.0` into core dependencies. lancedb/numpy remain correctly optional (lazy-imported).

## Validation

On Python 3.14 (stricter argparse than CI's 3.12):

- `_build_parser()` builds clean.
- The 20 CLI tests that were red in CI (`test_context_cli`, `test_breadcrumb_cli`, `test_events_cli`) pass.
- A clean no-extras install runs `macf_tools breadcrumb` and `macf_tools config show` with lancedb absent.

## Suggested follow-up (not in this PR)

Add a minimal-install smoke check to CI — install without extras and run `macf_tools --help` — so a runtime dependency mis-declared as optional fails fast.