### PR TITLE
create_sprint/play_time: let the finalize write overwrite its own provisional stub

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3819,6 +3819,27 @@ def cmd_task_get(args: argparse.Namespace) -> int:
     return 0
 
 
+def get_tasks_mtime(tasks_dir) -> float:
+    """Get latest modification time of any task file in the store directory."""
+    try:
+        if not tasks_dir or not tasks_dir.exists():
+            return 0.0
+
+        # Both backends are flat dirs of {id}.json (+ hidden .{id}.json).
+        # Include the directory's own mtime so create/delete/hide renames
+        # are detected even though they don't touch file mtimes.
+        mtimes = [tasks_dir.stat().st_mtime]
+        for task_file in tasks_dir.glob("*.json"):
+            mtimes.append(task_file.stat().st_mtime)
+        for task_file in tasks_dir.glob(".*.json"):
+            mtimes.append(task_file.stat().st_mtime)
+
+        return max(mtimes)
+    except (OSError, IOError) as e:
+        print(f"⚠️ MACF: task mtime scan failed: {e}", file=sys.stderr)
+        return 0.0
+
+
 def cmd_task_tree(args: argparse.Namespace) -> int:
     """Display task hierarchy tree from a root task."""
     import time
@@ -4137,24 +4158,6 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
         return True
 
-    def get_tasks_mtime(tasks_dir: Path) -> float:
-        """Get latest modification time of any file in tasks directory."""
-        try:
-            if not tasks_dir.exists():
-                return 0.0
-
-            # Get mtime of all JSON files in session subdirectories
-            mtimes = []
-            for session_dir in tasks_dir.iterdir():
-                if session_dir.is_dir():
-                    for task_file in session_dir.glob("*.json"):
-                        mtimes.append(task_file.stat().st_mtime)
-
-            return max(mtimes) if mtimes else 0.0
-        except (OSError, IOError) as e:
-            print(f"⚠️ MACF: task mtime scan failed: {e}", file=sys.stderr)
-            return 0.0
-
     # Parse task ID (preserve string IDs like "000")
     # Both branches set root_id to task_id_str — leading-zero forms (like "000")
     # need string identity preserved; ordinary numeric IDs are also kept as strings
@@ -4168,8 +4171,10 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
     # Loop mode - monitor for changes
     if args.loop:
         reader = TaskReader()
-        tasks_dir = reader.tasks_dir
-        last_mtime = 0.0
+        # Watch the resolved store (home store or legacy session dir), not the
+        # legacy per-session root — the home store lives outside ~/.claude/tasks.
+        tasks_dir = reader.session_path
+        last_mtime = None  # sentinel: always render the first iteration
 
         # Brand the terminal window with the agent calling card so
         # multi-agent terminal layouts are distinguishable at a glance.
@@ -4187,7 +4192,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                 current_mtime = get_tasks_mtime(tasks_dir)
 
                 # Display tree if tasks changed or first iteration
-                if current_mtime != last_mtime:
+                if last_mtime is None or current_mtime != last_mtime:
                     # Clear screen using ANSI escape code (works on macOS/Linux)
                     print("\033[2J\033[H", end="")
 

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -298,7 +298,8 @@ def _create_task_file(
     description: str,
     status: str = "pending",
     session_uuid: Optional[str] = None,
-    blocked_by: Optional[List[str]] = None
+    blocked_by: Optional[List[str]] = None,
+    overwrite: bool = False
 ) -> Path:
     """Create task JSON file directly.
 
@@ -306,6 +307,11 @@ def _create_task_file(
     - Temporarily unprotects directory if protected
     - Creates the task file
     - Re-protects directory (protection becomes default state)
+
+    overwrite=True finalizes a provisional stub the caller already reserved at
+    this id (the SPRINT/PLAY_TIME reserve-then-finalize pattern); it skips the
+    collision guard for that one write. Leave False everywhere else so a real
+    id race still turns into an error instead of silent clobber.
     """
     reader = TaskReader(session_uuid)
 
@@ -363,7 +369,7 @@ def _create_task_file(
     # this guard is the safety net that turns a silent data loss into an error.
     from .reader import resolve_task_file
     existing = resolve_task_file(reader.session_path, str(task_id)) if reader.session_path.exists() else None
-    if existing is not None:
+    if existing is not None and not overwrite:
         raise FileExistsError(
             f"Task #{task_id} already exists at {existing}. Refusing to overwrite "
             f"(possible concurrent create or stale id). Re-run to allocate a fresh id."
@@ -1572,7 +1578,8 @@ def create_sprint(
     # Simpler subject using compose_subject pattern
     subject = f"{ANSI_DIM}{('  #' + str(task_id)).rjust(4)}{ANSI_DIM_OFF} 🏃 SPRINT: {title}"
 
-    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid)
+    # overwrite=True: finalize the provisional stub reserved at this id above
+    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid, overwrite=True)
 
     # ------------------------------------------------------------------
     # 6. Auto-start chain
@@ -1802,7 +1809,8 @@ def create_play_time(
     description = f"→ {ca_path_relative}\n\n{_generate_mtmd_block(mtmd)}"
     subject = f"{ANSI_DIM}{('  #' + str(task_id)).rjust(4)}{ANSI_DIM_OFF} ⏲️ PLAY_TIME: {title}"
 
-    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid)
+    # overwrite=True: finalize the provisional stub reserved at this id above
+    task_file = _create_task_file(task_id, subject, description, session_uuid=session_uuid, overwrite=True)
 
     # ------------------------------------------------------------------
     # 6. Auto-start chain

--- a/macf/tests/test_task_create_sprint_play_time.py
+++ b/macf/tests/test_task_create_sprint_play_time.py
@@ -73,7 +73,7 @@ def mock_task_infra(tmp_path, monkeypatch):
 
     def fake_create_task_file(task_id, subject, description,
                               status="pending", session_uuid=None,
-                              blocked_by=None):
+                              blocked_by=None, overwrite=False):
         path = tmp_path / f"{task_id}.json"
         path.write_text(json.dumps({"id": str(task_id), "subject": subject,
                                     "description": description, "status": status}))

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -161,3 +161,43 @@ class TestLoopWatcherFlatStore:
         reader = TaskReader()
         assert reader.session_uuid == TaskReader.HOME_STORE_UUID
         assert reader.session_path == home_agent / "agent" / "public" / "tasks"
