### PR TITLE
task create: restore the store dir's original mode, always

### DIFF
--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -81,9 +81,12 @@ def _unprotect_for_creation(dir_path: Path) -> Generator[None, None, None]:
     try:
         yield
     finally:
-        # Always protect after creation (even if it wasn't protected before)
-        # This makes protection the default state
-        os.chmod(dir_path, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)  # 555
+        # Symmetric restoration: put back exactly the mode we found. Dirs are
+        # born protected (see the not-exists branch above), so protected stays
+        # protected; a dir the operator deliberately made writable must not be
+        # hijacked to 555 as a side effect of a create -- especially a FAILED
+        # one, which used to strand the store read-only mid-cleanup.
+        os.chmod(dir_path, stat.S_IMODE(current_mode))
 
 # ANSI escape codes for dim text (CC UI renders these!)
 ANSI_DIM = "\033[2m"

--- a/macf/tests/test_task_store_permissions.py
+++ b/macf/tests/test_task_store_permissions.py
@@ -1,0 +1,62 @@
+"""Tests for _unprotect_for_creation permission symmetry.
+
+A create must leave the store dir's mode exactly as it found it -- including
+when the create body raises. The old behavior force-protected to 555 on every
+exit, which hijacked deliberately-writable home stores and stranded them
+read-only after failed creates (observed twice on a live store, 2026-07-20).
+"""
+import os
+import stat
+
+import pytest
+
+from macf.task.create import _unprotect_for_creation
+
+
+def _mode(p):
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+@pytest.fixture
+def store(tmp_path):
+    d = tmp_path / "tasks"
+    d.mkdir()
+    return d
+
+
+def test_protected_dir_restored_after_success(store):
+    os.chmod(store, 0o555)
+    with _unprotect_for_creation(store):
+        assert _mode(store) == 0o755  # writable inside the context
+    assert _mode(store) == 0o555
+
+
+def test_protected_dir_restored_after_failure(store):
+    os.chmod(store, 0o555)
+    with pytest.raises(RuntimeError):
+        with _unprotect_for_creation(store):
+            raise RuntimeError("mid-create failure")
+    assert _mode(store) == 0o555
+
+
+def test_writable_dir_stays_writable_after_success(store):
+    os.chmod(store, 0o755)
+    with _unprotect_for_creation(store):
+        pass
+    assert _mode(store) == 0o755
+
+
+def test_writable_dir_stays_writable_after_failure(store):
+    """The observed bug: a failed create stranded a 755 store at 555."""
+    os.chmod(store, 0o755)
+    with pytest.raises(RuntimeError):
+        with _unprotect_for_creation(store):
+            raise RuntimeError("mid-create failure")
+    assert _mode(store) == 0o755
+
+
+def test_new_dir_is_born_protected(tmp_path):
+    d = tmp_path / "fresh_tasks"
+    with _unprotect_for_creation(d):
+        d.mkdir()
+    assert _mode(d) == 0o555


### PR DESCRIPTION
Phase 6 of the improvement drive. Reproduction-gated: the claim was verified before fixing.

**Repro** (pre-fix): a 755 store dir + a create body that raises -> dir left at 555. Exact observed field symptom (failed creates stranding a live home store read-only, twice on 2026-07-20).

**Root cause**: the context manager's `finally` force-protected to 555 unconditionally ('makes protection the default state') -- correct instinct for the legacy CC-purged store, but it hijacks deliberately-writable dirs and turns a failed create into a permissions incident.

**Fix**: symmetric restoration -- `finally` puts back `stat.S_IMODE` of the mode it found. The protection guarantee is preserved because new store dirs are still born 555 via the not-exists branch; a dir that is protected stays protected through success and failure alike.

**Local test evidence**: 5 new tests cover found-mode {555, 755} x outcome {success, raise} plus born-protected; suite 915 passed / 8 skipped / 9 xfailed under an isolated agent home.