### PR TITLE
knowledge gaps: exclude archived ideas from suggestions

### DIFF
--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -916,8 +916,12 @@ def detect_graph_gaps(kg: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any
                 "target_cluster": target_cluster or "isolated",
             })
 
-    # Check ideas
+    # Check ideas. Archived ideas are retired seeds -- suggesting new links
+    # for them is pure noise, so they are excluded from gap analysis (they
+    # stay in the graph itself for historical edges).
     for idea_id, idea in ideas.items():
+        if idea.get("status") == "archived":
+            continue
         deg = len(edges.get(idea_id, set()))
         _check_node(idea_id, idea.get("title", ""), "idea", deg)
 

--- a/macf/tests/test_knowledge_graph.py
+++ b/macf/tests/test_knowledge_graph.py
@@ -194,3 +194,43 @@ class TestIdeaGraphWikiLinks:
         graph = build_idea_graph()
         assert "valid-concept" in graph["wiki_index"]
         assert 4 in graph["wiki_index"]["valid-concept"]
+
+
+class TestGapDetectionExcludesArchived:
+    """Archived ideas are retired seeds; suggesting links for them is noise."""
+
+    def _write_idea(self, agent_root, idea_id, title, status, wiki_links):
+        ideas_dir = agent_root / "agent" / "public" / "ideas"
+        ideas_dir.mkdir(parents=True, exist_ok=True)
+        path = ideas_dir / f"{idea_id:03d}_2026-01-01_120000_test_idea.json"
+        path.write_text(json.dumps({
+            "schema_version": "1.0",
+            "id": idea_id,
+            "title": title,
+            "slug": f"test_idea_{idea_id}",
+            "status": status,
+            "category": "tooling",
+            "description": "fixture",
+            "links": {
+                "related_ideas": [],
+                "related_learnings": [],
+                "wiki_links": wiki_links,
+                "promoted_to": None,
+                "archived_reason": None,
+            },
+            "history": [],
+        }))
+
+    def test_archived_idea_generates_no_gap_suggestion(self, fake_agent_root, monkeypatch):
+        from macf.ideas import build_knowledge_graph, detect_graph_gaps
+        from macf.utils import paths as paths_mod
+        monkeypatch.setattr(paths_mod, "find_agent_home", lambda: fake_agent_root)
+        # Idea 1 establishes the concept; ideas 2 and 3 share a suggestible
+        # title, differing only in status.
+        self._write_idea(fake_agent_root, 1, "anchor", "captured", ["sonar_gate"])
+        self._write_idea(fake_agent_root, 2, "Sonar gate improvements", "captured", [])
+        self._write_idea(fake_agent_root, 3, "Sonar gate improvements", "archived", [])
+        gaps = detect_graph_gaps(build_knowledge_graph())
+        suggested_ids = {g["node_id"] for g in gaps if g["suggested_concept"] == "sonar_gate"}
+        assert "2" in suggested_ids
+        assert "3" not in suggested_ids


### PR DESCRIPTION
Phase 4 of the improvement drive.

`detect_graph_gaps` iterated every idea in the graph regardless of status, so retired seeds kept generating link suggestions forever. Archived ideas now skip gap analysis while remaining in the graph (their historical edges stay).

**Local test evidence**: new test writes captured + archived ideas with identical suggestible titles and asserts only the captured one is suggested; suite 911 passed / 8 skipped / 9 xfailed under an isolated agent home. Production-path check on a real bank (146 ideas, 40 archived): suggestions drop 98 -> 74, all 24 eliminated entries were archived-idea noise.