### PR TITLE
feat(supervisor): named tmux session + auto-restart send-keys input side channel

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -7275,7 +7275,8 @@ def _cmd_ar_launch(args):
         return 1
     return launch_in_terminal(cmd, name=args.name, restart_delay=args.delay,
                               terminal=getattr(args, 'terminal', 'auto'),
-                              use_tmux=not getattr(args, 'no_tmux', False))
+                              use_tmux=not getattr(args, 'no_tmux', False),
+                              session_spec=getattr(args, 'session_id', None))
 
 def _cmd_ar_list(args=None):
     from .supervisor import list_processes
@@ -8488,6 +8489,11 @@ def _build_parser() -> argparse.ArgumentParser:
                            help="terminal app (default: auto-detect)")
     ar_launch.add_argument("--no-tmux", action="store_true",
                            help="do not back the session with tmux (disables send-keys)")
+    ar_launch.add_argument("--session-id", default=None,
+                           help="pin a session: 'latest' (resume most recent CC session, like -c), "
+                                "'new' (fresh), or an explicit UUID. Exported as MACF_SESSION_ID "
+                                "for the command to forward (e.g. claude --session-id). "
+                                "Default: unset (command resumes on its own).")
     ar_launch.add_argument("cmd", nargs=argparse.REMAINDER, help="command to supervise (after --)")
     ar_launch.set_defaults(func=lambda args: _cmd_ar_launch(args))
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -8490,10 +8490,12 @@ def _build_parser() -> argparse.ArgumentParser:
     ar_launch.add_argument("--no-tmux", action="store_true",
                            help="do not back the session with tmux (disables send-keys)")
     ar_launch.add_argument("--session-id", default=None,
-                           help="pin a session: 'latest' (resume most recent CC session, like -c), "
-                                "'new' (fresh), or an explicit UUID. Exported as MACF_SESSION_ID "
-                                "for the command to forward (e.g. claude --session-id). "
-                                "Default: unset (command resumes on its own).")
+                           help="pin a session: 'latest' (most recent CC session), 'new' (fresh), "
+                                "or an explicit UUID. Exported as MACF_SESSION_ID for the command "
+                                "to forward (e.g. claude --session-id). NOTE: CC refuses to attach "
+                                "to a session that is still LIVE ('already in use'), so do not pin "
+                                "the conversation you are currently in - prefer the command's own "
+                                "`-c` for that. Default: unset (command resumes on its own).")
     ar_launch.add_argument("cmd", nargs=argparse.REMAINDER, help="command to supervise (after --)")
     ar_launch.set_defaults(func=lambda args: _cmd_ar_launch(args))
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -7274,7 +7274,8 @@ def _cmd_ar_launch(args):
         print("Usage: macf_tools auto-restart launch -- <command> [args...]")
         return 1
     return launch_in_terminal(cmd, name=args.name, restart_delay=args.delay,
-                              terminal=getattr(args, 'terminal', 'auto'))
+                              terminal=getattr(args, 'terminal', 'auto'),
+                              use_tmux=not getattr(args, 'no_tmux', False))
 
 def _cmd_ar_list(args=None):
     from .supervisor import list_processes
@@ -7301,6 +7302,14 @@ def _cmd_ar_kill(args):
     from .supervisor import kill_process
     kill_process(args.pid)
     return 0
+
+def _cmd_ar_send_keys(args):
+    from .supervisor import send_keys
+    keys = [a for a in args.keys if a != "--"]
+    if not keys:
+        print("Usage: macf_tools auto-restart send-keys <name|pid> -- <text...>")
+        return 1
+    return send_keys(args.target, keys, enter=not getattr(args, 'no_enter', False))
 
 
 def cmd_idea_create(args: argparse.Namespace) -> int:
@@ -8477,6 +8486,8 @@ def _build_parser() -> argparse.ArgumentParser:
                                     "ptyxis", "kgx", "tilix", "lxterminal", "foot",
                                     "xterm", "konsole", "x-terminal-emulator"],
                            help="terminal app (default: auto-detect)")
+    ar_launch.add_argument("--no-tmux", action="store_true",
+                           help="do not back the session with tmux (disables send-keys)")
     ar_launch.add_argument("cmd", nargs=argparse.REMAINDER, help="command to supervise (after --)")
     ar_launch.set_defaults(func=lambda args: _cmd_ar_launch(args))
 
@@ -8505,6 +8516,16 @@ def _build_parser() -> argparse.ArgumentParser:
     ar_kill = ar_sub.add_parser("kill", help="kill supervisor and child (nuclear option)")
     ar_kill.add_argument("pid", type=int, help="supervisor PID")
     ar_kill.set_defaults(func=lambda args: _cmd_ar_kill(args))
