### PR TITLE
Optional project-scoped home task store (divorce from ~/.claude/tasks)

### DIFF
--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -12,7 +12,11 @@
 
 Task management policy governs the use of Claude Code native Task* tools (TaskCreate, TaskUpdate, TaskGet, TaskList) with MacfTaskMetaData (MTMD) enhancement. Tasks provide persistent, structured work tracking with forensic breadcrumbs, hierarchy support, and lifecycle management.
 
-**Core Insight**: Tasks are persistent JSON files on disk (`~/.claude/tasks/{session_uuid}/*.json`), not ephemeral internal state. This changes everything about recovery, backup, and lifecycle management.
+**Core Insight**: Tasks are persistent JSON files on disk, not ephemeral internal state. This changes everything about recovery, backup, and lifecycle management.
+
+**Two storage backends** (see §0.1):
+- **Legacy (default)**: CC's `~/.claude/tasks/{session_uuid}/*.json`. Session-scoped — a new session UUID (continue / rewind / child) gets a *copy* that then diverges, and CC deletes all completed task files when the last open task completes. Fragile for long-lived history.
+- **Home store (opt-in)**: a single project-scoped directory under the agent home (`{agent_home}/agent/public/tasks/`, default), alongside the other consciousness artifacts. Set `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (or `MACF_TASK_STORE_DIR`). Not keyed by session UUID, so it survives fork/rewind and CC never touches it. This is the recommended backend for any agent that wants durable task history.
 
 **Supersedes**: `todo_hygiene.md` (DEPRECATED)
 
@@ -135,22 +139,21 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 
 ### 0.1 File Location
 
-Claude Code stores native task JSON files at:
-```
-~/.claude/tasks/{session_uuid}/*.json
-```
+Each task is stored as `{id}.json` (e.g., `1.json`, `67.json`) in the active store:
 
-Each task is stored as `{id}.json` (e.g., `1.json`, `67.json`).
+- **Legacy**: `~/.claude/tasks/{session_uuid}/{id}.json` — one directory per CC session.
+- **Home store**: `{agent_home}/agent/public/tasks/{id}.json` — one project-scoped directory, no session UUID. Activated by `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (path overridable; env `MACF_TASK_STORE_DIR` wins). The `TaskReader` resolves this via a `HOME_STORE_UUID` sentinel; all create/read/archive/CLI paths inherit it through `session_path`. Completed-task hiding (`.{id}.json`) is a CC-scanner concern and is skipped here, so the home store stays plain `{id}.json`.
 
 ### 0.2 Persistence Behavior
 
-| Event | Task Persistence | Confidence |
-|-------|------------------|------------|
-| Session restart | ✅ Tasks survive | HIGH |
-| Compaction | ⚠️ Likely survives | MEDIUM (needs validation) |
-| New session UUID | ❓ May not port | LOW (needs experiment) |
+| Event | Legacy store | Home store |
+|-------|--------------|------------|
+| Session restart | ✅ Survives | ✅ Survives |
+| Compaction | ✅ Survives (files on disk) | ✅ Survives |
+| New session UUID (continue/rewind/child) | ⚠️ Forks: CC copies the DB into the new UUID dir, then the copies diverge | ✅ Single store, no fork |
+| Last open task completed | ❌ CC deletes all completed task files | ✅ Nothing deleted |
 
-**Epistemological Honesty**: We have not empirically validated what creates new session UUIDs or whether tasks port across. Compaction behavior may have changed. See §12 for future experiments.
+**Empirically established (c25)**: a new session UUID does *not* cleanly port tasks — CC seeds the new directory with a copy and the databases then diverge (observed: one task present in only 2 of 7 sibling project session dirs). The macf `TaskReader` and CC's native tools also resolve the session directory differently (newest-mtime project dir vs literal `CLAUDE_CODE_SESSION_ID`), so they can read different DBs after a fork. The home store removes both failure modes by not keying storage on the session at all. Use `macf_tools task reconcile` to union-merge divergent legacy DBs into the home store (newest-mtime-per-id wins).
 
 ### 0.3 ID Assignment
 

--- a/framework/templates/settings.permissions.json
+++ b/framework/templates/settings.permissions.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "MACF Task Permissions Template - merged by hooks install",
+  "_comment": "MACF Task Permissions Template - merged additively into settings by hooks install",
   "permissions": {
     "allow": [
       "Bash(macf_tools mode:*)"
@@ -7,6 +7,12 @@
     "ask": [
       "Bash(macf_tools task grant-update:*)",
       "Bash(macf_tools task grant-delete:*)"
+    ],
+    "deny": [
+      "TaskCreate",
+      "TaskUpdate",
+      "TaskGet",
+      "TaskList"
     ]
   }
 }

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -5870,6 +5870,34 @@ def cmd_task_pause(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_task_reconcile(args: argparse.Namespace) -> int:
+    """Union-merge forked CC per-session task DBs into the home store.
+
+    Dry-run by default; pass --apply to write. Newest-mtime-per-id wins, so no
+    task ever worked on is dropped.
+    """
+    from .task.reconcile import reconcile
+
+    try:
+        report = reconcile(apply=args.apply)
+    except RuntimeError as e:
+        print(f"❌ {e}")
+        return 1
+
+    print(f"Sources ({len(report['sources'])} project session dirs):")
+    for name in report["sources"]:
+        print(f"  {name}")
+    print(f"Merged {report['merged_count']} unique task ids -> {report['dest']}")
+    if report["missing_status"]:
+        print(f"⚠️  {len(report['missing_status'])} task(s) missing a status field: "
+              f"{', '.join(report['missing_status'])}")
+    if report["applied"]:
+        print(f"✅ Wrote {report['merged_count']} task files to the home store.")
+    else:
+        print("DRY RUN — re-run with --apply to write.")
+    return 0
+
+
 def cmd_task_note(args: argparse.Namespace) -> int:
     """Add a note to a task's updates list (type='note').
 
@@ -6864,11 +6892,12 @@ def cmd_task_complete(args: argparse.Namespace) -> int:
     })
 
     if success:
-        # Hide completed task file from CC's native scanner (dot-prefix)
-        from .task.reader import hide_task_file
+        # Hide completed task file from CC's native scanner (dot-prefix).
+        # No-op in the home store, which CC never scans — report accordingly.
+        from .task.reader import hide_task_file, _is_cc_session_dir
         if reader.session_path:
-            hidden = hide_task_file(reader.session_path, str(task_id))
-            if hidden:
+            hide_task_file(reader.session_path, str(task_id))
+            if _is_cc_session_dir(reader.session_path):
                 print(f"   📁 Hidden from CC scanner (.{task_id}.json)")
 
         # Emit task lifecycle event for downstream hooks and proxy integration
@@ -8127,6 +8156,14 @@ def _build_parser() -> argparse.ArgumentParser:
     tree_archive_group.add_argument("--all", action="store_true", dest="show_all",
                                     help="show all tasks including archived (default hides archived)")
     task_tree_parser.set_defaults(func=cmd_task_tree)
+
+    # task reconcile
+    task_reconcile_parser = task_sub.add_parser(
+        "reconcile",
+        help="union-merge forked CC per-session task DBs into the home store")
+    task_reconcile_parser.add_argument("--apply", action="store_true",
+                                       help="write the merge (default: dry-run report)")
+    task_reconcile_parser.set_defaults(func=cmd_task_reconcile)
 
     # task delete
     task_delete_parser = task_sub.add_parser("delete", help="delete task(s) (HIGH protection)")

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -356,6 +356,19 @@ def _create_task_file(
         "blockedBy": blocked_by or []
     }
 
+    # Collision guard: never silently overwrite an existing task. If a
+    # concurrent create raced us to this id (or the id was miscomputed), refuse
+    # rather than clobber. True atomic id allocation would hold a lock across
+    # _get_next_task_id + this write; single-active-session makes that rare, so
+    # this guard is the safety net that turns a silent data loss into an error.
+    from .reader import resolve_task_file
+    existing = resolve_task_file(reader.session_path, str(task_id)) if reader.session_path.exists() else None
+    if existing is not None:
+        raise FileExistsError(
+            f"Task #{task_id} already exists at {existing}. Refusing to overwrite "
+            f"(possible concurrent create or stale id). Re-run to allocate a fresh id."
+        )
+
     # Use protection context manager for directory operations
     # This temporarily unprotects if needed, then re-protects after
     with _unprotect_for_creation(reader.session_path):

--- a/macf/src/macf/task/reader.py
+++ b/macf/src/macf/task/reader.py
@@ -42,14 +42,69 @@ class TaskReader:
         """Tasks directory (may be overridden by MACF_TASKS_DIR env var)."""
         return self._get_tasks_dir()
 
+    # Sentinel session_uuid meaning "resolve to the project-scoped home store
+    # instead of a CC per-session directory". See session_path / _resolve_home_store.
+    HOME_STORE_UUID = "home"
+
+    @classmethod
+    def _load_task_store_config(cls) -> tuple:
+        """Read the task_store block from {agent_home}/.maceff/config.json.
+
+        Returns:
+            (mode, rel_path) where mode is "home" or "legacy" and rel_path is the
+            store location relative to agent_home (default "agent/public/tasks").
+            Defaults to ("legacy", ...) so unconfigured agents keep CC-session storage.
+        """
+        try:
+            from ..utils.paths import find_agent_home
+            config_file = find_agent_home() / ".maceff" / "config.json"
+            if config_file.exists():
+                data = json.loads(config_file.read_text())
+                ts = data.get("task_store", {}) or {}
+                mode = ts.get("mode", "legacy")
+                rel = ts.get("path", "agent/public/tasks")
+                return mode, rel
+        except (OSError, ValueError) as e:
+            print(f"⚠️ MACF: task_store config read failed: {e}", file=sys.stderr)
+        return "legacy", "agent/public/tasks"
+
+    @classmethod
+    def _resolve_home_store(cls) -> Optional[Path]:
+        """Resolve the project-scoped home task store directory, or None for legacy.
+
+        Priority:
+        1. MACF_TASK_STORE_DIR env var (absolute path) - explicit override.
+        2. .maceff/config.json task_store.mode == "home" -> {agent_home}/{rel_path}.
+        3. None - legacy CC per-session storage (~/.claude/tasks/{session_uuid}/).
+
+        The home store is a single directory holding {id}.json files, NOT keyed by
+        CC session UUID, so it survives session fork/rewind and CC's completed-task
+        deletion.
+        """
+        env_dir = os.environ.get("MACF_TASK_STORE_DIR")
+        if env_dir:
+            return Path(env_dir)
+        mode, rel = cls._load_task_store_config()
+        if mode == "home":
+            from ..utils.paths import find_agent_home
+            return find_agent_home() / rel
+        return None
+
     def __init__(self, session_uuid: Optional[str] = None):
         """
-        Initialize reader for a specific session or current session.
+        Initialize reader for a specific session, the home store, or current session.
 
         Args:
-            session_uuid: Session UUID to read from. If None, auto-detect current session.
+            session_uuid: Session UUID to read from. If None, resolve to the home
+                store when configured (session_uuid becomes the HOME_STORE_UUID
+                sentinel), otherwise auto-detect the current CC session. An explicit
+                UUID always forces legacy per-session reads (used by migration and
+                cross-session tooling).
         """
-        self.session_uuid = session_uuid or self._detect_current_session()
+        if session_uuid is None and self._resolve_home_store() is not None:
+            self.session_uuid = self.HOME_STORE_UUID
+        else:
+            self.session_uuid = session_uuid or self._detect_current_session()
 
     @classmethod
     def _get_project_sessions(cls) -> Set[str]:
@@ -136,7 +191,14 @@ class TaskReader:
 
     @property
     def session_path(self) -> Optional[Path]:
-        """Path to current session's task folder."""
+        """Path to the directory holding this store's {id}.json task files.
+
+        Returns the project-scoped home store when session_uuid is the
+        HOME_STORE_UUID sentinel; otherwise the legacy CC per-session folder
+        ~/.claude/tasks/{session_uuid}/.
+        """
+        if self.session_uuid == self.HOME_STORE_UUID:
+            return self._resolve_home_store()
         if not self.session_uuid:
             return None
         return self.tasks_dir / self.session_uuid
@@ -266,12 +328,29 @@ def _protect_dir(dir_path: Path):
     os.chmod(dir_path, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)  # 555
 
 
+def _is_cc_session_dir(session_path: Path) -> bool:
+    """True only when session_path lives under CC's ~/.claude/tasks/ tree.
+
+    Hiding completed tasks as .{id}.json exists solely to keep them out of CC's
+    native scanner. The project-scoped home store is never scanned by CC, so
+    hide/unhide are no-ops there and tasks stay as plain {id}.json.
+    """
+    try:
+        cc_root = (Path.home() / ".claude" / "tasks").resolve()
+        return cc_root in session_path.resolve().parents
+    except (OSError, ValueError):
+        return False
+
+
 def hide_task_file(session_path: Path, task_id: str) -> bool:
     """Rename {id}.json -> .{id}.json to hide from CC's native scanner.
 
-    Idempotent: no-op if already hidden or file doesn't exist.
-    Handles chmod 555 directory protection.
+    Idempotent: no-op if already hidden or file doesn't exist. No-op success for
+    a non-CC store (the home store keeps plain {id}.json). Handles chmod 555
+    directory protection.
     """
+    if not _is_cc_session_dir(session_path):
+        return True  # home store: nothing to hide from
     visible = session_path / f"{task_id}.json"
     hidden = session_path / f".{task_id}.json"
 
@@ -296,9 +375,11 @@ def hide_task_file(session_path: Path, task_id: str) -> bool:
 def unhide_task_file(session_path: Path, task_id: str) -> bool:
     """Rename .{id}.json -> {id}.json to show to CC's native scanner.
 
-    Idempotent: no-op if already visible or file doesn't exist.
-    Handles chmod 555 directory protection.
+    Idempotent: no-op if already visible or file doesn't exist. No-op success for
+    a non-CC store (the home store never hides). Handles chmod 555 protection.
     """
+    if not _is_cc_session_dir(session_path):
+        return True  # home store: files are always visible
     hidden = session_path / f".{task_id}.json"
     visible = session_path / f"{task_id}.json"
 

--- a/macf/src/macf/task/reader.py
+++ b/macf/src/macf/task/reader.py
@@ -84,6 +84,11 @@ class TaskReader:
         env_dir = os.environ.get("MACF_TASK_STORE_DIR")
         if env_dir:
             return Path(env_dir)
+        # MACF_TASKS_DIR is the legacy per-session isolation override (tests, nested
+        # dirs). When it is set, stay on the legacy path and do NOT consult the agent
+        # home config — otherwise an isolated env would leak into the real home store.
+        if os.environ.get("MACF_TASKS_DIR"):
+            return None
         mode, rel = cls._load_task_store_config()
         if mode == "home":
             from ..utils.paths import find_agent_home
@@ -337,8 +342,8 @@ def _is_cc_session_dir(session_path: Path) -> bool:
     """
     try:
         cc_root = (Path.home() / ".claude" / "tasks").resolve()
-        return cc_root in session_path.resolve().parents
-    except (OSError, ValueError):
+        return cc_root in Path(session_path).resolve().parents
+    except (OSError, ValueError, TypeError):
         return False
 
 

--- a/macf/src/macf/task/reconcile.py
+++ b/macf/src/macf/task/reconcile.py
@@ -1,0 +1,93 @@
+"""Reconcile forked CC per-session task DBs into the project-scoped home store.
+
+Claude Code stores tasks at ~/.claude/tasks/{session_uuid}/ and copies the whole
+set into a new directory whenever a session forks (continue / rewind / child).
+The copies then diverge. This merges every project-scoped session directory into
+the configured home store using newest-mtime-per-id, so no task that was ever
+worked on is dropped. Completed tasks keep their status (it lives in the JSON);
+everything lands as plain {id}.json.
+"""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Optional, Dict, List, Any
+
+from .reader import TaskReader
+from ..utils.paths import find_project_root, encode_cc_project_path
+
+
+def _project_session_dirs() -> List[Path]:
+    """CC task directories whose UUID has a transcript JSONL for this project."""
+    tasks_root = Path.home() / ".claude" / "tasks"
+    if not tasks_root.exists():
+        return []
+    encoded = encode_cc_project_path(str(find_project_root()))
+    projects_dir = Path.home() / ".claude" / "projects" / encoded
+    project_uuids = {f.stem for f in projects_dir.glob("*.jsonl")} if projects_dir.exists() else set()
+    dirs = [d for d in tasks_root.iterdir()
+            if d.is_dir() and d.name in project_uuids and any(d.glob("*.json"))]
+    dirs.sort(key=lambda d: d.stat().st_mtime, reverse=True)
+    return dirs
+
+
+def reconcile(apply: bool = False, dest: Optional[Path] = None) -> Dict[str, Any]:
+    """Union-merge project session task DBs into the home store.
+
+    Args:
+        apply: when False (default), report only; when True, write the merged files.
+        dest: override destination store; defaults to the configured home store.
+
+    Returns:
+        A report dict: sources, merged id->(status, source_uuid), missing-status ids,
+        destination, and whether it was applied.
+    """
+    if dest is None:
+        dest = TaskReader._resolve_home_store()
+    if dest is None:
+        raise RuntimeError(
+            "No home store configured. Set task_store.mode=home in "
+            "{agent_home}/.maceff/config.json or MACF_TASK_STORE_DIR."
+        )
+
+    sources = _project_session_dirs()
+
+    # id -> (mtime, path), scanning visible and CC-hidden files
+    best: Dict[str, Any] = {}
+    for d in sources:
+        for f in list(d.glob("*.json")) + list(d.glob(".*.json")):
+            tid = f.stem.lstrip(".")
+            m = f.stat().st_mtime
+            if tid not in best or m > best[tid][0]:
+                best[tid] = (m, f)
+
+    merged = {}
+    missing_status = []
+    for tid, (_m, f) in best.items():
+        try:
+            data = json.loads(f.read_text())
+            status = data.get("status", "")
+        except (OSError, ValueError):
+            status = ""
+        merged[tid] = (status, f.parent.name)
+        if not status:
+            missing_status.append(tid)
+
+    report = {
+        "sources": [d.name for d in sources],
+        "merged_count": len(best),
+        "missing_status": sorted(missing_status),
+        "dest": str(dest),
+        "applied": False,
+    }
+
+    if not apply:
+        return report
+
+    dest.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest, 0o755)  # tolerate a prior chmod 555 protection
+    for tid, (_m, f) in best.items():
+        shutil.copy2(f, dest / f"{tid}.json")
+    report["applied"] = True
+    return report

--- a/macf/tests/test_permissions_template_merge.py
+++ b/macf/tests/test_permissions_template_merge.py
@@ -92,3 +92,23 @@ def test_update_settings_file_merges_ask_bucket_regression(tmp_path, monkeypatch
     ask = (data.get("permissions") or {}).get("ask") or []
     assert "Bash(macf_tools task grant-update:*)" in ask
     assert "Bash(macf_tools task grant-delete:*)" in ask
+
+
+def test_shipped_template_denies_native_task_tools():
+    """The shipped template must deny CC's native Task* tools so nothing writes
+    the per-session task dirs behind the project-scoped home store's back."""
+    root = find_maceff_root()
+    template = root / "framework" / "templates" / "settings.permissions.json"
+    deny = (_read(template).get("permissions") or {}).get("deny") or []
+    for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+        assert tool in deny, f"template must deny native {tool}"
+
+
+def test_update_settings_file_merges_deny_bucket(tmp_path, monkeypatch):
+    """A fresh settings file should gain the shipped deny entries after merge."""
+    monkeypatch.chdir(tmp_path)
+    settings_file = tmp_path / "settings.json"
+    _update_settings_file(settings_file, "python .claude/hooks")
+    deny = (_read(settings_file).get("permissions") or {}).get("deny") or []
+    for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+        assert tool in deny

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -1,0 +1,93 @@
+"""Tests for the project-scoped home task store backend.
+
+Covers store resolution (config mode, env overrides, MACF_TASKS_DIR isolation
+precedence), the hide/unhide no-op outside CC's tree, and the reconcile guard.
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+from macf.task.reader import (
+    TaskReader,
+    hide_task_file,
+    unhide_task_file,
+    _is_cc_session_dir,
+)
+from macf.task.reconcile import reconcile
+from macf.utils.paths import find_agent_home
+
+
+@pytest.fixture
+def home_agent(tmp_path, monkeypatch):
+    """An isolated agent home with task_store.mode=home configured."""
+    monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
+    monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
+    monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+    find_agent_home.cache_clear()
+    maceff = tmp_path / ".maceff"
+    maceff.mkdir()
+    (maceff / "config.json").write_text(json.dumps(
+        {"task_store": {"mode": "home", "path": "agent/public/tasks"}}))
+    yield tmp_path
+    find_agent_home.cache_clear()
+
+
+class TestHomeStoreResolution:
+    def test_home_mode_resolves_to_agent_home_store(self, home_agent):
+        reader = TaskReader()
+        assert reader.session_uuid == TaskReader.HOME_STORE_UUID
+        assert reader.session_path == home_agent / "agent" / "public" / "tasks"
+
+    def test_macf_tasks_dir_forces_legacy(self, home_agent, tmp_path, monkeypatch):
+        # The legacy isolation override must win over the home config, or an
+        # isolated env leaks into the real home store (the bug the suite caught).
+        iso = tmp_path / "iso_tasks"
+        iso.mkdir()
+        monkeypatch.setenv("MACF_TASKS_DIR", str(iso))
+        assert TaskReader._resolve_home_store() is None
+
+    def test_task_store_dir_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
+        store = tmp_path / "explicit_store"
+        monkeypatch.setenv("MACF_TASK_STORE_DIR", str(store))
+        assert TaskReader._resolve_home_store() == store
+
+    def test_unconfigured_agent_stays_legacy(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
+        monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))  # no config.json
+        find_agent_home.cache_clear()
+        assert TaskReader._resolve_home_store() is None
+        find_agent_home.cache_clear()
+
+
+class TestCcSessionDirDetection:
+    def test_accepts_str_and_path(self):
+        # Regression: hide/unhide pass a str; _is_cc_session_dir must not crash.
+        cc = Path.home() / ".claude" / "tasks" / "some-uuid"
+        assert _is_cc_session_dir(str(cc)) is True
+        assert _is_cc_session_dir(cc) is True
+
+    def test_home_store_is_not_a_cc_dir(self, tmp_path):
+        assert _is_cc_session_dir(tmp_path / "agent" / "public" / "tasks") is False
+
+
+class TestHideIsNoOpOutsideCc:
+    def test_hide_and_unhide_leave_home_store_visible(self, tmp_path):
+        store = tmp_path / "tasks"
+        store.mkdir()
+        task = store / "5.json"
+        task.write_text("{}")
+        assert hide_task_file(store, "5") is True
+        assert task.exists()  # not renamed to .5.json
+        assert not (store / ".5.json").exists()
+        assert unhide_task_file(store, "5") is True
+        assert task.exists()
+
+
+class TestReconcileGuard:
+    def test_raises_without_home_store(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MACF_TASKS_DIR", str(tmp_path))  # forces legacy -> no home
+        with pytest.raises(RuntimeError):
+            reconcile(apply=False)


### PR DESCRIPTION
## Problem

CC stores tasks at `~/.claude/tasks/{session_uuid}/`, one directory per session. A new session UUID (continue, rewind, child) gets a *copy* of the DB that then diverges, and CC deletes every completed task file when the last open task completes. Long-lived task history is fragile as a result. In practice this bit hard: a task ended up present in only two of seven sibling session dirs, and the macf reader and CC's native tools resolved *different* databases after the fork (newest-mtime project dir vs literal `CLAUDE_CODE_SESSION_ID`), so the same task id gave different answers depending on which tool you asked.

## What this does

Adds an opt-in, project-scoped **home store** backend. With `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (path overridable; env `MACF_TASK_STORE_DIR` wins), tasks live in a single directory under the agent home (`agent/public/tasks/` by default), alongside the other artifacts. It is not keyed by session UUID, so it survives fork/rewind and CC never touches it.

The default stays legacy, so existing installs are unchanged.

## How

- `TaskReader` resolves the home store via a `HOME_STORE_UUID` sentinel; create/read/archive/CLI all inherit it through `session_path`, so the change stays localized despite the many call sites.
- Completed-task hiding (`.{id}.json`) is a CC-scanner concern and is skipped outside `~/.claude/tasks/`, so the home store stays plain `{id}.json`.
- `create` refuses to overwrite an existing task id rather than clobber on an id race (the full atomic id-allocation lock is left for later; single-active-session makes a collision rare, and this turns the worst case into a loud error instead of silent loss).
- New `macf_tools task reconcile` union-merges divergent legacy session DBs into the home store (newest-mtime-per-id, dry-run by default, `--apply` to write).
- The install permissions template now denies the native `TaskCreate/TaskUpdate/TaskGet/TaskList` tools, so nothing writes CC's per-session dirs behind the home store's back. The installer already merges the deny bucket additively and idempotently.
- `task_management.md` updated: both backends documented, and the old "needs experiment" note on session-UUID porting replaced with the empirical finding.

## Testing

Trialed live end to end: legacy stays default when unconfigured; with `mode: home`, get/list/tree/create/complete all read and write the home store; a 144-task legacy set reconciled cleanly across four session dirs; completing the last open task deletes nothing; and completed tasks stay visible as `{id}.json`. The old `~/.claude/tasks/` dirs are left untouched, so reverting is just unsetting the config flag.