### PR TITLE
task tree: last-touched recency marker + touch-discipline nag

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4089,6 +4089,8 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                 if scope_state[task.id] == "active":
                     text += " 👀"
 
+            text += recency_marker(task)
+
             print(f"{prefix}{connector}{status_icon} {text}")
 
             # Print task details (plan, notes) with proper indentation
@@ -4101,6 +4103,32 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
             for i, child in enumerate(visible_children):
                 print_tree(child, prefix + extension, i == len(visible_children) - 1, depth + 1, children)
+
+        # Last-touched marker: the single most recently updated task (notes,
+        # lifecycle changes -- anything that stamps an update breadcrumb)
+        # carries a trailing left-pointing finger plus a dim relative age, so
+        # the reader can see at a glance where work last happened. Kept fresh
+        # by loop mode's timed redraw.
+        latest_id = None
+        latest_ts = 0
+        for t in all_tasks:
+            _ts = get_last_update_timestamp(t)
+            if _ts and _ts > latest_ts:
+                latest_ts = _ts
+                latest_id = t.id
+
+        def _rel_age(ts):
+            secs = max(0, int(time.time() - ts))
+            if secs < 3600:
+                return f"{secs // 60}m"
+            if secs < 86400:
+                return f"{secs // 3600}h"
+            return f"{secs // 86400}d"
+
+        def recency_marker(task):
+            if task.id != latest_id or not latest_ts:
+                return ""
+            return f" 👈 {ANSI_DIM}{_rel_age(latest_ts)}{ANSI_RESET}"
 
         # Print header
         total = 1 + count_descendants(root_id)
@@ -4123,6 +4151,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         if scope_state and root.id in scope_state:
             if scope_state[root.id] == "active":
                 root_text += " 👀"
+        root_text += recency_marker(root)
         print(f"{status_icon} {root_text}")
 
         # Print root task details (plan, notes) - extra indent beyond header

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4081,12 +4081,13 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
             if suffix:
                 text = f"{text} {suffix}"
 
-            # Scope indicator
+            # Scope indicator. Inactive scope gets NO marker: those tasks are
+            # completed, and the line already says so three ways (check icon,
+            # strikethrough, green timestamp) -- a fourth was pure noise, and
+            # the end-of-subject slot is reserved for the recency marker.
             if scope_state and task.id in scope_state:
                 if scope_state[task.id] == "active":
                     text += " 👀"
-                elif scope_state[task.id] == "inactive":
-                    text += " ✅"
 
             print(f"{prefix}{connector}{status_icon} {text}")
 
@@ -4122,8 +4123,6 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         if scope_state and root.id in scope_state:
             if scope_state[root.id] == "active":
                 root_text += " 👀"
-            elif scope_state[root.id] == "inactive":
-                root_text += " ✅"
         print(f"{status_icon} {root_text}")
 
         # Print root task details (plan, notes) - extra indent beyond header

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -58,6 +58,49 @@ def _is_bare_cd_command(command: str) -> bool:
     return False
 
 
