### PR TITLE
task tree: drop the redundant completed-scope checkmark

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4081,12 +4081,13 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
             if suffix:
                 text = f"{text} {suffix}"
 
-            # Scope indicator
+            # Scope indicator. Inactive scope gets NO marker: those tasks are
+            # completed, and the line already says so three ways (check icon,
+            # strikethrough, green timestamp) -- a fourth was pure noise, and
+            # the end-of-subject slot is reserved for the recency marker.
             if scope_state and task.id in scope_state:
                 if scope_state[task.id] == "active":
                     text += " 👀"
-                elif scope_state[task.id] == "inactive":
-                    text += " ✅"
 
             print(f"{prefix}{connector}{status_icon} {text}")
 
@@ -4122,8 +4123,6 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         if scope_state and root.id in scope_state:
             if scope_state[root.id] == "active":
                 root_text += " 👀"
-            elif scope_state[root.id] == "inactive":
-                root_text += " ✅"
         print(f"{status_icon} {root_text}")
 
         # Print root task details (plan, notes) - extra indent beyond header


### PR DESCRIPTION
Small renderer cleanup scoped per the improvement-drive roadmap Phase 2.

Tasks with `scope_status: inactive` (completed, left autonomous scope) rendered a trailing checkmark after the timestamp -- a fourth completed indicator on a line that already has the check icon, strikethrough, and green timestamp. Removed at both render sites (child lines and root). The active-scope eyes indicator is unchanged.

The freed end-of-subject slot is claimed by the next PR in the drive (last-touched recency marker).

**Local test evidence**: before/after render of a completed DETOUR line shows the trailing checkmark gone and nothing else changed; suite 910 passed / 8 skipped / 9 xfailed with PYTHONPATH pinned and an isolated agent home.