+
+    # auto-restart send-keys
+    ar_send = ar_sub.add_parser("send-keys",
+                                help="inject text into a supervised tmux session (drives the live CC client)")
+    ar_send.add_argument("target", help="supervisor name or PID")
+    ar_send.add_argument("--no-enter", action="store_true",
+                         help="do not press Enter after the text")
+    ar_send.add_argument("keys", nargs=argparse.REMAINDER,
+                         help="text to send (after --), e.g. -- /compact")
+    ar_send.set_defaults(func=lambda args: _cmd_ar_send_keys(args))
 
     # ── transcript-monitor ─────────────────────────────────────────────
     tm_parser = sub.add_parser("transcript-monitor", help="JSONL transcript monitoring daemon")

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -332,11 +332,13 @@ def launch_in_terminal(cmd_args: list, name: str = "",
             live child can be driven via `auto-restart send-keys`. Degrades
             gracefully (direct launch, no send-keys) when tmux is absent.
         session_spec: Session id to pin: None (default - do not pin; the
-            command resumes on its own, e.g. its own `-c`), "latest" (resume
-            the most recent CC transcript - restores `-c` continuity while
-            yielding an id to name tmux after), "new" (a fresh session), or an
-            explicit UUID. When set it is exported as MACF_SESSION_ID for the
-            command to forward via `claude --session-id`.
+            command resumes on its own, e.g. its own `-c`), "latest" (the most
+            recent CC transcript id), "new" (a fresh session), or an explicit
+            UUID. When set it is exported as MACF_SESSION_ID for the command to
+            forward via `claude --session-id`. CAVEAT: CC refuses `--session-id`
+            for a session that is currently LIVE ("already in use"), so do not
+            pin the conversation you are still in - use None (the command's own
+            `-c`) for that case.
 
     Returns:
         Supervisor PID

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -27,6 +27,7 @@ import signal
 import subprocess
 import sys
 import time
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -170,9 +171,107 @@ def _terminal_argv(term: str, cmd: list) -> list:
     return _terminal_command_form(base, real, cmd)
 
 
