### PR TITLE
fix(session): deterministic newest-JSONL selection in mtime fallback (#123)

### DIFF
--- a/macf/src/macf/utils/session.py
+++ b/macf/src/macf/utils/session.py
@@ -43,6 +43,11 @@ def _get_session_id_from_mtime() -> str:
     This is the legacy approach, kept as fallback for first run
     before any session_started events exist.
 
+    Selection is order-independent: among the candidate JSONL files it picks
+    the globally newest by mtime, with the filename as a tiebreaker, so the
+    result does not depend on glob / iterdir ordering (which is
+    filesystem-dependent and was a source of flaky behaviour).
+
     Returns:
         Session ID string or "unknown" if not found
     """
@@ -51,30 +56,26 @@ def _get_session_id_from_mtime() -> str:
     if not projects_dir.exists():
         return "unknown"
 
-    # Find project directory using current working directory name
-    project_name = find_project_root().name
-
-    # Try exact match first
-    for project_dir in projects_dir.glob(f"*{project_name}*"):
-        jsonl_files = sorted(
-            project_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True
-        )
-        if jsonl_files:
-            # Extract session ID from filename
-            newest = jsonl_files[0]
-            return newest.stem
-
-    # Fallback: find newest JSONL across all projects
-    all_jsonl = []
-    for project_dir in projects_dir.iterdir():
-        if project_dir.is_dir():
-            all_jsonl.extend(project_dir.glob("*.jsonl"))
-
-    if all_jsonl:
-        newest = max(all_jsonl, key=lambda p: p.stat().st_mtime)
+    def _newest_stem(dirs) -> Optional[str]:
+        candidates = []
+        for project_dir in dirs:
+            if project_dir.is_dir():
+                candidates.extend(project_dir.glob("*.jsonl"))
+        if not candidates:
+            return None
+        # Global newest by mtime; filename tiebreaks equal mtimes so the
+        # result is deterministic regardless of iteration order.
+        newest = max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
         return newest.stem
 
-    return "unknown"
+    # Prefer project directories matching the current project name; if none
+    # of them contain a JSONL, fall back to all projects.
+    project_name = find_project_root().name
+    return (
+        _newest_stem(projects_dir.glob(f"*{project_name}*"))
+        or _newest_stem(projects_dir.iterdir())
+        or "unknown"
+    )
 
 def get_last_user_prompt_uuid(session_id: Optional[str] = None) -> Optional[str]:
     """

--- a/macf/tests/test_session.py
+++ b/macf/tests/test_session.py
@@ -99,7 +99,13 @@ class TestSessionIDExtraction:
         - Use file modification time to determine current session
         - Handle files with different modification times
         """
-        with patch('pathlib.Path.home', return_value=mock_multiple_projects):
+        with patch('pathlib.Path.home', return_value=mock_multiple_projects), \
+             patch('macf.utils.session.find_project_root') as mock_root:
+            # Pin the project name to one that does not match the fixture's
+            # project dirs, so selection is deterministic and hermetic against
+            # the real cwd. The function picks the globally newest by mtime
+            # regardless of glob/iterdir order.
+            mock_root.return_value.name = "macf-test-cwd"
             session_id = get_current_session_id()
 
         assert session_id == "most-recent-session-uuid"


### PR DESCRIPTION
Completes the #123 fix. PR #122 replaced the fixture's `touch()`+`sleep(0.01)` with `os.utime()`, which removed the mtime-tie flakiness but not the real source of nondeterminism — so the test stayed intermittently flaky (passed in #122's CI, failed in #119's 3.12 job on the same committed code).

## Root cause

`_get_session_id_from_mtime` selected in an order-dependent way: the exact-match loop `for project_dir in projects_dir.glob(f"*{project_name}*"): ... return jsonl_files[0].stem` returned the first glob-matching project dir's session, and pathlib glob/iterdir order is filesystem-dependent. When the match set had more than one dir, the result ignored mtime entirely and varied per run.

## Fix

Pick the globally newest JSONL by `(mtime, name)` across the candidate dirs — deterministic regardless of iteration order. Preserves the prior semantics (prefer project-name-matching dirs, else all projects). Mock `find_project_root` in the test so it's hermetic against the real cwd.

## Validation

50/50 deterministic passes on Python 3.14; full `test_session.py` green.

Closes #123