### PR TITLE
create_sprint/play_time: let the finalize write overwrite its own provisional stub

### DIFF
--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -298,7 +298,8 @@ def _create_task_file(
     description: str,
     status: str = "pending",
     session_uuid: Optional[str] = None,
-    blocked_by: Optional[List[str]] = None
+    blocked_by: Optional[List[str]] = None,
+    overwrite: bool = False
 ) -> Path:
     """Create task JSON file directly.
 
@@ -306,6 +307,11 @@ def _create_task_file(
     - Temporarily unprotects directory if protected
     - Creates the task file
     - Re-protects directory (protection becomes default state)
+
+    overwrite=True finalizes a provisional stub the caller already reserved at
+    this id (the SPRINT/PLAY_TIME reserve-then-finalize pattern); it skips the
+    collision guard for that one write. Leave False everywhere else so a real
+    id race still turns into an error instead of silent clobber.
     """
     reader = TaskReader(session_uuid)
 
@@ -363,7 +369,7 @@ def _create_task_file(
     # this guard is the safety net that turns a silent data loss into an error.
     from .reader import resolve_task_file
     existing = resolve_task_file(reader.session_path, str(task_id)) if reader.session_path.exists() else None
-    if existing is not None:
+    if existing is not None and not overwrite:
         raise FileExistsError(
             f"Task #{task_id} already exists at {existing}. Refusing to overwrite "
             f"(possible concurrent create or stale id). Re-run to allocate a fresh id."
@@ -1572,7 +1578,8 @@ def create_sprint(
     # Simpler subject using compose_subject pattern
     subject = f"{ANSI_DIM}{('  #' + str(task_id)).rjust(4)}{ANSI_DIM_OFF} 🏃 SPRINT: {title}"
 
-    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid)
+    # overwrite=True: finalize the provisional stub reserved at this id above
+    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid, overwrite=True)
 
     # ------------------------------------------------------------------
     # 6. Auto-start chain
@@ -1802,7 +1809,8 @@ def create_play_time(
     description = f"→ {ca_path_relative}\n\n{_generate_mtmd_block(mtmd)}"
     subject = f"{ANSI_DIM}{('  #' + str(task_id)).rjust(4)}{ANSI_DIM_OFF} ⏲️ PLAY_TIME: {title}"
 
-    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid)
+    # overwrite=True: finalize the provisional stub reserved at this id above
+    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid, overwrite=True)
 
     # ------------------------------------------------------------------
     # 6. Auto-start chain

--- a/macf/tests/test_task_create_sprint_play_time.py
+++ b/macf/tests/test_task_create_sprint_play_time.py
@@ -73,7 +73,7 @@ def mock_task_infra(tmp_path, monkeypatch):
 
     def fake_create_task_file(task_id, subject, description,
                               status="pending", session_uuid=None,
-                              blocked_by=None):
+                              blocked_by=None, overwrite=False):
         path = tmp_path / f"{task_id}.json"
         path.write_text(json.dumps({"id": str(task_id), "subject": subject,
                                     "description": description, "status": status}))

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -161,3 +161,43 @@ class TestLoopWatcherFlatStore:
         reader = TaskReader()
         assert reader.session_uuid == TaskReader.HOME_STORE_UUID
         assert reader.session_path == home_agent / "agent" / "public" / "tasks"
+
+
+class TestSprintPlayTimeNoSelfCollision:
+    """create_sprint/create_play_time reserve a provisional stub then finalize
+    at the same id; the PR #134 collision guard must not block that finalize
+    (BUG #157). Regression: both must create without raising and the finalized
+    file must carry the real subject, not the '(provisional)' stub.
+    """
+
+    def test_create_sprint_scoped_finalizes(self, home_agent):
+        from macf.task.create import create_task, create_sprint
+        a = create_task(title="target A", plan="x")
+        b = create_task(title="target B", plan="x")
+        res = create_sprint(
+            "renewal-style sprint",
+            scoped_task_ids=[a.task_id, b.task_id],
+            no_auto_start=True,
+            agent_root=home_agent,
+        )
+        sid = res["task_id"]
+        f = home_agent / "agent" / "public" / "tasks" / f"{sid}.json"
+        assert f.exists()
+        data = json.loads(f.read_text())
+        assert "provisional" not in data["subject"]
+        assert "🏃 SPRINT:" in data["subject"]
+
+    def test_create_play_time_children_finalizes(self, home_agent):
+        from macf.task.create import create_play_time
+        res = create_play_time(
+            "play block",
+            timer_minutes=30,
+            children_titles=["c1", "c2"],
+            no_auto_start=True,
+            agent_root=home_agent,
+        )
+        pid = res["task_id"]
+        f = home_agent / "agent" / "public" / "tasks" / f"{pid}.json"
+        assert f.exists()
+        data = json.loads(f.read_text())
+        assert "provisional" not in data["subject"]


### PR DESCRIPTION
Fixes the regression the #134 collision guard introduced: create_sprint and create_play_time reserve their task id by pre-writing a provisional stub (the GH #69 child-collision fix), then finalize by writing the real task at the same id. The guard refused that second write, so every `task create sprint` / `task create play_time` self-collided, aborted mid-create, and left an orphaned provisional file plus the store directory stuck chmod 0555.

Fix: `_create_task_file` gains an `overwrite` flag (default False), passed True only by the two finalize-after-reservation call sites. A genuine id race still errors instead of clobbering.

Why the dedicated sprint/play_time tests missed it: they mock `_create_task_file`, so the mock had no collision guard. The mock now matches the real signature, and two unmocked regression tests in test_task_home_store exercise the real reserve-then-finalize path against a home store.

Verified: full suite 924 passed / 9 xfailed; live CLI `task create sprint --scoped` against an isolated MACF_TASK_STORE_DIR creates and finalizes cleanly (subject is the real sprint, not the provisional stub).

Stacked on #137 (the new tests extend that branch's test file); retarget to main after #137 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)