+def _tmux_available() -> bool:
+    """True if a tmux binary is on PATH (Linux and macOS alike)."""
+    return shutil.which("tmux") is not None
+
+
+def _new_session_id() -> str:
+    """A fresh CC-compatible session UUID. Its first 8 hex chars become the
+    breadcrumb short id (s_xxxxxxxx) and the tmux session-name suffix, so a
+    command that passes this through to `claude --session-id` lands a session
+    whose breadcrumb matches the tmux name by construction."""
+    return str(uuid.uuid4())
+
+
+def _sanitize_tmux_name(name: str) -> str:
+    """tmux forbids '.' and ':' in session names (they are window/pane
+    separators) and chokes on whitespace. Map those to '_'."""
+    cleaned = "".join("_" if ch in ".: \t\n" else ch for ch in name)
+    return cleaned or "session"
+
+
+def _tmux_wrap(tmux_session: str, cmd: list) -> list:
+    """Wrap *cmd* (an argv list) so it runs inside a named tmux session.
+
+    tmux's [shell-command] is a SINGLE argument re-parsed by `/bin/sh -c`, so
+    the command is passed as one shell-safe string. `-A` attaches to an
+    existing session of that name instead of erroring, which is the right
+    behaviour for a long-lived supervisor pane.
+    """
+    return ["tmux", "new-session", "-A", "-s", tmux_session,
+            _shell_command_string(cmd)]
+
+
+def _find_supervisor(target: str) -> dict | None:
+    """Find a RUNNING supervisor registry entry by supervisor PID or by name.
+    On multiple name matches, returns the most recently created."""
+    if not REGISTRY_DIR.exists():
+        return None
+    matches = []
+    for entry in REGISTRY_DIR.glob("*.json"):
+        if entry.name == "supervisor_crash.log":
+            continue
+        try:
+            data = json.loads(entry.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        sup_pid = data.get("supervisor_pid", 0)
+        if not _is_alive(sup_pid):
+            continue
+        if target == str(sup_pid) or target == data.get("name"):
+            matches.append(data)
+    if not matches:
+        return None
+    return max(matches, key=lambda d: d.get("created", 0))
+
+
+def send_keys(target: str, keys: list, enter: bool = True) -> int:
+    """Inject literal text (plus an optional Enter) into a supervised session's
+    tmux pane - the side channel for driving the live CC client (e.g. a real
+    `/compact`, which the client parses only from its own TTY input).
+
+    *target* is a supervisor name or PID. The text is sent with `-l` (literal,
+    no key-name interpretation) and the Enter is a separate key press, so text
+    that happens to contain 'Enter' or 'C-c' is not reinterpreted.
+    """
+    if not _tmux_available():
+        print("[auto-restart] tmux not found; send-keys requires a tmux-backed session.",
+              file=sys.stderr)
+        return 1
+    data = _find_supervisor(target)
+    if not data:
+        print(f"[auto-restart] No running supervised process matching '{target}'.",
+              file=sys.stderr)
+        return 1
+    tmux_session = data.get("tmux_session")
+    if not tmux_session:
+        print(f"[auto-restart] '{data.get('name')}' was launched without a tmux session; "
+              f"send-keys is unavailable.\n"
+              f"  Relaunch (with tmux on PATH) to enable the input side channel.",
+              file=sys.stderr)
+        return 1
+    text = " ".join(keys)
+    # `-t <session>` targets that session's active pane. `--` guards text that
+    # starts with '-'. CC's stdin reader receives the bytes as if typed.
+    rc = subprocess.run(
+        ["tmux", "send-keys", "-t", tmux_session, "-l", "--", text]
+    ).returncode
+    if rc == 0 and enter:
+        rc = subprocess.run(["tmux", "send-keys", "-t", tmux_session, "Enter"]).returncode
+    if rc == 0:
+        suffix = " + Enter" if enter else ""
+        print(f"[auto-restart] Sent to tmux session '{tmux_session}': {text!r}{suffix}")
+    else:
+        print(f"[auto-restart] tmux send-keys failed (rc={rc}). "
+              f"Is the session alive?  tmux ls", file=sys.stderr)
+    return rc
+
+
 def launch_in_terminal(cmd_args: list, name: str = "",
                        restart_delay: int = 5,
-                       terminal: str = "auto") -> int:
+                       terminal: str = "auto",
+                       use_tmux: bool = True) -> int:
     """Launch a supervised process in a new terminal window.
 
     Args:
@@ -182,6 +281,10 @@ def launch_in_terminal(cmd_args: list, name: str = "",
         terminal: Terminal app to use: "auto", "terminal", "iterm2",
             "gnome-terminal", "ptyxis", "kgx", "tilix", "lxterminal", "foot",
             "xterm", "konsole", "x-terminal-emulator"
+        use_tmux: If True (default) and tmux is on PATH, run the supervisor
+            inside a named tmux session ("<name>_<short-session-id>") so the
+            live child can be driven via `auto-restart send-keys`. Degrades
+            gracefully (direct launch, no send-keys) when tmux is absent.
 
     Returns:
         Supervisor PID
@@ -193,18 +296,45 @@ def launch_in_terminal(cmd_args: list, name: str = "",
     if not name:
         name = os.path.basename(cmd_args[0])
 
-    # Build the supervisor command that runs in the new terminal
+    # Pin a session id up front. The supervised command (e.g. a wrapper around
+    # `claude`) can pass it through via `claude --session-id "$MACF_SESSION_ID"`,
+    # so the CC breadcrumb (s_<first8>) matches the tmux session name below.
+    session_id = _new_session_id()
+    short_id = session_id[:8]
+
+    # Optionally back the session with a named tmux session so the live child
+    # is reachable by `auto-restart send-keys`.
+    tmuxify = use_tmux and _tmux_available()
+    tmux_session = _sanitize_tmux_name(f"{name}_{short_id}") if tmuxify else None
+    if use_tmux and not tmuxify:
+        print("[auto-restart] tmux not found - launching without the send-keys "
+              "side channel (install tmux to enable it).", file=sys.stderr)
+
+    # Build the supervisor command that runs in the new terminal. --session-id
+    # and --tmux-session are recorded by the supervisor in its registry entry.
     supervisor_cmd = [
         sys.executable, "-m", "macf.supervisor",
         "_run_loop",
         "--name", name,
         "--delay", str(restart_delay),
-        "--",
-    ] + cmd_args
+        "--session-id", session_id,
+    ]
+    if tmux_session:
+        supervisor_cmd += ["--tmux-session", tmux_session]
+    supervisor_cmd += ["--"] + cmd_args
+
+    # When tmux-backed, the terminal hosts `tmux new-session` which runs the
+    # supervisor in its pane (-A: attach if a session of that name already
+    # exists). tmux's [shell-command] is a single shell-reparsed argument, so
+    # pass the supervisor command as one shell-safe string.
+    if tmux_session:
+        launch_cmd = _tmux_wrap(tmux_session, supervisor_cmd)
+    else:
+        launch_cmd = supervisor_cmd
 
     # macOS terminals run their command argument through a shell, so build a
     # shell-safe string and then escape it for the AppleScript literal.
-    escaped_cmd = _applescript_quote(_shell_command_string(supervisor_cmd))
+    escaped_cmd = _applescript_quote(_shell_command_string(launch_cmd))
 
     system = platform.system()
     if system == "Darwin":
@@ -247,12 +377,12 @@ def launch_in_terminal(cmd_args: list, name: str = "",
         candidates = [terminal] if terminal not in ("auto", "") else _LINUX_TERMINALS
         for term in candidates:
             if subprocess.run(["which", term], capture_output=True).returncode == 0:
-                subprocess.Popen(_terminal_argv(term, supervisor_cmd))
+                subprocess.Popen(_terminal_argv(term, launch_cmd))
                 time.sleep(1.5)
                 break
         else:
             print("No terminal emulator found. Run directly:", file=sys.stderr)
-            print(f"  {_shell_command_string(supervisor_cmd)}", file=sys.stderr)
+            print(f"  {_shell_command_string(launch_cmd)}", file=sys.stderr)
             return 1
     else:
         print(f"Unsupported platform: {system}", file=sys.stderr)
@@ -266,6 +396,10 @@ def launch_in_terminal(cmd_args: list, name: str = "",
             pid = data.get("supervisor_pid", "?")
             print(f"[auto-restart] Launched '{name}' in new terminal (supervisor PID: {pid})")
             print(f"[auto-restart] Command: {' '.join(cmd_args)}")
+            print(f"[auto-restart] Session id: {session_id} (breadcrumb s_{short_id})")
+            if tmux_session:
+                print(f"[auto-restart] tmux session: {tmux_session}")
+                print(f"[auto-restart] Send input: macf_tools auto-restart send-keys {name} -- <text>")
             print(f"[auto-restart] Manage: macf_tools auto-restart list")
             return pid
 
@@ -273,13 +407,24 @@ def launch_in_terminal(cmd_args: list, name: str = "",
     return 0
 
 
-def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5):
+def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
+             tmux_session: str = None, session_id: str = None):
     """Run the supervisor loop (called inside the new terminal).
 
     This is the actual supervisor process — manages the child.