+### Touch-discipline nag thresholds (tool calls since last task-store write).
+### Gentle by design: single line, fires only AT thresholds (not continuously),
+### ramps in tone, resets the moment any task is touched. Override the base
+### threshold with MACF_TOUCH_NAG_BASE; set 0 to disable.
+TOUCH_NAG_BASE = 40
+
+
+def _touch_discipline_nag(session_id: str) -> str:
+    """One-line nag when many tool calls have passed without a task-store touch."""
+    import os
+    base = int(os.environ.get("MACF_TOUCH_NAG_BASE", TOUCH_NAG_BASE))
+    if base <= 0:
+        return ""
+    from macf.task import TaskReader
+    from macf.utils import get_session_dir
+
+    tasks_dir = TaskReader().tasks_dir
+    mtimes = [f.stat().st_mtime for f in tasks_dir.rglob("*.json")]
+    store_mtime = max(mtimes) if mtimes else 0.0
+
+    sdir = get_session_dir(session_id=session_id, subdir="hooks")
+    if not sdir:
+        return ""
+    state_file = sdir / "touch_nag.json"
+    try:
+        state = json.loads(state_file.read_text())
+    except (OSError, ValueError):
+        state = {}
+    if state.get("store_mtime") != store_mtime:
+        state = {"store_mtime": store_mtime, "count": 0}
+    state["count"] += 1
+    state_file.write_text(json.dumps(state))
+
+    n = state["count"]
+    if n == base:
+        return f"🌱 {n} tool calls since the task tree was last touched -- a note would anchor this work"
+    if n == base * 2:
+        return f"🌿 {n} tool calls untouched -- the tree can't see this work; add a note or start the right task"
+    if n >= base * 3 and n % base == 0:
+        return f"🌳 {n} tool calls untracked -- future-you cannot recover this work from the tree; touch it"
+    return ""
+
+
 def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
     """
     Run PreToolUse hook logic.
@@ -364,6 +407,15 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                     message_parts.append(f"🎯 {display_tool}")
                 else:
                     message_parts.append("⚙️")
+
+        # Touch-discipline nag (task_management policy: notes during work,
+        # not just at completion). Never let it break the hook.
+        try:
+            nag = _touch_discipline_nag(session_id)
+            if nag:
+                message_parts.append(nag)
+        except (OSError, ValueError, ImportError, AttributeError) as e:
+            print(f"⚠️ MACF: touch nag skipped: {e}", file=sys.stderr)
 
         # Format message (compact single line)
         message = " ".join(message_parts)

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -61,8 +61,10 @@ def _is_bare_cd_command(command: str) -> bool:
 ### Touch-discipline nag thresholds (tool calls since last task-store write).
 ### Gentle by design: single line, fires only AT thresholds (not continuously),
 ### ramps in tone, resets the moment any task is touched. Override the base
-### threshold with MACF_TOUCH_NAG_BASE; set 0 to disable.
-TOUCH_NAG_BASE = 40
+### threshold with MACF_TOUCH_NAG_BASE; set 0 to disable. Calibration note:
+### CC's native task nag re-floods context with the whole open-task list on a
+### ~10-call cadence; this one-liner at 20 is half as frequent and far smaller.
+TOUCH_NAG_BASE = 20
 
 
 def _touch_discipline_nag(session_id: str) -> str:

--- a/macf/tests/test_touch_nag.py
+++ b/macf/tests/test_touch_nag.py
@@ -1,0 +1,82 @@
+"""Tests for the PreToolUse touch-discipline nag.
+
+The nag counts tool calls since the last task-store write (sidecar state
+file keyed by store mtime) and emits a single ramping line at threshold
+multiples. It must reset the moment any task file changes, stay silent
+between thresholds, and honor the MACF_TOUCH_NAG_BASE=0 kill switch.
+"""
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from macf.hooks.handle_pre_tool_use import _touch_discipline_nag
+
+
+@pytest.fixture
+def nag_env(tmp_path, monkeypatch):
+    """Fake task store + session dir; base threshold of 3 for fast tests."""
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "1.json").write_text("{}")
+
+    session_dir = tmp_path / "session_hooks"
+    session_dir.mkdir()
+
+    class FakeReader:
+        def __init__(self):
+            self.tasks_dir = tasks_dir
+
+    import macf.task
+    import macf.utils
+    monkeypatch.setattr(macf.task, "TaskReader", FakeReader)
+    monkeypatch.setattr(macf.utils, "get_session_dir", lambda **kw: session_dir)
+    monkeypatch.setenv("MACF_TOUCH_NAG_BASE", "3")
+    return tasks_dir, session_dir
+
+
+def _run_n(n, session="s"):
+    out = []
+    for _ in range(n):
+        out.append(_touch_discipline_nag(session))
+    return out
+
+
+def test_silent_below_threshold(nag_env):
+    assert _run_n(2) == ["", ""]
+
+
+def test_fires_at_base_then_silent_then_ramps(nag_env):
+    msgs = _run_n(9)
+    assert msgs[2] != "" and "3 tool calls" in msgs[2]      # n == base
+    assert msgs[3] == "" and msgs[4] == ""                   # between thresholds
+    assert msgs[5] != "" and "6 tool calls" in msgs[5]      # n == 2*base
+    assert msgs[8] != "" and "9 tool calls" in msgs[8]      # n == 3*base
+
+
+def test_ramp_tone_escalates(nag_env):
+    msgs = _run_n(9)
+    assert msgs[2].startswith("\U0001f331")   # seedling
+    assert msgs[5].startswith("\U0001f33f")   # herb
+    assert msgs[8].startswith("\U0001f333")   # tree
+
+
+def test_store_touch_resets_counter(nag_env):
+    tasks_dir, _ = nag_env
+    _run_n(2)
+    # Touch the store (newer mtime), as any task note/start/complete would
+    time.sleep(0.01)
+    f = tasks_dir / "1.json"
+    f.write_text("{}")
+    now = time.time()
+    import os
+    os.utime(f, (now + 5, now + 5))
+    msgs = _run_n(3)
+    assert msgs[0] == "" and msgs[1] == ""    # counter restarted at 1, 2
+    assert "3 tool calls" in msgs[2]          # fires again at base
+
+
+def test_kill_switch(nag_env, monkeypatch):
+    monkeypatch.setenv("MACF_TOUCH_NAG_BASE", "0")
+    assert _run_n(5) == [""] * 5


### PR DESCRIPTION
Replaces #143 (auto-closed when #142's base branch was deleted on merge during the 2026-07-24 GitHub incident; branch intact). Adds a 👈 last-touched recency marker (fills the slot #142 freed) + a touch-discipline nag in handle_pre_tool_use. Rebased on current main; 49 tests pass py3.14, live render verified.