### PR TITLE
fix(auto-mode): bootstrap command + fail-closed auth token (#115)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1820,6 +1820,51 @@ def cmd_agent_init(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_agent_init_auth_token(args: argparse.Namespace) -> int:
+    """Generate and install the AUTO_MODE auth token on a host.
+
+    Writes a random ``auto_mode_auth_token`` into
+    ``<agent_home>/.maceff/settings.json`` (preserving existing keys). This is
+    the sanctioned bootstrap for bare-metal / migrated installs where
+    ``docker/scripts/start.py`` never ran (cversek/MacEff#115). Refuses to
+    overwrite an existing token unless ``--force``.
+    """
+    import secrets
+
+    agent_home = find_agent_home()
+    maceff_dir = agent_home / ".maceff"
+    maceff_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = maceff_dir / "settings.json"
+
+    settings = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"❌ Could not read existing {settings_path}: {e}")
+            return 1
+
+    if settings.get("auto_mode_auth_token") and not getattr(args, "force", False):
+        print(f"⚠️ An auth token is already configured in {settings_path}.")
+        print("   Re-run with --force to regenerate (invalidates the old one).")
+        return 1
+
+    token = secrets.token_hex(16)
+    settings["auto_mode_auth_token"] = token
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+
+    print(f"✅ AUTO_MODE auth token written to {settings_path}")
+    print("   Activate with:")
+    print(f"     macf_tools mode set AUTO_MODE --auth-token '{token}'")
+    print(
+        "\n   Security note: on a single-user host this token is a coordination /\n"
+        "   accidental-self-auth gate, not a hard boundary — a same-user agent can\n"
+        "   read or rewrite this file. True enforcement requires the external harness\n"
+        "   classifier or a multi-user / file-permission setup."
+    )
+    return 0
+
+
 def cmd_agent_set_github(args: argparse.Namespace) -> int:
     """Set per-project GitHub identity via GH_TOKEN in settings.local.json."""
     username = args.username
@@ -7634,6 +7679,17 @@ def _build_parser() -> argparse.ArgumentParser:
     agent_init_parser = agent_sub.add_parser("init", help="initialize agent with PA preamble")
     agent_init_parser.add_argument("-y", "--yes", action="store_true", help="skip confirmation prompt")
     agent_init_parser.set_defaults(func=cmd_agent_init)
+
+    # AUTO_MODE auth token bootstrap (host / non-Docker installs) — #115
+    auth_token_parser = agent_sub.add_parser(
+        "init-auth-token",
+        help="generate + install the AUTO_MODE auth token (host bootstrap)",
+    )
+    auth_token_parser.add_argument(
+        "--force", action="store_true",
+        help="overwrite an existing token (invalidates the old one)",
+    )
+    auth_token_parser.set_defaults(func=cmd_agent_init_auth_token)
 
     # Agent backup subcommands
     backup_parser = agent_sub.add_parser("backup", help="consciousness backup operations")

