### PR TITLE
fix(hooks): PreToolUse denies no longer halt the turn

### DIFF
--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -236,8 +236,9 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                 "  macf_tools task create task \"Title\"         # Standalone task\n\n"
                 "📚 For guidance: macf_tools policy navigate task_management"
             )
+            # deny (without continue:False) blocks the call but lets the agent
+            # read the reason and retry via the CLI (gh-154)
             return {
-                "continue": False,
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
@@ -282,8 +283,9 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                 f"{hint}\n\n"
                 "📚 For guidance: macf_tools policy navigate task_management"
             )
+            # deny (without continue:False) blocks the call but lets the agent
+            # read the reason and retry via the CLI (gh-154)
             return {
-                "continue": False,
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
@@ -393,10 +395,10 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                         # AUTO_MODE: warn but continue
                         message_parts.append(f"⚠️ Bare cd detected - use subshell or absolute paths")
                     else:
-                        # MANUAL_MODE: Use permissionDecision pattern (like TodoWrite)
-                        # This shows as permission dialog, not scary "Error:"
+                        # MANUAL_MODE: deny (without continue:False) blocks the
+                        # call but lets the agent read the reason, rewrap the
+                        # command, and retry in the same turn (gh-154)
                         return {
-                            "continue": False,
                             "hookSpecificOutput": {
                                 "hookEventName": "PreToolUse",
                                 "permissionDecision": "deny",

--- a/macf/tests/test_handle_pre_tool_use.py
+++ b/macf/tests/test_handle_pre_tool_use.py
@@ -311,3 +311,62 @@ def test_anticipate_compound_shell_command(mock_dependencies):
     assert "🔨" in context
     # Old work mode should NOT appear — set-work replaces, not stacks
     assert "🔍" not in context
+
+
+# ==================== Deny-Without-Halt Tests (issue #154) ====================
+# permissionDecision "deny" must NOT be paired with continue:False — deny alone
+# rejects the tool call and feeds the reason back so the agent can retry in the
+# same turn; continue:False halts the whole turn (unrecoverable without a human).
+
+def _assert_deny_with_continuation(result):
+    hso = result["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "deny"
+    assert hso["permissionDecisionReason"]
+    # The critical regression check: no turn-halting flag on a recoverable deny
+    assert result.get("continue") is not False
+
+
+def test_taskcreate_deny_does_not_halt_turn(mock_dependencies):
+    """TaskCreate redirect denies the call but leaves the turn continuable."""
+    from macf.hooks.handle_pre_tool_use import run
+    import json
+
+    stdin = json.dumps({
+        "tool_name": "TaskCreate",
+        "tool_input": {"subject": "some task"}
+    })
+    result = run(stdin)
+
+    _assert_deny_with_continuation(result)
+    assert "Use CLI commands" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_taskupdate_deny_does_not_halt_turn(mock_dependencies):
+    """TaskUpdate redirect denies the call but leaves the turn continuable."""
+    from macf.hooks.handle_pre_tool_use import run
+    import json
+
+    stdin = json.dumps({
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "7", "status": "completed"}
+    })
+    result = run(stdin)
+
+    _assert_deny_with_continuation(result)
+    assert "task complete" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_bare_cd_manual_mode_deny_does_not_halt_turn(mock_dependencies):
+    """MANUAL_MODE bare-cd guard denies the call but leaves the turn continuable."""
+    from macf.hooks.handle_pre_tool_use import run
+    import json
+
+    with patch('macf.hooks.handle_pre_tool_use.detect_auto_mode', return_value=(False, None)):
+        stdin = json.dumps({
+            "tool_name": "Bash",
+            "tool_input": {"command": "cd /some/path && make test"}
+        })
+        result = run(stdin)
+
+    _assert_deny_with_continuation(result)
+    assert "Bare 'cd'" in result["hookSpecificOutput"]["permissionDecisionReason"]


### PR DESCRIPTION
Fixes #154

The three PreToolUse deny returns (TaskCreate redirect, TaskUpdate redirect, bare-cd MANUAL_MODE guard) paired permissionDecision "deny" with "continue": False. Per the Claude Code hooks contract, deny alone blocks the tool call and surfaces the reason to the model so it can correct and retry in the same turn; continue:false takes precedence and stops the turn outright. The practical effect was that an easily recoverable violation (like a bare cd the hook itself tells you how to rewrap) killed the agent's continuation and needed a manual re-prompt.

Fix: drop "continue": False from the deny returns. The deny + reason already carries the corrective guidance.

Also adds three regression tests asserting deny responses leave the turn continuable.

**Test evidence**: `python3 -m pytest macf/tests/test_handle_pre_tool_use.py -q` passes locally (18 passed, 2 xfailed, includes the new tests). Full suite: 925 passed; the only failures are pre-existing ModuleNotFoundError (lancedb not installed locally) in search modules unrelated to this change.