### PR TITLE
scope: heal orphaned scope_status when event history is lost (+ task edit NameError fix)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4318,17 +4318,17 @@ def cmd_task_edit(args: argparse.Namespace) -> int:
     if field == "subject":
         print(f"❌ Direct subject editing is not allowed")
         print(f"   Subject is composed from task metadata (id, parent, type, title)")
-        print(f"   To change the title: macf_tools task metadata set {task_id_str} title \"New Title\"")
+        print(f"   To change the title: macf_tools task metadata set {task_id} title \"New Title\"")
         return 1
 
     # Block direct status editing - use lifecycle commands instead
     if field == "status":
         print(f"❌ Direct status editing is not allowed")
         print(f"   Use lifecycle commands instead:")
-        print(f"   • macf_tools task start {task_id_str}    → in_progress")
-        print(f"   • macf_tools task pause {task_id_str}    → pending")
-        print(f"   • macf_tools task complete {task_id_str} → completed")
-        print(f"   • macf_tools task archive {task_id_str}  → archived")
+        print(f"   • macf_tools task start {task_id}    → in_progress")
+        print(f"   • macf_tools task pause {task_id}    → pending")
+        print(f"   • macf_tools task complete {task_id} → completed")
+        print(f"   • macf_tools task archive {task_id}  → archived")
         return 1
 
     # Block direct description editing - preserves MTMD metadata
@@ -4336,8 +4336,8 @@ def cmd_task_edit(args: argparse.Namespace) -> int:
         print(f"❌ Direct description editing is not allowed")
         print(f"   Description contains MTMD metadata set during creation.")
         print(f"   Use structured commands instead:")
-        print(f"   • macf_tools task note {task_id_str} \"message\"  → append notes")
-        print(f"   • macf_tools task edit {task_id_str} plan \"ref\" → update plan reference")
+        print(f"   • macf_tools task note {task_id} \"message\"  → append notes")
+        print(f"   • macf_tools task edit {task_id} plan \"ref\" → update plan reference")
         return 1
 
     editable_fields = []
@@ -6216,16 +6216,26 @@ def cmd_task_scope_set(args: argparse.Namespace) -> int:
 
 def cmd_task_scope_show(args: argparse.Namespace) -> int:
     """Display current scope with status."""
-    from .task.scope import get_active_scope
+    from .task.scope import get_active_scope, find_orphaned_scope_tasks
 
     tasks = get_active_scope()
-    if not tasks:
+    orphans = find_orphaned_scope_tasks()
+    if not tasks and not orphans:
         print("No active scope.")
         return 0
 
     active = [t for t in tasks if t["status"] == "active"]
     paused = [t for t in tasks if t["status"] == "paused"]
     inactive = [t for t in tasks if t["status"] == "inactive"]
+
+    if not tasks:
+        print(f"No active scope (event state empty).")
+        print(f"⚠️  {len(orphans)} task(s) carry stale scope_status with no event history (orphans):")
+        for tid in sorted(orphans, key=lambda x: int(x) if x.isdigit() else 0):
+            print(f"   🧟 #{tid} (mtmd: {orphans[tid]})")
+        print("   Heal with: macf_tools task scope remove <ids>  (drop from scope)")
+        print("         or:  macf_tools task scope pause <ids> --justification ...  (adopt as paused)")
+        return 0
 
     summary_parts = [f"{len(active)} active"]
     if paused:
@@ -6238,6 +6248,12 @@ def cmd_task_scope_show(args: argparse.Namespace) -> int:
         print(f"   ⏸️  #{t['id']} {t['subject']}")
     for t in inactive:
         print(f"   ✅ #{t['id']} {t['subject']}")
+    if orphans:
+        print(f"⚠️  {len(orphans)} task(s) carry stale scope_status with no event history (orphans):")
+        for tid in sorted(orphans, key=lambda x: int(x) if x.isdigit() else 0):
+            print(f"   🧟 #{tid} (mtmd: {orphans[tid]})")
+        print("   Heal with: macf_tools task scope remove <ids>  (drop from scope)")
+        print("         or:  macf_tools task scope pause <ids> --justification ...  (adopt as paused)")
     return 0
 
 

--- a/macf/src/macf/task/scope.py
+++ b/macf/src/macf/task/scope.py
@@ -151,10 +151,12 @@ def clear_scope(session_id: str = "") -> dict:
     scope = get_scope_state()
     active = [tid for tid, s in scope.items() if s == "active"]
     inactive = [tid for tid, s in scope.items() if s == "inactive"]
+    orphans = list(find_orphaned_scope_tasks())
 
     result = {
         "active_removed": active,
         "inactive_removed": inactive,
+        "orphans_swept": orphans,
         "success": False,
     }
 
@@ -168,9 +170,10 @@ def clear_scope(session_id: str = "") -> dict:
         },
     )
 
-    # Clear MTMD scope_status on all scoped tasks
+    # Clear MTMD scope_status on all scoped tasks, plus any orphans whose
+    # scope events were lost (their stale MTMD is what makes them orphans).
     if success:
-        for tid in active + inactive:
+        for tid in set(active + inactive + orphans):
             _update_task_scope_status(str(tid), None)
 
     result["success"] = success
@@ -228,14 +231,41 @@ def get_scope_state() -> Dict[str, str]:
                 state[tid] = "inactive"
         elif event_type == "scope_paused":
             for tid in data.get("task_ids", []):
-                if str(tid) in state and state[str(tid)] == "active":
-                    state[str(tid)] = "paused"
+                stid = str(tid)
+                # Unknown tids are adopted as paused: pausing implies scope
+                # membership, and this lets orphan-healing pause events
+                # (BUG: stale MTMD with lost event history) replay correctly.
+                if stid not in state or state[stid] == "active":
+                    state[stid] = "paused"
         elif event_type == "scope_unpaused":
             for tid in data.get("task_ids", []):
                 if str(tid) in state and state[str(tid)] == "paused":
                     state[str(tid)] = "active"
 
     return state
+
+
+def find_orphaned_scope_tasks() -> Dict[str, str]:
+    """Find tasks whose MTMD scope_status is set but which are absent from
+    the event-derived scope state.
+
+    Orphans arise when scope events are lost (legacy sessions, log rotation,
+    or clears that found an already-empty event state) while the durable
+    task-file MTMD keeps its scope_status. The tree renders such tasks as
+    scoped, but scope commands cannot see them -- the BUG this heals.
+
+    Returns:
+        Dict of {task_id: mtmd_scope_status} for statuses 'active'/'paused'.
+    """
+    from .reader import TaskReader
+
+    event_scope = get_scope_state()
+    orphans: Dict[str, str] = {}
+    for task in TaskReader().read_all_tasks():
+        mtmd_status = task.mtmd.scope_status if task.mtmd else None
+        if mtmd_status in ("active", "paused") and str(task.id) not in event_scope:
+            orphans[str(task.id)] = mtmd_status
+    return orphans
 
 
 def pause_scoped_tasks(task_ids: List[str], justification: str, session_id: str = "") -> dict:
@@ -254,17 +284,25 @@ def pause_scoped_tasks(task_ids: List[str], justification: str, session_id: str 
         Dict with 'paused_ids' (list, those that transitioned), 'skipped_ids'
         (list with reasons), 'success' (bool).
     """
-    result = {"paused_ids": [], "skipped_ids": [], "success": False}
+    result = {"paused_ids": [], "skipped_ids": [], "healed_ids": [], "success": False}
 
     if not justification or not justification.strip():
         result["skipped_ids"] = [{"id": tid, "reason": "missing_justification"} for tid in task_ids]
         return result
 
     scope = get_scope_state()
+    orphans = find_orphaned_scope_tasks()
+    healed: List[str] = []
     pausable: List[str] = []
     for tid in task_ids:
         sid = str(tid)
         if sid not in scope:
+            if sid in orphans:
+                # Stale MTMD scope_status with no event history: adopt and
+                # pause it so the durable state and event state re-converge.
+                pausable.append(sid)
+                healed.append(sid)
+                continue
             result["skipped_ids"].append({"id": sid, "reason": "not_in_scope"})
             continue
         if scope[sid] == "paused":
@@ -294,6 +332,7 @@ def pause_scoped_tasks(task_ids: List[str], justification: str, session_id: str 
             # Also append a task note for human audit (best-effort)
             add_task_note(tid, f"⏸️ SCOPE PAUSED: {justification}")
         result["paused_ids"] = pausable
+        result["healed_ids"] = healed
 
     result["success"] = success
     return result
@@ -397,12 +436,19 @@ def remove_from_scope(task_ids: List[str], session_id: str = "") -> dict:
     Returns:
         Dict with 'removed_ids', 'skipped_ids' (not in scope), 'success'.
     """
-    result = {"removed_ids": [], "skipped_ids": [], "success": False}
+    result = {"removed_ids": [], "skipped_ids": [], "healed_ids": [], "success": False}
     scope = get_scope_state()
+    orphans = find_orphaned_scope_tasks()
     removable: List[str] = []
     for tid in task_ids:
         sid = str(tid)
         if sid not in scope:
+            if sid in orphans:
+                # Stale MTMD with no event history: removing clears the MTMD
+                # and records the removal event -- the orphan is healed.
+                removable.append(sid)
+                result["healed_ids"].append(sid)
+                continue
             result["skipped_ids"].append({"id": sid, "reason": "not_in_scope"})
             continue
         removable.append(sid)

--- a/macf/tests/test_scope_and_stop.py
+++ b/macf/tests/test_scope_and_stop.py
@@ -273,3 +273,93 @@ class TestScopeAddRemovePrimitives:
         result = remove_from_scope(["999"])
         assert result["removed_ids"] == []
         assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])