--- a/macf/src/macf/utils/cycles.py
+++ b/macf/src/macf/utils/cycles.py
@@ -84,22 +84,39 @@ def set_auto_mode(
         MANUAL_MODE can always be set without auth.
     """
     try:
-        # Validate auth token for AUTO_MODE activation
+        # Validate auth token for AUTO_MODE activation.
+        # FAIL CLOSED (cversek/MacEff#115): a configured, matching token is
+        # required. The old behaviour skipped validation entirely when the
+        # settings file was absent or the token was empty, which let ANY
+        # non-empty string activate AUTO_MODE on a host that never ran the
+        # docker bootstrap. The token is a coordination / accidental-self-auth
+        # gate — on a single-user host it is not a hard boundary (a same-user
+        # agent can rewrite the file), so true enforcement still depends on the
+        # external harness classifier — but it must at least not accept an
+        # arbitrary string.
         if enabled and auth_token is not None:
-            # Load expected token from settings
             if agent_home is None:
                 agent_home = find_agent_home()
             settings_path = agent_home / ".maceff" / "settings.json"
 
+            expected_token = None
             if settings_path.exists():
-                with open(settings_path, 'r') as f:
-                    settings = json.load(f)
-                expected_token = settings.get('auto_mode_auth_token')
+                try:
+                    with open(settings_path, 'r') as f:
+                        settings = json.load(f)
+                    expected_token = settings.get('auto_mode_auth_token')
+                except (OSError, json.JSONDecodeError) as e:
+                    return (False, f"Could not read auth token settings: {e}")
 
-                if expected_token and auth_token != expected_token:
-                    return (False, "Invalid auth token")
-            # If no settings file or no token configured, skip validation
-            # (allows initial setup before tokens exist)
+            if not expected_token:
+                return (
+                    False,
+                    "AUTO_MODE auth token not configured. Run "
+                    "`macf_tools agent init-auth-token` to generate one "
+                    f"(writes {settings_path}).",
+                )
+            if auth_token != expected_token:
+                return (False, "Invalid auth token")
 
         # Log mode change event
         try:

--- a/macf/tests/test_auto_mode_auth_token.py
+++ b/macf/tests/test_auto_mode_auth_token.py
@@ -1,0 +1,127 @@
+"""Tests for the AUTO_MODE auth-token bootstrap + fail-closed validation.
+
+Coverage for cversek/MacEff#115:
+
+1. Installation gap — ``macf_tools agent init-auth-token`` is the sanctioned
+   host bootstrap that generates + writes ``auto_mode_auth_token`` into
+   ``<agent_home>/.maceff/settings.json`` (previously only docker start.py
+   created it, so bare-metal hosts had no path to the token).
+
+2. Validation gap — ``set_auto_mode`` now FAILS CLOSED: a missing settings
+   file or empty token is rejected instead of skipped, so an arbitrary
+   non-empty string can no longer activate AUTO_MODE.
+"""
+import argparse
+import json
+
+from macf.utils.cycles import set_auto_mode
+from macf.cli import cmd_agent_init_auth_token
+
+
+# --- fail-closed validation -------------------------------------------------
+
+def test_auto_mode_fails_closed_without_token_file(tmp_path):
+    """No settings.json → AUTO_MODE rejected (was: any string accepted)."""
+    ok, msg = set_auto_mode(
+        enabled=True, session_id="s", auth_token="anything", agent_home=tmp_path
+    )
+    assert ok is False
+    assert "not configured" in msg
+
+
+def test_auto_mode_fails_closed_with_empty_token_in_file(tmp_path):
+    """settings.json present but no token configured → still rejected."""
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "settings.json").write_text(json.dumps({"other": "x"}))
+    ok, msg = set_auto_mode(
+        enabled=True, session_id="s", auth_token="anything", agent_home=tmp_path
+    )
+    assert ok is False
+    assert "not configured" in msg
+
+
+def test_auto_mode_accepts_matching_token(tmp_path):
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "settings.json").write_text(
+        json.dumps({"auto_mode_auth_token": "secret123"})
+    )
+    ok, _ = set_auto_mode(
+        enabled=True, session_id="s", auth_token="secret123", agent_home=tmp_path
+    )
+    assert ok is True
+
+
+def test_auto_mode_rejects_mismatched_token(tmp_path):
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "settings.json").write_text(
+        json.dumps({"auto_mode_auth_token": "secret123"})
+    )
+    ok, msg = set_auto_mode(
+        enabled=True, session_id="s", auth_token="wrong", agent_home=tmp_path
+    )
+    assert ok is False
+    assert "Invalid" in msg
+
+
+def test_manual_mode_never_needs_token(tmp_path):
+    """MANUAL_MODE can always be set without auth (no token file present)."""
+    ok, _ = set_auto_mode(
+        enabled=False, session_id="s", auth_token=None, agent_home=tmp_path
+    )
+    assert ok is True
+
+
+# --- bootstrap command ------------------------------------------------------
+
+def test_init_auth_token_writes_token(tmp_path, monkeypatch):
+    monkeypatch.setattr("macf.cli.find_agent_home", lambda: tmp_path)
+    rc = cmd_agent_init_auth_token(argparse.Namespace(force=False))
+    assert rc == 0
+    settings = json.loads((tmp_path / ".maceff" / "settings.json").read_text())
+    # secrets.token_hex(16) → 32 hex chars
+    assert len(settings["auto_mode_auth_token"]) == 32
+
+
+def test_init_auth_token_refuses_overwrite_without_force(tmp_path, monkeypatch):
+    monkeypatch.setattr("macf.cli.find_agent_home", lambda: tmp_path)
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "settings.json").write_text(
+        json.dumps({"auto_mode_auth_token": "existing"})
+    )
+    rc = cmd_agent_init_auth_token(argparse.Namespace(force=False))
+    assert rc == 1
+    # token unchanged
+    assert json.loads(
+        (maceff / "settings.json").read_text()
+    )["auto_mode_auth_token"] == "existing"
+
+
+def test_init_auth_token_force_regenerates_and_preserves_keys(tmp_path, monkeypatch):
+    monkeypatch.setattr("macf.cli.find_agent_home", lambda: tmp_path)
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "settings.json").write_text(
+        json.dumps({"auto_mode_auth_token": "old", "other": "keep"})
+    )
+    rc = cmd_agent_init_auth_token(argparse.Namespace(force=True))
+    assert rc == 0
+    s = json.loads((maceff / "settings.json").read_text())
+    assert s["auto_mode_auth_token"] != "old"
+    assert s["other"] == "keep"  # existing keys preserved
+
+
+def test_init_token_then_activate_roundtrip(tmp_path, monkeypatch):
+    """Bootstrap writes a token that set_auto_mode then accepts (end-to-end)."""
+    monkeypatch.setattr("macf.cli.find_agent_home", lambda: tmp_path)
+    cmd_agent_init_auth_token(argparse.Namespace(force=False))
+    token = json.loads(
+        (tmp_path / ".maceff" / "settings.json").read_text()
+    )["auto_mode_auth_token"]
+    ok, _ = set_auto_mode(
+        enabled=True, session_id="s", auth_token=token, agent_home=tmp_path
+    )
+    assert ok is True


### PR DESCRIPTION
Two gaps in the AUTO_MODE `auto_mode_auth_token` mechanism, surfaced on a bare-metal (non-Docker) host.

## 1. Install path

The token was generated only by `docker/scripts/start.py` at container first-boot, so bare-metal / migrated hosts had no sanctioned way to create it (`framework install` doesn't, the runtime only reads it). Add **`macf_tools agent init-auth-token`** — generates a random token via `secrets` and writes `auto_mode_auth_token` into `<agent_home>/.maceff/settings.json`, preserving existing keys. Refuses to overwrite an existing token without `--force`.

## 2. Fail-closed validation

`set_auto_mode` skipped validation entirely when `settings.json` was absent or the token empty ("allows initial setup before tokens exist"), so the only remaining gate was the CLI's presence check — **any non-empty string activated AUTO_MODE**. Now fails closed: a configured, matching token is required, and the error points the user at the bootstrap command.

## Security model (stated honestly)

The token is a coordination / accidental-self-auth gate, **not** a hard boundary on a single-user host: a same-user agent can read or rewrite the file. True enforcement still depends on the external harness classifier (or a multi-user / file-permission setup). The bootstrap command's output and the code comments say this plainly rather than implying macf enforces human-origination.

## Migration note

Hosts that currently rely on the absent-file fail-open to activate AUTO_MODE will need to run `macf_tools agent init-auth-token` once. This is the intended hardening.

## Tests

9 new tests (fail-closed paths, matching/mismatched token, bootstrap write / idempotency / `--force` key-preservation, end-to-end roundtrip) + existing cycles tests — 17 passed.

Closes #115