### PR TITLE
fix: reparent recomposes the subject marker even when title isn't stored

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4706,16 +4706,24 @@ def cmd_task_reparent(args: argparse.Namespace) -> int:
     new_description = task.description_with_updated_mtmd(new_mtmd)
     updates = {"description": new_description}
 
-    # Recompose subject only when title is recoverable (Bug 3 invariant)
-    if new_mtmd.title is not None:
-        from .task.create import compose_subject
-        new_subject = compose_subject(
-            task_id=str(task_id),
-            task_type=new_mtmd.task_type,
-            title=new_mtmd.title,
-            parent_id=new_mtmd.parent_id,
-        )
-        updates["subject"] = new_subject
+    # Always recompose the subject so its [^#parent] marker tracks parent_id.
+    # When the MTMD title isn't stored, recover it from the current subject —
+    # closing the Bug-3 gap where a title-less task kept a stale parent marker.
+    from .task.create import compose_subject, title_from_subject
+    custom = new_mtmd.custom or None
+    title = new_mtmd.title
+    if title is None:
+        title = title_from_subject(task.subject, new_mtmd.task_type,
+                                   new_mtmd.plan_ca_ref, custom)
+    new_subject = compose_subject(
+        task_id=str(task_id),
+        task_type=new_mtmd.task_type,
+        title=title,
+        parent_id=new_mtmd.parent_id,
+        plan_ca_ref=new_mtmd.plan_ca_ref,
+        custom=custom,
+    )
+    updates["subject"] = new_subject
 
     if update_task_file(task_id, updates):
         print(f"✅ Reparented #{task_id}: {old_parent} → {new_parent}")

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -99,6 +99,35 @@ ANSI_STRIKE_OFF = "\033[29m"
 SENTINEL_TASK_ID = "000"
 
 
