### PR TITLE
task tree --loop: watch the resolved store, not the legacy session root

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3819,6 +3819,27 @@ def cmd_task_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def get_tasks_mtime(tasks_dir) -> float:
+    """Get latest modification time of any task file in the store directory."""
+    try:
+        if not tasks_dir or not tasks_dir.exists():
+            return 0.0
+
+        # Both backends are flat dirs of {id}.json (+ hidden .{id}.json).
+        # Include the directory's own mtime so create/delete/hide renames
+        # are detected even though they don't touch file mtimes.
+        mtimes = [tasks_dir.stat().st_mtime]
+        for task_file in tasks_dir.glob("*.json"):
+            mtimes.append(task_file.stat().st_mtime)
+        for task_file in tasks_dir.glob(".*.json"):
+            mtimes.append(task_file.stat().st_mtime)
+
+        return max(mtimes)
+    except (OSError, IOError) as e:
+        print(f"⚠️ MACF: task mtime scan failed: {e}", file=sys.stderr)
+        return 0.0
+
+
 def cmd_task_tree(args: argparse.Namespace) -> int:
     """Display task hierarchy tree from a root task."""
     import time
@@ -4137,24 +4158,6 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
         return True
 
-    def get_tasks_mtime(tasks_dir: Path) -> float:
-        """Get latest modification time of any file in tasks directory."""
-        try:
-            if not tasks_dir.exists():
-                return 0.0
-
-            # Get mtime of all JSON files in session subdirectories
-            mtimes = []
-            for session_dir in tasks_dir.iterdir():
-                if session_dir.is_dir():
-                    for task_file in session_dir.glob("*.json"):
-                        mtimes.append(task_file.stat().st_mtime)
-
-            return max(mtimes) if mtimes else 0.0
-        except (OSError, IOError) as e:
-            print(f"⚠️ MACF: task mtime scan failed: {e}", file=sys.stderr)
-            return 0.0
-
     # Parse task ID (preserve string IDs like "000")
     # Both branches set root_id to task_id_str — leading-zero forms (like "000")
     # need string identity preserved; ordinary numeric IDs are also kept as strings
@@ -4168,8 +4171,10 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
     # Loop mode - monitor for changes
     if args.loop:
         reader = TaskReader()
-        tasks_dir = reader.tasks_dir
-        last_mtime = 0.0
+        # Watch the resolved store (home store or legacy session dir), not the
+        # legacy per-session root — the home store lives outside ~/.claude/tasks.
+        tasks_dir = reader.session_path
+        last_mtime = None  # sentinel: always render the first iteration
 
         # Brand the terminal window with the agent calling card so
         # multi-agent terminal layouts are distinguishable at a glance.
@@ -4187,7 +4192,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                 current_mtime = get_tasks_mtime(tasks_dir)
 
                 # Display tree if tasks changed or first iteration
-                if current_mtime != last_mtime:
+                if last_mtime is None or current_mtime != last_mtime:
                     # Clear screen using ANSI escape code (works on macOS/Linux)
                     print("\033[2J\033[H", end="")
 

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -115,3 +115,49 @@ class TestReconcileOverwritesReadOnly:
         report = reconcile(apply=True)
         assert report["applied"] is True
         assert target.read_text().strip().startswith("{")
+
+
+class TestLoopWatcherFlatStore:
+    """task tree --loop must detect changes in a flat store dir (#144)."""
+
+    def test_mtime_none_and_missing_dir(self, tmp_path):
+        from macf.cli import get_tasks_mtime
+        assert get_tasks_mtime(None) == 0.0
+        assert get_tasks_mtime(tmp_path / "nope") == 0.0
+
+    def test_mtime_sees_flat_store_files(self, tmp_path):
+        import os
+        from macf.cli import get_tasks_mtime
+        store = tmp_path / "tasks"
+        store.mkdir()
+        task = store / "7.json"
+        task.write_text("{}")
+        first = get_tasks_mtime(store)
+        assert first > 0.0
+        # A later write must move the watermark (flat glob, no session subdirs)
+        os.utime(task, (first + 10, first + 10))
+        assert get_tasks_mtime(store) > first
+
+    def test_mtime_sees_hidden_files_and_dir_changes(self, tmp_path):
+        import os
+        from macf.cli import get_tasks_mtime
+        store = tmp_path / "tasks"
+        store.mkdir()
+        hidden = store / ".8.json"
+        hidden.write_text("{}")
+        base = get_tasks_mtime(store)
+        assert base > 0.0
+        os.utime(hidden, (base + 10, base + 10))
+        assert get_tasks_mtime(store) > base
+        # Deleting a file bumps the dir mtime -> watermark changes even
+        # though no surviving file mtime moved.
+        before = get_tasks_mtime(store)
+        hidden.unlink()
+        os.utime(store, (before + 20, before + 20))
+        assert get_tasks_mtime(store) != before
+
+    def test_loop_watches_session_path_not_legacy_root(self, home_agent):
+        # The watcher dir must be the resolved store, not ~/.claude/tasks root.
+        reader = TaskReader()
+        assert reader.session_uuid == TaskReader.HOME_STORE_UUID
+        assert reader.session_path == home_agent / "agent" / "public" / "tasks"


### PR DESCRIPTION
Follow-up to #134/#135. The loop watcher was never updated for the home store: it watched the legacy ~/.claude/tasks root and scanned per-session subdirs, so with task_store.mode="home" it stared at the wrong directory in the wrong layout and never redrew - the parallel-window "task tree --loop" workflow silently went stale.

Fix:
- Watch reader.session_path (the resolved store for either backend; both are flat dirs) and glob *.json + hidden .*.json directly.
- Include the directory's own mtime in the watermark so hide/unhide renames and deletions trigger a redraw (they don't change file mtimes).
- Force the first render with a None sentinel; previously an empty store compared 0.0 == 0.0 and never drew at all.
- get_tasks_mtime extracted to module level for testability.

Sweep: the remaining per-session iterdir walkers (list_all_sessions, _detect_current_session, reconcile) are intentionally legacy-layout for migration and left alone.

Verification: 4 new tests in test_task_home_store.py; full suite 922 passed / 9 xfailed. Live smoke test: started --loop against a home store, touched a task file, observed the redraw within the 1 s poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)