### PR TITLE
tests: isolate the agent home for every test (ideas-bank pollution fix)

### DIFF
--- a/macf/tests/conftest.py
+++ b/macf/tests/conftest.py
@@ -113,6 +113,44 @@ def isolated_events_log(tmp_path, monkeypatch):
     set_log_path(None)
 
 
+@pytest.fixture(autouse=True)
+def isolated_agent_home(tmp_path, monkeypatch):
+    """
+    Isolate the agent home so tests can never write into the live agent's
+    consciousness artifacts (ideas bank, task store, learnings, ...).
+
+    Why this exists: find_agent_home() is lru_cached. The test process
+    inherits the real MACEFF_AGENT_HOME_DIR from the developer's shell, so
+    whichever test resolves the home first pins the LIVE home into the cache
+    and every later per-test monkeypatch of the env var is silently ignored.
+    Three separate suite runs wrote test ideas into a live agent's bank
+    (2026-07-20 twice, 2026-07-22) before this fixture.
+
+    Applies to ALL tests (autouse). It:
+    - points MACEFF_AGENT_HOME_DIR at a per-test tmp home (inherited by
+      subprocess CLI invocations too)
+    - clears the find_agent_home cache before the test, so the tmp home
+      actually takes effect regardless of test order
+    - clears it again after, so no test leaks its home to the next
+
+    Tests that need their own home layout can still monkeypatch the env var
+    on top of this; the pre-cleared cache makes that reliable.
+
+    Yields:
+        Path to the isolated agent home
+    """
+    from macf.utils.paths import find_agent_home
+
+    test_home = tmp_path / "_macf_isolated_home"
+    test_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(test_home))
+    find_agent_home.cache_clear()
+
+    yield test_home
+
+    find_agent_home.cache_clear()
+
+
 @pytest.fixture
 def mock_environment_detection():
     """Mock environment detection utilities."""


### PR DESCRIPTION
Fixes the test-runs-pollute-the-live-ideas-bank bug (three documented occurrences: two on 2026-07-20, one today during the drive's own Phase 1 suite run).

**Root cause**: `find_agent_home()` is `lru_cache`d and pytest inherits the real `MACEFF_AGENT_HOME_DIR` from the shell. Whichever test resolves the home first pins the LIVE home into the cache; later per-test `monkeypatch.setenv` calls (which some tests already carried, correctly written) were silently ignored. Hence intermittent, order-dependent pollution.

**Fix**: a global autouse fixture `isolated_agent_home` alongside the existing `isolated_events_log` precedent -- per-test tmp home via env (subprocess-inherited), `cache_clear()` before AND after each test.

**Evidence**: pre-fix full-suite run wrote 2 test ideas into the live bank; post-fix, 910 passed / 8 skipped / 9 xfailed and the live ideas dir is count-stable (146 -> 146) across the run. One collision fixed en route: the fixture's home dir is named `_macf_isolated_home` so identity tests that mkdir their own `agent_home` under tmp_path are untouched.