### PR TITLE
task tree --loop: clear scrollback and redraw on a timer

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4170,6 +4170,8 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         reader = TaskReader()
         tasks_dir = reader.tasks_dir
         last_mtime = 0.0
+        last_draw = 0.0
+        REDRAW_SECS = 60.0  # timed redraw keeps relative-age displays current
 
         # Brand the terminal window with the agent calling card so
         # multi-agent terminal layouts are distinguishable at a glance.
@@ -4185,11 +4187,15 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         try:
             while True:
                 current_mtime = get_tasks_mtime(tasks_dir)
+                now = time.time()
 
-                # Display tree if tasks changed or first iteration
-                if current_mtime != last_mtime:
-                    # Clear screen using ANSI escape code (works on macOS/Linux)
-                    print("\033[2J\033[H", end="")
+                # Redraw when tasks changed, on first iteration, or on the
+                # timed interval so age displays don't go stale.
+                if current_mtime != last_mtime or (now - last_draw) >= REDRAW_SECS:
+                    # Clear scrollback (E3) + screen + home. Without E3 the
+                    # terminal keeps every stale tree in scrollback, which
+                    # reads as history that never happened.
+                    print("\033[3J\033[2J\033[H", end="")
 
                     if not display_tree(root_id):
                         return 1
@@ -4197,6 +4203,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                     print()  # Add blank line
                     print(f"{ANSI_DIM}[Monitoring for changes... Press Ctrl+C to exit]{ANSI_RESET}")
                     last_mtime = current_mtime
+                    last_draw = now
 
                 time.sleep(1)  # Poll every second
 


### PR DESCRIPTION
Two loop-mode changes, scoped per the improvement-drive roadmap Phase 1.

**Scrollback**: each redraw now emits E3 (`ESC[3J`) before the screen clear, so stale trees no longer accumulate in terminal scrollback. Scrolling back over previous renders was more confusing than useful -- old states read as current.

**Timed redraw**: the loop redraws at least once every 60 s even with no task-file change, so time-relative displays (the upcoming last-touched age marker from Phase 3) stay roughly current instead of freezing at their last change. Change-triggered redraws are unchanged; poll stays at 1 s.

**Local test evidence**: captured loop output begins `1b5b334a 1b5b324a 1b5b48` (E3, 2J, home) on every redraw; full suite 910 passed / 8 skipped / 9 xfailed with PYTHONPATH pinned to the worktree src.

Note for reviewer: this suite run reproduced the ideas-bank test-pollution bug a third time (wrote 2 test ideas into the live bank, archived immediately) -- the drive's Phase 5 fixes it and may deserve to land first.