+
+    tmux_session / session_id are recorded in the registry (for `send-keys`
+    resolution and breadcrumb correlation). When session_id is set it is also
+    exported as MACF_SESSION_ID so the supervised command can forward it (e.g.
+    `claude --session-id "$MACF_SESSION_ID"`).
     """
     pid = os.getpid()
     created = time.time()
+
+    # Export the pinned session id so the child (run via $SHELL -ic, which
+    # inherits this environment) can pass it to `claude --session-id`.
+    if session_id:
+        os.environ["MACF_SESSION_ID"] = session_id
 
     _write_registry(pid, {
         "supervisor_pid": pid,
@@ -291,6 +436,8 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5):
         "status": "running",
         "last_restart": None,
         "child_pid": None,
+        "tmux_session": tmux_session,
+        "session_id": session_id,
     })
 
     child = None
@@ -563,6 +710,8 @@ def status(pid: int):
     print(f"Command:         {' '.join(data.get('command', []))}")
     print(f"Status:          {data.get('status', '?')}")
     print(f"Child PID:       {data.get('child_pid', 'none')}")
+    print(f"tmux session:    {data.get('tmux_session') or 'none (send-keys unavailable)'}")
+    print(f"Session id:      {data.get('session_id') or 'N/A'}")
     print(f"Created:         {data.get('created_iso', '?')}")
     print(f"Restarts:        {data.get('restart_count', 0)}")
     print(f"Last exit code:  {data.get('last_exit_code', 'N/A')}")
@@ -593,11 +742,14 @@ if __name__ == "__main__":
         parser.add_argument("action", choices=["_run_loop"])
         parser.add_argument("--name", default="")
         parser.add_argument("--delay", type=int, default=2)
+        parser.add_argument("--tmux-session", default=None)
+        parser.add_argument("--session-id", default=None)
 
         args = parser.parse_args(supervisor_argv)
 
         if args.action == "_run_loop":
-            run_loop(cmd, name=args.name, restart_delay=args.delay)
+            run_loop(cmd, name=args.name, restart_delay=args.delay,
+                     tmux_session=args.tmux_session, session_id=args.session_id)
 
     except Exception as e:
         # Top-level supervisor crash handler — bare Exception is intentional:

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -21,6 +21,7 @@ Architecture:
 import json
 import os
 import platform
+import re
 import shlex
 import shutil
 import signal
@@ -176,12 +177,56 @@ def _tmux_available() -> bool:
     return shutil.which("tmux") is not None
 
 
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
 def _new_session_id() -> str:
     """A fresh CC-compatible session UUID. Its first 8 hex chars become the
     breadcrumb short id (s_xxxxxxxx) and the tmux session-name suffix, so a
     command that passes this through to `claude --session-id` lands a session
     whose breadcrumb matches the tmux name by construction."""
     return str(uuid.uuid4())
+
+
+def _latest_session_id() -> str:
+    """The session id of the most recently modified CC transcript under
+    ~/.claude/projects/ - i.e. the conversation `claude -c` would resume.
+    Returns None if there are no transcripts. Lets the supervisor pin (and
+    name the tmux session after) the session the user is actually continuing,
+    instead of minting a fresh empty one."""
+    projects = Path.home() / ".claude" / "projects"
+    if not projects.exists():
+        return None
+    latest, latest_mtime = None, -1.0
+    for jf in projects.glob("*/*.jsonl"):
+        if not _UUID_RE.match(jf.stem):
+            continue
+        try:
+            m = jf.stat().st_mtime
+        except OSError:
+            continue
+        if m > latest_mtime:
+            latest_mtime, latest = m, jf.stem
+    return latest
+
+
+def _resolve_session_spec(spec: str) -> str:
+    """Map a launch-time --session-id spec to a concrete session id (or None).
+
+    None/""  -> None      (do not pin; the command runs as-is, e.g. its own -c)
+    "new"    -> a fresh UUID
+    "latest" -> the most recent CC transcript's id (resume it), or a fresh UUID
+                if none exists - this restores `claude -c` continuity while
+                still yielding an id to name the tmux session after.
+    <uuid>   -> that explicit id
+    """
+    if spec in (None, ""):
+        return None
+    if spec == "new":
+        return _new_session_id()
+    if spec == "latest":
+        return _latest_session_id() or _new_session_id()
+    return spec
 
 
 def _sanitize_tmux_name(name: str) -> str:
@@ -271,7 +316,8 @@ def send_keys(target: str, keys: list, enter: bool = True) -> int:
 def launch_in_terminal(cmd_args: list, name: str = "",
                        restart_delay: int = 5,
                        terminal: str = "auto",
-                       use_tmux: bool = True) -> int:
+                       use_tmux: bool = True,
+                       session_spec: str = None) -> int:
     """Launch a supervised process in a new terminal window.
 
     Args:
