### PR TITLE
task start: stale-resume banner + cycle in the tree marker

### DIFF
--- a/framework/commands/maceff/task/start.md
+++ b/framework/commands/maceff/task/start.md
@@ -54,6 +54,7 @@ After reading policies, you should be able to answer:
 14. **What note-taking discipline does the policy require during task execution?** When should notes be added?
 15. **What types of developments warrant task notes?** What distinguishes significant events from routine steps?
 16. **How do task notes integrate with the task lifecycle?** What is their relationship to completion reports?
+17. **What does the policy require when resuming work last touched in an earlier cycle?** What signal marks this case, and what must precede execution before continuing?
 
 ---
 

--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -83,6 +83,7 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 **5 Mandatory Reading Discipline**
 - When must I read CA references?
 - How does MTMD enforce this?
+- What must precede resuming work put down in an earlier cycle?
 - What note-taking discipline does the policy require during task execution?
 - When should I add notes to tasks?
 - What developments warrant task notes vs routine steps?
@@ -678,6 +679,20 @@ macf_tools task archive #67   # → archived (with cascade)
 3. On completion → `macf_tools task complete #67 --report "..."`
 
 This is not optional - it's the **only way** the user maintains awareness of active work.
+
+### 5.3.1 Resuming Stale Work (Cross-Cycle)
+
+Work put down for one or more cycles loses its live working context to compaction. The task notes are the recovery surface, but nothing forces you to actually re-read them before diving back in.
+
+`macf_tools task start #N` detects the **stale-resume** case — the task's most recent activity was in an earlier cycle than the current one, and it is not complete — and responds even when the task is already `in_progress` (a task left active across a cycle boundary still counts). On a stale resume the command:
+
+1. **Bumps the stamp** — appends a `resumed via CLI (stale-resume from Cycle N)` update carrying a fresh breadcrumb, so the task's displayed date/cycle reflects the resumption (see §9 tree display).
+2. **Prints a resume banner** — which cycle the task was last worked, how long ago, and the current cycle.
+3. **Prompts the resume ritual** — read the full history (`task get #N`), re-read every note in the update stream plus any `plan_ca_ref` it references, and **narrate your understanding of where things stand and the next step to the user before executing.**
+
+A same-cycle re-start of an already-active task stays a plain no-op — no banner, no ritual.
+
+**Obligation**: when the banner fires, perform the ritual. Do not resume mechanically off the compaction summary alone. The narration is the evidence you re-oriented; skipping it is the stale-resume anti-pattern.
 
 ### 5.4 Note-Taking Discipline During Task Execution
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3924,19 +3924,29 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                 return text
             return text[:max_len-3] + "..."
 
+        def get_last_update_breadcrumb(task):
+            """Breadcrumb of the task's most recent activity (last update, else creation)."""
+            if not task.mtmd or not task.mtmd.updates:
+                return task.mtmd.creation_breadcrumb if task.mtmd else None
+            return task.mtmd.updates[-1].breadcrumb
+
         def get_last_update_timestamp(task):
             """Extract Unix timestamp from last update's breadcrumb t_ field."""
-            if not task.mtmd or not task.mtmd.updates:
-                # Fall back to creation_breadcrumb if no updates
-                bc = task.mtmd.creation_breadcrumb if task.mtmd else None
-            else:
-                # Get last update's breadcrumb
-                bc = task.mtmd.updates[-1].breadcrumb
+            bc = get_last_update_breadcrumb(task)
             if not bc:
                 return None
             # Extract t_ timestamp from breadcrumb (format: s_.../c_.../g_.../p_.../t_XXXXXXXX)
             import re
             match = re.search(r't_(\d+)', bc)
+            return int(match.group(1)) if match else None
+
+        def get_last_update_cycle(task):
+            """Extract the cycle number from the last-activity breadcrumb (c_N)."""
+            bc = get_last_update_breadcrumb(task)
+            if not bc:
+                return None
+            import re
+            match = re.search(r'/c_(\d+)', bc) or re.search(r'(?:^|/)C(\d+)', bc)
             return int(match.group(1)) if match else None
 
         def format_task_suffix(task):
@@ -3955,6 +3965,10 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
             if ts:
                 dt = datetime.fromtimestamp(ts)
                 time_str = dt.strftime("%m/%d %H:%M")