+def _compose_type_part(task_type: str, plan_ca_ref: Optional[str] = None,
+                       custom: Optional[dict] = None) -> str:
+    """The type-marker segment of a composed subject (e.g. '🐛 BUG:', '🔧', '📋').
+
+    Shared by compose_subject and title_from_subject so the two directions
+    agree on the exact marker text.
+    """
+    # PHASE type: 📋 if has subplan (plan_ca_ref), - if not
+    if task_type == "PHASE":
+        return "📋" if plan_ca_ref else "-"
+    type_map = {
+        "MISSION": "🗺️ MISSION:",
+        "EXPERIMENT": "🧪 EXPERIMENT:",
+        "DETOUR": "↩️ DETOUR:",
+        "DELEG_PLAN": "📜 DELEG:",
+        "BUG": "🐛 BUG:",
+        "TASK": "🔧",  # Generic task with wrench emoji
+    }
+    # GH_ISSUE has special format: 🐙 GH/owner/repo#N [label]: title
+    if task_type == "GH_ISSUE" and custom:
+        owner = custom.get("gh_owner", "?")
+        repo = custom.get("gh_repo", "?")
+        issue_num = custom.get("gh_issue_number", "?")
+        labels = custom.get("gh_labels", [])
+        label_str = f" [{labels[0]}]" if labels else ""
+        return f"🐙 GH/{owner}/{repo}#{issue_num}{label_str}:"
+    return type_map.get(task_type, "")
+
+
 def compose_subject(task_id: str, task_type: str, title: str,
                     parent_id: Optional[str] = None, status: str = "pending",
                     plan_ca_ref: Optional[str] = None,
@@ -129,31 +158,30 @@ def compose_subject(task_id: str, task_type: str, title: str,
     else:
         parent_part = ""
 
-    # Type emoji/marker
-    # PHASE type: 📋 if has subplan (plan_ca_ref), - if not
-    if task_type == "PHASE":
-        type_part = "📋" if plan_ca_ref else "-"
-    else:
-        type_map = {
-            "MISSION": "🗺️ MISSION:",
-            "EXPERIMENT": "🧪 EXPERIMENT:",
-            "DETOUR": "↩️ DETOUR:",
-            "DELEG_PLAN": "📜 DELEG:",
-            "BUG": "🐛 BUG:",
-            "TASK": "🔧",  # Generic task with wrench emoji
-        }
-        # GH_ISSUE has special format: 🐙 GH/owner/repo#N [label]: title
-        if task_type == "GH_ISSUE" and custom:
-            owner = custom.get("gh_owner", "?")
-            repo = custom.get("gh_repo", "?")
-            issue_num = custom.get("gh_issue_number", "?")
-            labels = custom.get("gh_labels", [])
-            label_str = f" [{labels[0]}]" if labels else ""
-            type_part = f"🐙 GH/{owner}/{repo}#{issue_num}{label_str}:"
-        else:
-            type_part = type_map.get(task_type, "")
+    # Type emoji/marker (shared with title_from_subject via _compose_type_part)
+    type_part = _compose_type_part(task_type, plan_ca_ref, custom)
 
     return f"{id_part}{parent_part} {type_part} {title}"
+
+
+def title_from_subject(subject: str, task_type: str,
+                       plan_ca_ref: Optional[str] = None,
+                       custom: Optional[dict] = None) -> str:
+    """Recover the plain title from a composed subject — the inverse of
+    compose_subject.
+
+    Robust to a stale or mismatched ``[^#N]`` parent marker: it strips ANY
+    parent marker present, not the one the caller expects. This lets
+    ``task reparent`` recompose a fresh subject even when the MTMD ``title``
+    field was never stored (the Bug-3 gap that left stale parent markers).
+    """
+    s = re.sub(r'\033\[[0-9;]*m', '', subject)   # strip ANSI
+    s = re.sub(r'^\s*#\d+\s*', '', s)             # id prefix (padded)
+    s = re.sub(r'^\[\^#\d+\]\s*', '', s)          # any parent marker
+    type_part = _compose_type_part(task_type, plan_ca_ref, custom)
+    if type_part and s.startswith(type_part):
+        s = s[len(type_part):]
+    return s.strip()
 
 
 def _ensure_sentinel_task(session_path: Path) -> None:

--- a/macf/tests/test_reparent_subject_recompose.py
+++ b/macf/tests/test_reparent_subject_recompose.py
@@ -1,0 +1,121 @@
+"""Regression tests: `task reparent` must keep the subject's [^#parent] marker
+in sync with parent_id even when MTMD.title was never stored.
+
+Background: reparent used to recompose the subject only `if mtmd.title is not
+None` (the "Bug 3 invariant"). Most tasks store their title only inside the
+composed subject string, so title was None and the recompose was skipped —
+leaving a stale [^#old_parent] marker that the task tree then rendered,
+contradicting both parent_id and the task's actual position. The fix recovers
+the title from the subject (title_from_subject) so reparent always recomposes.
+
+Follows the mocking conventions in test_task_mutation_verbs.py: MagicMock task
+fixtures, patch the source namespaces that cmd_task_reparent imports from.
+"""
+import argparse
+from unittest.mock import patch, MagicMock
+
+from macf.cli import cmd_task_reparent
+from macf.task.create import compose_subject, title_from_subject
+
+
+def _ns(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# title_from_subject — the inverse of compose_subject, robust to marker drift
+# ---------------------------------------------------------------------------
+
+def test_title_roundtrips_across_types():
+    cases = [("BUG", None, None), ("TASK", None, None),
+             ("MISSION", None, None), ("PHASE", "roadmap.md", None)]
+    for ttype, plan, custom in cases:
+        subj = compose_subject("7", ttype, "Some Title", parent_id="3",
+                               plan_ca_ref=plan, custom=custom)
+        assert title_from_subject(subj, ttype, plan, custom) == "Some Title"
+
+
+def test_title_recovery_ignores_stale_marker():
+    # Subject carries parent [^#99]; the title recovers regardless of the value.
+    subj = compose_subject("7", "BUG", "Real Title", parent_id="99")
+    assert title_from_subject(subj, "BUG") == "Real Title"
+
+
+def test_title_roundtrips_for_gh_issue():
+    custom = {"gh_owner": "o", "gh_repo": "r",
+              "gh_issue_number": "42", "gh_labels": ["bug"]}
+    subj = compose_subject("7", "GH_ISSUE", "Fix the thing",
+                           parent_id="3", custom=custom)
+    assert title_from_subject(subj, "GH_ISSUE", None, custom) == "Fix the thing"
+
+
+# ---------------------------------------------------------------------------
+# cmd_task_reparent — recomposes the subject when title is None
+# ---------------------------------------------------------------------------
+
+def _titleless_task(task_id, parent_id, task_type, subject_title):
+    """A task whose MTMD.title is None but whose subject was composed normally."""
+    task = MagicMock()
+    task.id = task_id
+    task.parent_id = parent_id
+    task.subject = compose_subject(task_id, task_type, subject_title,
+                                   parent_id=parent_id)
+
+    mtmd = MagicMock()
+    mtmd.parent_id = parent_id
+    mtmd.title = None            # the Bug-3 condition
+    mtmd.task_type = task_type
+    mtmd.plan_ca_ref = None
+    mtmd.custom = {}
+    mtmd.updates = []
+
+    def _upd(field, value, breadcrumb, description=""):
+        new = MagicMock()
+        new.parent_id, new.title, new.task_type = mtmd.parent_id, None, task_type
+        new.plan_ca_ref, new.custom = None, {}
+        setattr(new, field, value)
+        return new
+
+    mtmd.with_updated_field.side_effect = _upd
+    task.mtmd = mtmd
+    task.description_with_updated_mtmd.return_value = "<!-- updated -->"
+    return task
+
+
+def _run_reparent(task, new_parent):
+    grant = {"event": "task_grant_update",
+             "data": {"task_ids": [task.id], "field": "parent_id",
+                      "value": new_parent},
+             "timestamp": 200}
+    captured = {}
+    with patch("macf.task.TaskReader") as MockReader, \
+         patch("macf.task.update_task_file",
+               side_effect=lambda tid, updates: captured.setdefault("updates", updates) or True), \
+         patch("macf.utils.breadcrumbs.get_breadcrumb", return_value="s_t/c_0/g_a/p_x/t_0"), \
+         patch("macf.task.protection.clear_grant"), \
+         patch("macf.event_queries.get_latest_event",
+               side_effect=lambda et, **_: grant if et == "task_grant_update" else None):
+        MockReader.return_value.read_task.return_value = task
+        rc = cmd_task_reparent(_ns(task_id=task.id, parent=new_parent))
+    return rc, captured.get("updates", {})
+
+
+def test_reparent_to_sentinel_strips_marker_when_title_none():
+    task = _titleless_task("10", "5", "BUG", "Real Title")
+    rc, updates = _run_reparent(task, "000")
+    assert rc == 0
+    subj = updates["subject"]
+    assert "[^#" not in subj, f"parent marker leaked after reparent to 000: {subj!r}"
+    assert title_from_subject(subj, "BUG") == "Real Title"
+
+
+def test_reparent_to_digit_updates_marker_when_title_none():
+    task = _titleless_task("10", "5", "BUG", "Real Title")
+    rc, updates = _run_reparent(task, "7")
+    assert rc == 0
+    subj = updates["subject"]
+    assert "[^#7]" in subj and "[^#5]" not in subj
+    assert title_from_subject(subj, "BUG") == "Real Title"


### PR DESCRIPTION
Closes #148.

reparent updated `parent_id` but skipped recomposing the subject unless `mtmd.title` was set — and most tasks only carry their title inside the composed subject, so the `[^#parent]` marker went stale (the tree showed a task at its new position with its old parent label).

**Fix:** `title_from_subject()` (inverse of `compose_subject`, strips any parent marker) lets reparent recover the title and always recompose; `plan_ca_ref`/`custom` are now passed through so PHASE/GH_ISSUE markers don't degrade. `compose_subject` emits no marker for the `000` sentinel, so reparent-to-sentinel clears it.

**Tests:** `test_reparent_subject_recompose.py` — title_from_subject round-trips across BUG/TASK/MISSION/PHASE/GH_ISSUE and ignores a stale marker; reparent-to-000 strips the marker and reparent-to-digit updates it, both with title=None. Full mutation + task-cli suites (66 tests) green on 3.14.