+
+
+class TestSprintPlayTimeNoSelfCollision:
+    """create_sprint/create_play_time reserve a provisional stub then finalize
+    at the same id; the PR #134 collision guard must not block that finalize
+    (BUG #157). Regression: both must create without raising and the finalized
+    file must carry the real subject, not the '(provisional)' stub.
+    """
+
+    def test_create_sprint_scoped_finalizes(self, home_agent):
+        from macf.task.create import create_task, create_sprint
+        a = create_task(title="target A", plan="x")
+        b = create_task(title="target B", plan="x")
+        res = create_sprint(
+            "renewal-style sprint",
+            scoped_task_ids=[a.task_id, b.task_id],
+            no_auto_start=True,
+            agent_root=home_agent,
+        )
+        sid = res["task_id"]
+        f = home_agent / "agent" / "public" / "tasks" / f"{sid}.json"
+        assert f.exists()
+        data = json.loads(f.read_text())
+        assert "provisional" not in data["subject"]
+        assert "🏃 SPRINT:" in data["subject"]
+
+    def test_create_play_time_children_finalizes(self, home_agent):
+        from macf.task.create import create_play_time
+        res = create_play_time(
+            "play block",
+            timer_minutes=30,
+            children_titles=["c1", "c2"],
+            no_auto_start=True,
+            agent_root=home_agent,
+        )
+        pid = res["task_id"]
+        f = home_agent / "agent" / "public" / "tasks" / f"{pid}.json"
+        assert f.exists()
+        data = json.loads(f.read_text())
+        assert "provisional" not in data["subject"]

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -115,3 +115,49 @@ class TestReconcileOverwritesReadOnly:
         report = reconcile(apply=True)
         assert report["applied"] is True
         assert target.read_text().strip().startswith("{")
+
+
+class TestLoopWatcherFlatStore:
+    """task tree --loop must detect changes in a flat store dir (#144)."""
+
+    def test_mtime_none_and_missing_dir(self, tmp_path):
+        from macf.cli import get_tasks_mtime
+        assert get_tasks_mtime(None) == 0.0
+        assert get_tasks_mtime(tmp_path / "nope") == 0.0
+
+    def test_mtime_sees_flat_store_files(self, tmp_path):
+        import os
+        from macf.cli import get_tasks_mtime
+        store = tmp_path / "tasks"
+        store.mkdir()
+        task = store / "7.json"
+        task.write_text("{}")
+        first = get_tasks_mtime(store)
+        assert first > 0.0
+        # A later write must move the watermark (flat glob, no session subdirs)
+        os.utime(task, (first + 10, first + 10))
+        assert get_tasks_mtime(store) > first
+
+    def test_mtime_sees_hidden_files_and_dir_changes(self, tmp_path):
+        import os
+        from macf.cli import get_tasks_mtime
+        store = tmp_path / "tasks"
+        store.mkdir()
+        hidden = store / ".8.json"
+        hidden.write_text("{}")
+        base = get_tasks_mtime(store)
+        assert base > 0.0
+        os.utime(hidden, (base + 10, base + 10))
+        assert get_tasks_mtime(store) > base
+        # Deleting a file bumps the dir mtime -> watermark changes even
+        # though no surviving file mtime moved.
+        before = get_tasks_mtime(store)
+        hidden.unlink()
+        os.utime(store, (before + 20, before + 20))
+        assert get_tasks_mtime(store) != before
+
+    def test_loop_watches_session_path_not_legacy_root(self, home_agent):
+        # The watcher dir must be the resolved store, not ~/.claude/tasks root.
+        reader = TaskReader()
+        assert reader.session_uuid == TaskReader.HOME_STORE_UUID
+        assert reader.session_path == home_agent / "agent" / "public" / "tasks"


### PR DESCRIPTION
Replaces #138 (closed by a stale-cache nudge during the 2026-07-24 GitHub incident; branch intact). create_sprint/create_play_time reserve a provisional stub then finalize at the same id — the #134 collision guard must not block that finalize. Adds overwrite=False to _create_task_file, skipping the guard only for the reserve-then-finalize write. Rebased on current main; 35 tests pass py3.14.