+                # Append the cycle the timestamp belongs to, e.g. "07/17 16:20 C25"
+                cyc = get_last_update_cycle(task)
+                if cyc is not None:
+                    time_str = f"{time_str} C{cyc}"
                 # Color based on status
                 if task.status == "in_progress":
                     time_str = f"{ANSI_RED}{time_str}{ANSI_RESET}"
@@ -5651,6 +5665,41 @@ def cmd_task_grant_delete(args: argparse.Namespace) -> int:
     return 0
 
 
+def _stale_resume_info(task):
+    """Detect resuming work that was put down in an earlier cycle.
+
+    Returns (last_cycle, last_ts, current_cycle) if the task's most recent
+    activity was in a cycle before the current one and the task isn't complete;
+    otherwise None. Must be called BEFORE appending the new start update, so the
+    "last activity" reflects the prior work, not this resume.
+    """
+    from .utils.breadcrumbs import get_breadcrumb, parse_breadcrumb
+    if not task.mtmd or task.status == "completed":
+        return None
+    bc = None
+    if task.mtmd.updates:
+        bc = task.mtmd.updates[-1].breadcrumb
+    bc = bc or getattr(task.mtmd, "started_breadcrumb", None) or task.mtmd.creation_breadcrumb
+    prev = parse_breadcrumb(bc or "") or {}
+    cur = parse_breadcrumb(get_breadcrumb() or "") or {}
+    last_cycle, cur_cycle = prev.get("cycle"), cur.get("cycle")
+    if last_cycle is None or cur_cycle is None or last_cycle >= cur_cycle:
+        return None
+    return (last_cycle, prev.get("timestamp"), cur_cycle)
+
+
+def _print_stale_resume_banner(task_id, last_cycle, last_ts, cur_cycle):
+    """Terminal banner prompting the read-notes-and-narrate resume ritual."""
+    from .utils.temporal import format_duration
+    import time as _time
+    elapsed = f", {format_duration(_time.time() - last_ts)} ago" if last_ts else ""
+    print(f"🔁 Resuming #{task_id} — last worked in Cycle {last_cycle}{elapsed} (now Cycle {cur_cycle}).")
+    print(f"   Put down across cycles; the live working context was lost to compaction. Before continuing:")
+    print(f"   • Read the full history:  macf_tools task get {task_id}")
+    print(f"   • Re-read every note in the update stream, plus any plan/CA it references.")
+    print(f"   • Narrate your understanding of where things stand and the next step to the user before executing.")
+
+
 def cmd_task_start(args: argparse.Namespace) -> int:
     """Start work on a task - sets status to in_progress with started_breadcrumb."""
     from .task import TaskReader, update_task_file
@@ -5675,18 +5724,43 @@ def cmd_task_start(args: argparse.Namespace) -> int:
         print(f"❌ Task #{task_id} not found")
         return 1
 
-    if task.status == "in_progress":
-        print(f"⚠️  Task #{task_id} is already in_progress")
-        return 0
+    # Detect resuming work put down in an earlier cycle BEFORE mutating the task,
+    # so "last activity" reflects the prior work rather than this resume.
+    stale = _stale_resume_info(task)
 
     breadcrumb = get_breadcrumb()
+
+    if task.status == "in_progress":
+        # Already active. A same-cycle re-start is a no-op, but a stale resume
+        # (last worked an earlier cycle) still bumps the stamp + prompts the
+        # read-notes-and-narrate ritual -- the case task start otherwise misses.
+        if not stale:
+            print(f"⚠️  Task #{task_id} is already in_progress")
+            return 0
+        last_cycle, last_ts, cur_cycle = stale
+        if task.mtmd:
+            from .task.models import MacfTaskUpdate
+            import copy
+            new_mtmd = copy.deepcopy(task.mtmd)
+            new_mtmd.started_breadcrumb = breadcrumb
+            new_mtmd.updates.append(MacfTaskUpdate(
+                breadcrumb=breadcrumb,
+                description=f"Task resumed via CLI (stale-resume from Cycle {last_cycle})",
+                agent="PA"))
+            update_task_file(task_id, {"description": task.description_with_updated_mtmd(new_mtmd)})
+        append_event("task_resumed", {
+            "task_id": str(task_id), "from_cycle": last_cycle, "breadcrumb": breadcrumb})
+        _print_stale_resume_banner(task_id, last_cycle, last_ts, cur_cycle)
+        return 0
 
     if task.mtmd:
         from .task.models import MacfTaskUpdate
         import copy
         new_mtmd = copy.deepcopy(task.mtmd)
         new_mtmd.started_breadcrumb = breadcrumb