+
+
+class TestScopeOrphanHealing:
+    """Stale MTMD scope_status with lost event history.
+
+    The bug: task files keep scope_status="active" from a legacy session while
+    the event log carries no scope membership -- the tree renders 👀 but every
+    scope command reports not_in_scope. Orphans must be detectable, and
+    pause/remove/clear must heal them.
+    """
+
+    @pytest.fixture
+    def home_with_orphan(self, tmp_path, monkeypatch):
+        from macf.utils.paths import find_agent_home
+        monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
+        monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        find_agent_home.cache_clear()
+        maceff = tmp_path / ".maceff"
+        maceff.mkdir()
+        (maceff / "config.json").write_text(json.dumps(
+            {"task_store": {"mode": "home", "path": "agent/public/tasks"}}))
+        (maceff / "agent_events_log.jsonl").touch()
+        store = tmp_path / "agent" / "public" / "tasks"
+        store.mkdir(parents=True)
+        desc = (
+            '<macf_task_metadata version="1.0">\n'
+            "creation_breadcrumb: s_test/c_1/p_x/t_1\n"
+            "created_cycle: 1\n"
+            "created_by: PA\n"
+            "scope_status: active\n"
+            "</macf_task_metadata>"
+        )
+        (store / "99.json").write_text(json.dumps({
+            "id": "99",
+            "subject": "#99 orphan task",
+            "description": desc,
+            "status": "pending",
+        }))
+        yield tmp_path
+        find_agent_home.cache_clear()
+
+    def test_orphan_detected_but_absent_from_event_state(self, home_with_orphan):
+        from macf.task.scope import get_scope_state, find_orphaned_scope_tasks
+        assert get_scope_state() == {}
+        assert find_orphaned_scope_tasks() == {"99": "active"}
+
+    def test_remove_heals_orphan(self, home_with_orphan):
+        from macf.task.reader import TaskReader
+        from macf.task.scope import remove_from_scope, find_orphaned_scope_tasks
+        result = remove_from_scope(["99"])
+        assert result["success"]
+        assert result["removed_ids"] == ["99"]
+        assert result["healed_ids"] == ["99"]
+        assert find_orphaned_scope_tasks() == {}
+        task = TaskReader().read_task("99")
+        assert task.mtmd.scope_status is None
+
+    def test_pause_heals_orphan_and_event_state_adopts(self, home_with_orphan):
+        from macf.task.reader import TaskReader
+        from macf.task.scope import (
+            pause_scoped_tasks, get_scope_state, find_orphaned_scope_tasks,
+        )
+        result = pause_scoped_tasks(["99"], justification="stale scoping from a legacy sprint")
+        assert result["success"]
+        assert result["paused_ids"] == ["99"]
+        assert result["healed_ids"] == ["99"]
+        # Event replay adopts the previously-unknown tid as paused
+        assert get_scope_state() == {"99": "paused"}
+        assert find_orphaned_scope_tasks() == {}
+        task = TaskReader().read_task("99")
+        assert task.mtmd.scope_status == "paused"
+
+    def test_clear_sweeps_orphans(self, home_with_orphan):
+        from macf.task.reader import TaskReader
+        from macf.task.scope import clear_scope, find_orphaned_scope_tasks
+        result = clear_scope()
+        assert result["success"]
+        assert result["orphans_swept"] == ["99"]
+        assert find_orphaned_scope_tasks() == {}
+        task = TaskReader().read_task("99")
+        assert task.mtmd.scope_status is None
+
+    def test_unscoped_unknown_task_still_skipped(self, home_with_orphan):
+        # A task with NO stale MTMD must still be refused (no accidental adoption)
+        from macf.task.scope import pause_scoped_tasks, remove_from_scope
+        result = pause_scoped_tasks(["555"], justification="reason")
+        assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])
+        result = remove_from_scope(["555"])
+        assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])


### PR DESCRIPTION
## The bug

Task tree renders scoped-eye markers from durable task-file MTMD `scope_status`, while every scope command derives membership from the event log. When scope events are lost (legacy sessions, clears that found an already-empty event state), tasks keep `scope_status: active` forever: the tree shows them scoped, `scope show` says "No active scope", and `scope pause/remove` refuse with `not_in_scope`. Observed live on three tasks scoped by a cycle-12 sprint whose events no longer reconstruct.

## The fix

- `find_orphaned_scope_tasks()` — tasks whose MTMD scope_status is set but absent from event-derived state
- `scope pause`/`scope remove` accept orphans and heal them (MTMD + a fresh event re-converge the two stores); unknown tasks with no stale MTMD are still refused
- `clear_scope` sweeps orphan MTMD along with tracked members, so the auto-clear on task completion also self-heals
- `scope_paused` event replay adopts unknown tids as paused, so healing events reconstruct correctly on future replays
- `scope show` lists orphans with healing instructions instead of claiming no scope exists

## Also

`cmd_task_edit` crashed with `NameError: task_id_str` in every rejection-guidance path (subject/status/description edits) — fixed to use the parsed `task_id`.

## Tests

New `TestScopeOrphanHealing` (5 tests: detection, remove-heal, pause-heal with replay adoption, clear-sweep, no accidental adoption of unknown tasks). Full suite: 915 passed, 8 skipped, 9 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)