### PR TITLE
reconcile: overwrite read-only dest files instead of failing midway

### DIFF
--- a/macf/src/macf/task/reconcile.py
+++ b/macf/src/macf/task/reconcile.py
@@ -86,8 +86,14 @@ def reconcile(apply: bool = False, dest: Optional[Path] = None) -> Dict[str, Any
         return report
 
     dest.mkdir(parents=True, exist_ok=True)
-    os.chmod(dest, 0o755)  # tolerate a prior chmod 555 protection
+    os.chmod(dest, 0o755)  # tolerate a prior chmod 555 dir protection
     for tid, (_m, f) in best.items():
-        shutil.copy2(f, dest / f"{tid}.json")
+        target = dest / f"{tid}.json"
+        # Task files may be read-only (copied from CC's protected dirs); make the
+        # target writable before overwriting so a re-reconcile doesn't fail midway.
+        if target.exists():
+            os.chmod(target, 0o644)
+        shutil.copy2(f, target)
+        os.chmod(target, 0o644)
     report["applied"] = True
     return report

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -91,3 +91,27 @@ class TestReconcileGuard:
         monkeypatch.setenv("MACF_TASKS_DIR", str(tmp_path))  # forces legacy -> no home
         with pytest.raises(RuntimeError):
             reconcile(apply=False)
+
+
+class TestReconcileOverwritesReadOnly:
+    def test_reapply_over_readonly_dest(self, tmp_path, monkeypatch):
+        # Task files copied from CC's protected dirs are read-only; a second
+        # reconcile must still overwrite them instead of failing midway.
+        import os
+        import macf.task.reconcile as rec
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "5.json").write_text('{"id": "5", "status": "completed"}')
+        dest = tmp_path / "dest"
+        monkeypatch.setenv("MACF_TASK_STORE_DIR", str(dest))
+        monkeypatch.setattr(rec, "_project_session_dirs", lambda: [src])
+
+        reconcile(apply=True)
+        target = dest / "5.json"
+        assert target.exists()
+        os.chmod(target, 0o444)  # simulate a protected/read-only dest file
+
+        # Must not raise despite the read-only target.
+        report = reconcile(apply=True)
+        assert report["applied"] is True
+        assert target.read_text().strip().startswith("{")


### PR DESCRIPTION
Follow-up to #134.

`macf_tools task reconcile --apply` copies the newest version of each task into the home store. Task files copied from CC's protected session directories are read-only, so on a *second* reconcile `shutil.copy2` raised `PermissionError` on the first existing target and stopped partway through the merge, leaving it half-applied.

Fix: chmod each target writable before (and after) the copy, so re-reconcile is idempotent. Adds a test that reconciles twice over a read-only target.

Found while repairing a real store: a pre-#134 test run (before the `MACF_TASKS_DIR` isolation fix landed) had written into the production home store, and the cleanup re-reconcile surfaced this.