-        new_mtmd.updates.append(MacfTaskUpdate(breadcrumb=breadcrumb, description="Task started via CLI", agent="PA"))
+        desc = (f"Task resumed via CLI (stale-resume from Cycle {stale[0]})"
+                if stale else "Task started via CLI")
+        new_mtmd.updates.append(MacfTaskUpdate(breadcrumb=breadcrumb, description=desc, agent="PA"))
         new_description = task.description_with_updated_mtmd(new_mtmd)
         update_task_file(task_id, {"status": "in_progress", "description": new_description})
     else:
@@ -5723,6 +5797,8 @@ def cmd_task_start(args: argparse.Namespace) -> int:
     print(f"   Breadcrumb: {breadcrumb}")
     if injected_policies:
         print(f"   Auto-injected policies: {injected_policies}")
+    if stale:
+        _print_stale_resume_banner(task_id, stale[0], stale[1], stale[2])
     return 0
 
 

--- a/macf/tests/test_task_start_stale_resume.py
+++ b/macf/tests/test_task_start_stale_resume.py
@@ -1,0 +1,134 @@
+"""Tests for the stale-resume behavior on `task start`.
+
+When a task last worked in an earlier cycle is resumed (whether it is still
+`pending` or was left `in_progress` across cycles), `task start` bumps the
+stamp with a resume update and prints a banner prompting the read-notes-and-
+narrate ritual. A same-cycle re-start of an already-active task stays a no-op.
+
+Covers:
+  _stale_resume_info   — the pure detector (cycle-delta + not-complete)
+  cmd_task_start       — banner emission on stale resume vs fresh start
+
+Patch targets (mirrors test_task_mutation_verbs.py conventions):
+  TaskReader          — macf.task.TaskReader          (local import in cmd)
+  update_task_file    — macf.task.update_task_file     (local import in cmd)
+  unhide_task_file    — macf.task.reader.unhide_task_file
+  get_breadcrumb      — macf.utils.breadcrumbs.get_breadcrumb (local import)
+  append_event        — macf.cli.append_event          (top-level import in cli.py)
+
+Fixtures use generic placeholders only (no project-specific names).
+"""
+import argparse
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from macf.cli import _stale_resume_info, cmd_task_start
+
+
+_PATCH_TASK_READER = "macf.task.TaskReader"
+_PATCH_UPDATE = "macf.task.update_task_file"
+_PATCH_UNHIDE = "macf.task.reader.unhide_task_file"
+_PATCH_BREADCRUMB = "macf.utils.breadcrumbs.get_breadcrumb"
+_PATCH_APPEND_EVENT = "macf.cli.append_event"
+
+
+def _bc(cycle, ts):
+    # minimal enhanced breadcrumb with the cycle + timestamp fields the detector reads
+    return f"s_abc12345/c_{cycle}/p_def67890/t_{ts}"
+
+
+def _fake_task(status="in_progress", last_cycle=23, last_ts=1000,
+               created_cycle=20, created_ts=500, with_updates=True):
+    """A task whose most recent activity sits in `last_cycle`."""
+    updates = []
+    if with_updates:
+        updates = [SimpleNamespace(breadcrumb=_bc(last_cycle, last_ts))]
+    mtmd = SimpleNamespace(
+        updates=updates,
+        started_breadcrumb=None,
+        creation_breadcrumb=_bc(created_cycle, created_ts),
+        task_type=None,
+        plan_ca_ref=None,
+    )
+    task = MagicMock()
+    task.status = status
+    task.mtmd = mtmd
+    task.description_with_updated_mtmd.return_value = "<!-- updated description -->"
+    return task
+
+
+class TestStaleResumeInfo:
+    def test_prior_cycle_is_stale(self):
+        task = _fake_task(status="in_progress", last_cycle=23, last_ts=1000)
+        with patch(_PATCH_BREADCRUMB, return_value=_bc(25, 2000)):
+            assert _stale_resume_info(task) == (23, 1000, 25)
+
+    def test_same_cycle_is_not_stale(self):
+        task = _fake_task(status="in_progress", last_cycle=25, last_ts=1900)
+        with patch(_PATCH_BREADCRUMB, return_value=_bc(25, 2000)):
+            assert _stale_resume_info(task) is None
+
+    def test_completed_is_never_stale(self):
+        task = _fake_task(status="completed", last_cycle=23)
+        with patch(_PATCH_BREADCRUMB, return_value=_bc(25, 2000)):
+            assert _stale_resume_info(task) is None
+
+    def test_no_mtmd_is_not_stale(self):
+        task = MagicMock()
+        task.status = "pending"
+        task.mtmd = None
+        with patch(_PATCH_BREADCRUMB, return_value=_bc(25, 2000)):
+            assert _stale_resume_info(task) is None
+
+    def test_falls_back_to_creation_when_no_updates(self):
+        task = _fake_task(status="pending", created_cycle=20, created_ts=500,
+                          with_updates=False)
+        with patch(_PATCH_BREADCRUMB, return_value=_bc(25, 2000)):
+            assert _stale_resume_info(task) == (20, 500, 25)
+
+
+class TestStartBanner:
+    def _run(self, task, cur_bc):
+        reader = MagicMock()
+        reader.session_path = "/tmp/session"
+        reader.read_task.return_value = task
+        args = argparse.Namespace(task_id="10")
+        with patch(_PATCH_TASK_READER, return_value=reader), \
+             patch(_PATCH_UPDATE) as upd, \
+             patch(_PATCH_UNHIDE), \
+             patch(_PATCH_APPEND_EVENT), \
+             patch(_PATCH_BREADCRUMB, return_value=cur_bc):
+            rc = cmd_task_start(args)
+        return rc, upd
+
+    def test_stale_in_progress_prints_banner_and_bumps(self, capsys):
+        task = _fake_task(status="in_progress", last_cycle=23, last_ts=1000)
+        # capture the resume update appended to the deep-copied mtmd before persist
+        appended = []
+        with patch("macf.task.models.MacfTaskUpdate",
+                   side_effect=lambda **kw: appended.append(kw) or MagicMock(**kw)):
+            rc, upd = self._run(task, _bc(25, 2000))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "🔁 Resuming #10" in out
+        assert "Cycle 23" in out
+        assert "narrate" in out.lower()
+        # bumped: a resume update was appended and the task file was re-persisted
+        assert upd.called
+        assert any("resumed" in kw["description"].lower() for kw in appended)
+
+    def test_same_cycle_in_progress_is_plain_noop(self, capsys):
+        task = _fake_task(status="in_progress", last_cycle=25, last_ts=1900)
+        rc, _ = self._run(task, _bc(25, 2000))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "already in_progress" in out
+        assert "🔁 Resuming" not in out
+
+    def test_fresh_pending_starts_without_banner(self, capsys):
+        task = _fake_task(status="pending", last_cycle=25, last_ts=1900)
+        rc, _ = self._run(task, _bc(25, 2000))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "started" in out
+        assert "🔁 Resuming" not in out


