### PR TITLE
fix(tokens): close post-compaction read-before-write race (#118)

### DIFF
--- a/macf/src/macf/event_queries.py
+++ b/macf/src/macf/event_queries.py
@@ -417,6 +417,31 @@ def get_delegations_this_drive_from_events(session_id: str) -> List[Dict]:
     return delegations
 
 
+def _latest_session_event(event_type: str, session_id: str) -> Optional[dict]:
+    """Most recent event of ``event_type`` whose ``data.session_id`` matches.
+
+    Shared by the compaction-anchor queries below. Matching uses the first 8
+    characters of ``session_id`` (same prefix convention as
+    ``get_active_dev_drv_start``) so a different session's events do not bound
+    the current session's reads.
+
+    Returns the full event record dict (``timestamp``, ``event``, ``data``,
+    ``breadcrumb``) or ``None`` if no matching event exists.
+    """
+    session_prefix = session_id[:8] if session_id else ""
+    if not session_prefix:
+        return None
+
+    for event in read_events(reverse=True):
+        if event.get("event") != event_type:
+            continue
+        event_session = event.get("data", {}).get("session_id", "")
+        if not event_session or not event_session.startswith(session_prefix):
+            continue
+        return event
+    return None
+
+
 def get_latest_compaction_event(session_id: str) -> Optional[dict]:
     """Most recent ``compaction_detected`` event for a given session.
 
@@ -432,28 +457,38 @@ def get_latest_compaction_event(session_id: str) -> Optional[dict]:
     boundary or a preserved-segment replay with its original older timestamp)
     and must be filtered out.
 
+    NOTE: ``compaction_detected`` is written by SessionStart a few seconds AFTER
+    the compaction boundary. For the read-before-write transient immediately
+    after compaction, pair this with ``get_latest_precompact_event`` (emitted
+    BEFORE compaction) and take the later timestamp — see
+    ``tokens._compaction_lower_bound_iso`` (cversek/MacEff#118).
+
     Args:
-        session_id: Session ID to filter events. Matching uses the first 8
-                    characters (same prefix convention as
-                    ``get_active_dev_drv_start``). A different session's
-                    compaction does NOT bound the current session's reads.
+        session_id: Session ID to filter events (first-8-char prefix match).
 
     Returns:
-        The full event record dict (with ``timestamp``, ``event``, ``data``,
-        ``breadcrumb`` keys) or ``None`` if no matching event exists.
+        The full event record dict or ``None`` if no matching event exists.
     """
-    session_prefix = session_id[:8] if session_id else ""
-    if not session_prefix:
-        return None
+    return _latest_session_event("compaction_detected", session_id)
 
-    for event in read_events(reverse=True):
-        if event.get("event") != "compaction_detected":
-            continue
-        event_session = event.get("data", {}).get("session_id", "")
-        if not event_session or not event_session.startswith(session_prefix):
-            continue
-        return event
-    return None
+
+def get_latest_precompact_event(session_id: str) -> Optional[dict]:
+    """Most recent ``pre_compact`` event for a given session.
+
+    The PreCompact hook emits ``pre_compact`` immediately BEFORE compaction, so
+    it is already in the event log during the transient window after compaction
+    but before SessionStart writes ``compaction_detected``. Its timestamp (~the
+    compaction moment) is a valid lower bound on post-compaction assistant
+    timestamps, which closes the read-before-write race in that window
+    (cversek/MacEff#118).
+
+    Args:
+        session_id: Session ID to filter events (first-8-char prefix match).
+
+    Returns:
+        The full event record dict or ``None`` if no matching event exists.
+    """
+    return _latest_session_event("pre_compact", session_id)
 
 
 def get_active_dev_drv_start(session_id: str) -> tuple[float, str]:

--- a/macf/src/macf/utils/tokens.py
+++ b/macf/src/macf/utils/tokens.py
@@ -32,14 +32,33 @@ def _compaction_lower_bound_iso(session_id: str) -> str:
     be filtered out of the tail-scan / full-scan selectors. A wrong-type
     ``timestamp`` on the event record is a contract violation by
     ``append_event`` and will raise naturally — not silently swallowed.
+
+    Closes cversek/MacEff#118: takes the LATER of two compaction anchors.
+    ``compaction_detected`` is written by SessionStart ~3-4s AFTER the
+    boundary; ``pre_compact`` is written by the PreCompact hook BEFORE
+    compaction. During the read-before-write transient (compaction done but
+    ``compaction_detected`` not yet emitted), only ``pre_compact`` is present —
+    using its timestamp as the lower bound rejects the pre-compaction tail and
+    preserved-segment replays that would otherwise leak a stale high token
+    count into the CL meter for a few seconds.
     """
     if not session_id:
         return ""
-    from ..event_queries import get_latest_compaction_event
-    event = get_latest_compaction_event(session_id)
-    if event is None:
+    from ..event_queries import (
+        get_latest_compaction_event,
+        get_latest_precompact_event,
+    )
+    epochs = [
+        ev["timestamp"]
+        for ev in (
+            get_latest_compaction_event(session_id),
+            get_latest_precompact_event(session_id),
+        )
+        if ev is not None
+    ]
+    if not epochs:
         return ""
-    epoch = event["timestamp"]
+    epoch = max(epochs)
     return (
         datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.")
         + f"{int((epoch - int(epoch)) * 1000):03d}Z"
@@ -264,14 +283,21 @@ def get_token_info(session_id: Optional[str] = None) -> Dict[str, Any]:
                             current_tokens = latest["tokens"]
                             last_timestamp = latest["timestamp"]
                         elif last_boundary_idx >= 0:
-                            # Compaction detected but no post-boundary messages yet
-                            # Return conservative estimate (~30% usage)
+                            # Compaction detected but no post-boundary in-cycle
+                            # message yet. Return a conservative estimate scaled
+                            # to the ACTUAL context window: the fixed 60000 was
+                            # 200K-calibrated, so its hardcoded 30%/CL70 were
+                            # wrong on 1M (60000 is ~6% there). Derive the bands
+                            # from max_tokens so the CL meter is sane on any
+                            # window. (cversek/MacEff#118)
+                            est_tokens = min(60000, max_tokens)
+                            pct_used = round(est_tokens / max_tokens * 100, 1)
                             return {
-                                "tokens_used": 60000,
-                                "tokens_remaining": max_tokens - 60000,
-                                "percentage_used": 30.0,
-                                "percentage_remaining": 70.0,
-                                "cl_level": 70,
+                                "tokens_used": est_tokens,
+                                "tokens_remaining": max_tokens - est_tokens,
+                                "percentage_used": pct_used,
+                                "percentage_remaining": round(100 - pct_used, 1),
+                                "cl_level": round(100 - pct_used),
                                 "last_updated": "post_compaction",
                                 "source": "post_compaction_estimate",
                             }

--- a/macf/tests/test_get_token_info_compaction_lower_bound.py
+++ b/macf/tests/test_get_token_info_compaction_lower_bound.py
@@ -216,3 +216,89 @@ def test_helper_returns_empty_when_no_compaction_event():
     with patch("macf.event_queries.get_latest_compaction_event",
                return_value=None):
         assert _compaction_lower_bound_iso("test-session-id-deadbeef") == ""
+
+
+# ---------------------------------------------------------------------------
+# cversek/MacEff#118 — read-before-write transient (pre_compact anchor)
+# ---------------------------------------------------------------------------
+
+
+def _precompact_event(session_id: str, iso: str) -> dict:
+    """Fake ``pre_compact`` event-record shape (emitted BEFORE compaction)."""
+    return {
+        "event": "pre_compact",
+        "timestamp": _epoch_for(iso),
+        "breadcrumb": "s_test/c_test/g_test/p_test/t_test",
+        "data": {
+            "session_id": session_id,
+            "cycle": 100,
+            "tokens_used": 140_000,
+            "cl_level": 30,
+            "source": "auto",
+        },
+        "hook_input": {},
+    }
+
+
+def test_precompact_anchors_lower_bound_in_read_before_write_transient(patched_session):
+    """#118: deterministic offline repro of the post-compaction transient.
+
+    Immediately after compaction, SessionStart has NOT yet written
+    ``compaction_detected`` (returns None here), but the PreCompact hook
+    already wrote ``pre_compact`` BEFORE compaction. The transcript holds the
+    compact_boundary line and preserved-segment replays (original older
+    timestamps, high token counts) after it, with no post-boundary in-cycle
+    message yet. Without the pre_compact anchor the replays leak a stale high
+    count; with it, they are rejected and the reader returns the conservative
+    estimate.
+    """
+    precompact_iso = "2026-06-08T10:05:00.000Z"
+    replay_iso = "2026-05-01T08:00:00.000Z"  # original pre-compaction timestamps
+
+    lines = [
+        json.dumps({
+            "type": "summary",
+            "compact_boundary": True,
+            "timestamp": "2026-06-08T10:04:59.000Z",
+            "preservedSegment": {},
+        }),
+        _assistant_event(replay_iso, 900_000),  # preserved replay after boundary
+        _assistant_event(replay_iso, 880_000),  # another replay
+    ]
+    _write_jsonl(patched_session, lines)
+
+    fake_precompact = _precompact_event("test-session-id-deadbeef", precompact_iso)
+    with patch("macf.event_queries.get_latest_compaction_event", return_value=None), \
+         patch("macf.event_queries.get_latest_precompact_event",
+               return_value=fake_precompact):
+        result = get_token_info()
+
+    # Replays rejected by the pre_compact bound → conservative estimate,
+    # NOT the stale 900k/880k pre-compaction tally.
+    assert result["tokens_used"] not in (900_000, 880_000)
+    assert result["source"] == "post_compaction_estimate"
+
+
+def test_lower_bound_takes_later_of_compaction_and_precompact():
+    """#118: the bound is the LATER of compaction_detected and pre_compact,
+    whichever is present and newer — so the transient (pre_compact only) and
+    the steady state (compaction_detected) are both covered."""
+    from macf.utils.tokens import _compaction_lower_bound_iso
+
+    # pre_compact newer than compaction_detected → pre_compact wins
+    older = _compaction_event("test-session-id-deadbeef", "2026-06-08T10:00:00.000Z")
+    newer = _precompact_event("test-session-id-deadbeef", "2026-06-08T10:05:00.000Z")
+    with patch("macf.event_queries.get_latest_compaction_event", return_value=older), \
+         patch("macf.event_queries.get_latest_precompact_event", return_value=newer):
+        assert _compaction_lower_bound_iso("test-session-id-deadbeef").startswith(
+            "2026-06-08T10:05:00"
+        )
+
+    # compaction_detected newer than pre_compact → compaction_detected wins
+    old_pre = _precompact_event("test-session-id-deadbeef", "2026-06-08T10:00:00.000Z")
+    new_comp = _compaction_event("test-session-id-deadbeef", "2026-06-08T10:05:00.000Z")
+    with patch("macf.event_queries.get_latest_compaction_event", return_value=new_comp), \
+         patch("macf.event_queries.get_latest_precompact_event", return_value=old_pre):
+        assert _compaction_lower_bound_iso("test-session-id-deadbeef").startswith(
+            "2026-06-08T10:05:00"
+        )


### PR DESCRIPTION
Follow-up to #111. The event-anchor fix was correct in steady state but had an unguarded transient window in the first few seconds after a compaction: `get_token_info`'s lower bound used only `compaction_detected`, which SessionStart writes ~3-4s AFTER the boundary. A statusline render in that window got the *previous* (older) compaction as its bound, so pre-compaction preserved-segment replays leaked a stale high token count into the CL meter.

## Fix

Take the LATER of two anchors. The PreCompact hook writes `pre_compact` BEFORE compaction, so it is already in the log during the transient — its timestamp anchors the bound and rejects the replays. `_compaction_lower_bound_iso` now uses `max(compaction_detected, pre_compact)`.

Also recalibrate the no-post-boundary conservative estimate to derive its percentage / CL from the actual context window — the fixed `30%`/CL70 was 200K-calibrated and wrong on 1M (60000 tokens is ~6% there, CL94).

Adds `get_latest_precompact_event` via a shared `_latest_session_event` helper (DRY with `get_latest_compaction_event`), plus a deterministic offline repro test that exercises the exact transient (boundary + replays present, `pre_compact` present, `compaction_detected` absent) without forcing a real compaction.

## Out of scope (unchanged from the issue)

Not about transcript/event-log size — the unbounded single-session logs and reverse scans are an intentional continuity tradeoff, not a defect. No scan-strategy or perf changes here; pure event reuse.

## Validation

31/31 token tests pass (4 token test files), including the two new #118 tests.

Closes #118