@@ -285,6 +331,12 @@ def launch_in_terminal(cmd_args: list, name: str = "",
             inside a named tmux session ("<name>_<short-session-id>") so the
             live child can be driven via `auto-restart send-keys`. Degrades
             gracefully (direct launch, no send-keys) when tmux is absent.
+        session_spec: Session id to pin: None (default - do not pin; the
+            command resumes on its own, e.g. its own `-c`), "latest" (resume
+            the most recent CC transcript - restores `-c` continuity while
+            yielding an id to name tmux after), "new" (a fresh session), or an
+            explicit UUID. When set it is exported as MACF_SESSION_ID for the
+            command to forward via `claude --session-id`.
 
     Returns:
         Supervisor PID
@@ -296,16 +348,21 @@ def launch_in_terminal(cmd_args: list, name: str = "",
     if not name:
         name = os.path.basename(cmd_args[0])
 
-    # Pin a session id up front. The supervised command (e.g. a wrapper around
-    # `claude`) can pass it through via `claude --session-id "$MACF_SESSION_ID"`,
-    # so the CC breadcrumb (s_<first8>) matches the tmux session name below.
-    session_id = _new_session_id()
-    short_id = session_id[:8]
+    # Optionally pin a session id. When set, the supervised command (e.g. a
+    # wrapper around `claude`) forwards it via `claude --session-id
+    # "$MACF_SESSION_ID"`, so the CC breadcrumb (s_<first8>) matches the tmux
+    # session name below. "latest" resumes the user's current conversation.
+    session_id = _resolve_session_spec(session_spec)
+    short_id = session_id[:8] if session_id else None
 
     # Optionally back the session with a named tmux session so the live child
-    # is reachable by `auto-restart send-keys`.
+    # is reachable by `auto-restart send-keys`. The id suffix is added only
+    # when an id is pinned; otherwise the bare name is used.
     tmuxify = use_tmux and _tmux_available()
-    tmux_session = _sanitize_tmux_name(f"{name}_{short_id}") if tmuxify else None
+    if tmuxify:
+        tmux_session = _sanitize_tmux_name(f"{name}_{short_id}" if short_id else name)
+    else:
+        tmux_session = None
     if use_tmux and not tmuxify:
         print("[auto-restart] tmux not found - launching without the send-keys "
               "side channel (install tmux to enable it).", file=sys.stderr)
@@ -317,8 +374,9 @@ def launch_in_terminal(cmd_args: list, name: str = "",
         "_run_loop",
         "--name", name,
         "--delay", str(restart_delay),
-        "--session-id", session_id,
     ]
+    if session_id:
+        supervisor_cmd += ["--session-id", session_id]
     if tmux_session:
         supervisor_cmd += ["--tmux-session", tmux_session]
     supervisor_cmd += ["--"] + cmd_args
@@ -396,7 +454,8 @@ def launch_in_terminal(cmd_args: list, name: str = "",
             pid = data.get("supervisor_pid", "?")
             print(f"[auto-restart] Launched '{name}' in new terminal (supervisor PID: {pid})")
             print(f"[auto-restart] Command: {' '.join(cmd_args)}")
-            print(f"[auto-restart] Session id: {session_id} (breadcrumb s_{short_id})")
+            if session_id:
+                print(f"[auto-restart] Session id: {session_id} (breadcrumb s_{short_id})")
             if tmux_session:
                 print(f"[auto-restart] tmux session: {tmux_session}")
                 print(f"[auto-restart] Send input: macf_tools auto-restart send-keys {name} -- <text>")

--- a/macf/tests/test_supervisor_tmux_sendkeys.py
+++ b/macf/tests/test_supervisor_tmux_sendkeys.py
@@ -155,3 +155,56 @@ def test_send_keys_no_enter(monkeypatch):
     assert rc == 0
     assert len(calls) == 1  # no Enter press
     assert calls[0][-3:] == ["-l", "--", "hello world"]
+
+
+# --- session spec resolution (the resume-latest continuity fix) -----------
+
+def test_resolve_spec_none_does_not_pin():
+    assert sup._resolve_session_spec(None) is None
+    assert sup._resolve_session_spec("") is None
+
+
+def test_resolve_spec_new_mints_uuid():
+    sid = sup._resolve_session_spec("new")
+    assert sup._UUID_RE.match(sid)
+
+
+def test_resolve_spec_explicit_uuid_passthrough():
+    u = "59ae6fca-58d3-4812-92fa-27932564b231"
+    assert sup._resolve_session_spec(u) == u
+
+
+def test_resolve_spec_latest_resumes_existing(monkeypatch):
+    # 'latest' must return the most-recent transcript id (so the launch RESUMES
+    # the user's current conversation instead of starting fresh).
+    monkeypatch.setattr(sup, "_latest_session_id",
+                        lambda: "59ae6fca-58d3-4812-92fa-27932564b231")
+    assert sup._resolve_session_spec("latest") == "59ae6fca-58d3-4812-92fa-27932564b231"
+
+
+def test_resolve_spec_latest_falls_back_to_new(monkeypatch):
+    monkeypatch.setattr(sup, "_latest_session_id", lambda: None)
+    sid = sup._resolve_session_spec("latest")
+    assert sup._UUID_RE.match(sid)  # minted fresh when no transcript exists
+
+
+def test_latest_session_id_picks_newest(tmp_path, monkeypatch):
+    import os
+    proj = tmp_path / ".claude" / "projects" / "encoded-proj"
+    proj.mkdir(parents=True)
+    older = proj / "11111111-1111-1111-1111-111111111111.jsonl"
+    newer = proj / "22222222-2222-2222-2222-222222222222.jsonl"
+    older.write_text("{}")
+    newer.write_text("{}")
+    os.utime(older, (1000, 1000))
+    os.utime(newer, (2000, 2000))
+    # a non-uuid file must be ignored
+    (proj / "notes.jsonl").write_text("{}")
+    os.utime(proj / "notes.jsonl", (3000, 3000))
+    monkeypatch.setattr(sup.Path, "home", staticmethod(lambda: tmp_path))
+    assert sup._latest_session_id() == "22222222-2222-2222-2222-222222222222"
+
+
+def test_latest_session_id_none_when_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(sup.Path, "home", staticmethod(lambda: tmp_path))
+    assert sup._latest_session_id() is None

--- a/macf/tests/test_supervisor_tmux_sendkeys.py
+++ b/macf/tests/test_supervisor_tmux_sendkeys.py
@@ -1,0 +1,157 @@
+"""Tests for the tmux-backed named session + `auto-restart send-keys`.
+
+Covers session-id pinning, tmux session naming/sanitization, the tmux-wrap
+command form, registry-based target resolution, and the send-keys tmux
+invocation (literal text + separate Enter).
+"""
+
+import json
+import re
+
+import pytest
+
+from macf import supervisor as sup
+
+SUP_CMD = ["python3", "-m", "macf.supervisor", "_run_loop",
+           "--name", "humphry_blackbox", "--delay", "5",
+           "--session-id", "59ae6fca-58d3-4812-92fa-27932564b231",
+           "--", "/home/u/launch.sh"]
+
+
+# --- session id + tmux naming ---------------------------------------------
+
+def test_new_session_id_is_uuid():
+    sid = sup._new_session_id()
+    assert re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", sid)
+
+
+def test_short_id_matches_breadcrumb_convention():
+    # The tmux suffix and the breadcrumb s_<id> both take the first 8 hex.
+    sid = "59ae6fca-58d3-4812-92fa-27932564b231"
+    assert sid[:8] == "59ae6fca"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("humphry_blackbox_59ae6fca", "humphry_blackbox_59ae6fca"),
+    ("launch_x.sh_59ae6fca", "launch_x_sh_59ae6fca"),   # '.' -> '_'
+    ("a:b 59ae6fca", "a_b_59ae6fca"),                   # ':' and ' ' -> '_'
+])
+def test_sanitize_tmux_name(raw, expected):
+    assert sup._sanitize_tmux_name(raw) == expected
+
+
+def test_sanitize_tmux_name_empty():
+    assert sup._sanitize_tmux_name("") == "session"
+    assert sup._sanitize_tmux_name("...") == "___"  # not empty -> kept as underscores
+
+
+# --- tmux wrap form -------------------------------------------------------
+
+def test_tmux_wrap_passes_single_shell_string():
+    argv = sup._tmux_wrap("humphry_blackbox_59ae6fca", SUP_CMD)
+    assert argv[:5] == ["tmux", "new-session", "-A", "-s", "humphry_blackbox_59ae6fca"]
+    # The supervisor command collapses into exactly ONE shell-safe arg.
+    assert len(argv) == 6
+    assert argv[5] == sup._shell_command_string(SUP_CMD)
+    # round-trips: shlex.split of that arg reproduces the original argv
+    import shlex
+    assert shlex.split(argv[5]) == SUP_CMD
+
+
+# --- registry resolution --------------------------------------------------
+
+def _seed_registry(tmp_path, monkeypatch, entries):
+    monkeypatch.setattr(sup, "REGISTRY_DIR", tmp_path)
+    for data in entries:
+        (tmp_path / f"{data['supervisor_pid']}.json").write_text(json.dumps(data))
+    # treat every seeded supervisor pid as alive unless overridden
+    alive = {e["supervisor_pid"] for e in entries if e.get("_alive", True)}
+    monkeypatch.setattr(sup, "_is_alive", lambda pid: pid in alive)
+
+
+def test_find_supervisor_by_name(tmp_path, monkeypatch):
+    _seed_registry(tmp_path, monkeypatch, [
+        {"supervisor_pid": 100, "name": "humphry_blackbox",
+         "tmux_session": "humphry_blackbox_59ae6fca", "created": 1.0},
+    ])
+    found = sup._find_supervisor("humphry_blackbox")
+    assert found and found["supervisor_pid"] == 100
+
+
+def test_find_supervisor_by_pid(tmp_path, monkeypatch):
+    _seed_registry(tmp_path, monkeypatch, [
+        {"supervisor_pid": 100, "name": "humphry_blackbox", "created": 1.0},
+    ])
+    assert sup._find_supervisor("100")["supervisor_pid"] == 100
+
+
+def test_find_supervisor_skips_dead(tmp_path, monkeypatch):
+    _seed_registry(tmp_path, monkeypatch, [
+        {"supervisor_pid": 100, "name": "x", "created": 1.0, "_alive": False},
+    ])
+    assert sup._find_supervisor("x") is None
+
+
+def test_find_supervisor_prefers_most_recent_name_match(tmp_path, monkeypatch):
+    _seed_registry(tmp_path, monkeypatch, [
+        {"supervisor_pid": 100, "name": "dup", "created": 1.0, "tmux_session": "old"},
+        {"supervisor_pid": 200, "name": "dup", "created": 5.0, "tmux_session": "new"},
+    ])
+    assert sup._find_supervisor("dup")["tmux_session"] == "new"
+
+
+# --- send_keys ------------------------------------------------------------
+
+def test_send_keys_requires_tmux(monkeypatch, capsys):
+    monkeypatch.setattr(sup, "_tmux_available", lambda: False)
+    assert sup.send_keys("x", ["/compact"]) == 1
+    assert "tmux not found" in capsys.readouterr().err
+
+
+def test_send_keys_no_match(monkeypatch, capsys):
+    monkeypatch.setattr(sup, "_tmux_available", lambda: True)
+    monkeypatch.setattr(sup, "_find_supervisor", lambda t: None)
+    assert sup.send_keys("nope", ["/compact"]) == 1
+    assert "No running supervised process" in capsys.readouterr().err
+
+
+def test_send_keys_no_tmux_session_recorded(monkeypatch, capsys):
+    monkeypatch.setattr(sup, "_tmux_available", lambda: True)
+    monkeypatch.setattr(sup, "_find_supervisor",
+                        lambda t: {"name": "x", "tmux_session": None})
+    assert sup.send_keys("x", ["/compact"]) == 1
+    assert "without a tmux session" in capsys.readouterr().err
+
+
+def test_send_keys_happy_path_literal_then_enter(monkeypatch):
+    monkeypatch.setattr(sup, "_tmux_available", lambda: True)
+    monkeypatch.setattr(sup, "_find_supervisor",
+                        lambda t: {"name": "x", "tmux_session": "x_59ae6fca"})
+    calls = []
+
+    class _R:
+        returncode = 0
+
+    def fake_run(argv, *a, **k):
+        calls.append(argv)
+        return _R()
+
+    monkeypatch.setattr(sup.subprocess, "run", fake_run)
+    rc = sup.send_keys("x", ["/compact"])
+    assert rc == 0
+    # First call: literal text with -l and -- guard; second: a bare Enter.
+    assert calls[0] == ["tmux", "send-keys", "-t", "x_59ae6fca", "-l", "--", "/compact"]
+    assert calls[1] == ["tmux", "send-keys", "-t", "x_59ae6fca", "Enter"]
+
+
+def test_send_keys_no_enter(monkeypatch):
+    monkeypatch.setattr(sup, "_tmux_available", lambda: True)
+    monkeypatch.setattr(sup, "_find_supervisor",
+                        lambda t: {"name": "x", "tmux_session": "x_59ae6fca"})
+    calls = []
+    monkeypatch.setattr(sup.subprocess, "run",
+                        lambda argv, *a, **k: calls.append(argv) or type("R", (), {"returncode": 0})())
+    rc = sup.send_keys("x", ["hello world"], enter=False)
+    assert rc == 0
+    assert len(calls) == 1  # no Enter press
+    assert calls[0][-3:] == ["-l", "--", "hello world"]


### PR DESCRIPTION
Stacked on #127 (base is that branch; GitHub will retarget to `main` once #127 merges).

## Motivation

The auto-restart supervisor can restart a session (kill + `claude -c`), but a Unix signal carries no payload, so it cannot deliver a *specific* input - notably a real `/compact`, which the CC **client** parses only from its own TTY input. A channel-delivered "/compact" (Telegram) reaches the *model* as text and never executes. This adds the missing TTY-level side channel.

## What's new

### Named session matching the breadcrumb
- `launch_in_terminal` pins a `session_id` (uuid4) and names the tmux session `<name>_<first8>`.
- macf derives the breadcrumb as `session_id[:8]` and CC names the transcript by session id, so a supervised command that forwards the id via `claude --session-id "$MACF_SESSION_ID"` lands a session whose breadcrumb `s_<first8>` **matches the tmux name by construction** - no SessionStart hook.
- The supervisor exports `MACF_SESSION_ID` (inherited through its `$SHELL -ic` child) and records `session_id` + `tmux_session` in the registry.
- `--session-id` is idempotent in CC 2.1.183 (create-then-resume), so every restart resumes the same pinned conversation - more robust than `-c` ("most recent", which drifts).

### tmux backing (portable: Linux + macOS)
- When tmux is on PATH, the terminal hosts `tmux new-session -A -s <name>` running the supervisor in its pane; the setsid child still inherits the pane PTY, so `send-keys` reaches it.
- Graceful degradation to a direct launch (no send-keys) when tmux is absent; `--no-tmux` opts out.
- Session names sanitized (`.`/`:`/whitespace -> `_`). Reuses #127's `_shell_command_string` for the single shell-arg tmux expects.

### `auto-restart send-keys`
- `macf_tools auto-restart send-keys <name|pid> -- <text>` resolves the tmux session from the registry and sends the text with `-l` (literal) then a **separate Enter**, so text containing `Enter`/`C-c` is not reinterpreted. `--no-enter` sends without submitting.
- `status` now shows the tmux session + session id.

## Tests

`tests/test_supervisor_tmux_sendkeys.py` (16 cases): session-id/naming/sanitization, tmux-wrap form (round-trips via shlex), registry resolution (by name/pid, skip-dead, most-recent), and send-keys dispatch (tmux-absent / no-match / no-session / literal-then-Enter / no-enter). All pass; full cli + supervisor suites stay green.

Validated live on a GNOME/ptyxis host: a real `send_keys()` delivered `/compact` into a detached tmux pane and the program inside read it verbatim.

## Integration note

The breadcrumb match requires the supervised command to forward `MACF_SESSION_ID` (e.g. `claude --session-id "$MACF_SESSION_ID"`). Commands that ignore it still run; they just don't get the matched breadcrumb. The supervisor stays command-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)