### PR DESCRIPTION
## What

Two related changes that surface cross-cycle context on tasks, so work put down for a while is resumed deliberately rather than mechanically.

**Stale-resume banner on `task start`.** When a task was last worked in an earlier cycle and isn't complete — including tasks left `in_progress` across a cycle boundary, which `task start` previously skipped with a bare "already in_progress" — the command now:
- bumps the stamp with a `resumed via CLI (stale-resume from Cycle N)` update,
- prints which cycle it was last worked and how long ago,
- prompts the read-notes-and-narrate ritual (read full history + notes, narrate understanding to the user before executing).

A same-cycle re-start stays a plain no-op.

**Cycle in the tree marker.** The `%m/%d %H:%M` marker gains the cycle the timestamp belongs to, e.g. `07/17 16:20 C25`, from the same last-activity breadcrumb. Notes already bump it (they append current-breadcrumb updates).

## Policy as API

Behavioral content lives in the policy: `task_management` §5.3.1 describes the resume ritual, with a discovery question in the §5 CEP nav guide. The `maceff/task/start` command gets a single timeless extractive question (#17) pointing at it — no embedded steps.

## Tests

`macf/tests/test_task_start_stale_resume.py` (8 tests): the `_stale_resume_info` detector across prior-cycle / same-cycle / completed / no-mtmd / creation-fallback, plus banner emission vs plain start. Full suite green (868 passed).

## Files
- `macf/src/macf/cli.py` — `_stale_resume_info`, `_print_stale_resume_banner`, `cmd_task_start` rewire, `get_last_update_cycle` + marker
- `framework/policies/base/development/task_management.md` — §5.3.1 + nav question
- `framework/commands/maceff/task/start.md` — extractive question #17
- `macf/tests/test_task_start_stale_resume.py` — new