### PR TITLE
feat(tasks): make GH_ISSUE close-out calling card opt-in

### DIFF
--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -848,8 +848,33 @@ GH_ISSUE tasks bridge to external GitHub issues. Completion requires the agent t
    - The agent's `--report` text as the body (the agent's conscious, professional contribution)
    - Commit links (automated from `--commit` hashes)
    - Verification method (automated from `--verified` text)
-   - Agent calling card footer: `[AgentName: task#N breadcrumb]` for traceability
+   - Agent calling card footer: `[AgentName: task#N breadcrumb]` for traceability —
+     **opt-in only**, gated by `opsec.public_attribution` in `{agent_home}/.maceff/config.json`
+     (default `false`; see below)
    - Issue closed with reason "completed"
+
+   **Calling-card attribution is opt-in (`opsec.public_attribution`)**:
+
+   ```json
+   {
+     "opsec": {
+       "public_attribution": true
+     }
+   }
+   ```
+
+   🚨 **OPSEC WARNING**: enabling this publishes the agent's calling card
+   (moniker + id fragment) and breadcrumb on a **public** GitHub issue. The
+   pair is a deliberate link between public artifacts and the agent's private
+   task/transcript context: fully traceable by the agent's operator, innocuous
+   to third parties — but it still reveals to the public that an agent produced
+   the work and gives that agent a stable public identity. Default is OFF so
+   operator-proxy deployments (public work authored under the operator's
+   identity, no agent attribution) are safe out of the box. Turn it ON
+   deliberately — the intended case is dogfooding agents contributing to MacEff
+   or other repos where agent traceability is part of the development story.
+   The `--report` body itself must still never contain private-context
+   non-sequiturs; the gate covers only the structured footer.
 
    **Agent Responsibility in the Report**: The `--report` text IS the professional contribution. Draft it with the posture of an excellent OSS maintainer:
    - Thank the contributor for the report (if filed by someone other than the closing agent)
@@ -884,7 +909,7 @@ The gate pattern generalizes to any task type. Each gate redirects to its own po
 
 | Type | Gate Concept | Status |
 |------|-------------|--------|
-| GH_ISSUE | Commit citations + verification method + GitHub closeout + calling card | Implemented (DETOUR #99) |
+| GH_ISSUE | Commit citations + verification method + GitHub closeout + calling card (opt-in via opsec.public_attribution) | Implemented (DETOUR #99) |
 | MISSION | All phases completed | Future |
 | EXPERIMENT | Results documented | Future |
 | DELEG_PLAN | Delegation executed | Future |

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6491,12 +6491,41 @@ def _commit_landed_in_merged_pr(repo_slug: str, commits: list) -> bool:
     return False
 
 
+def _public_attribution_enabled() -> bool:
+    """Read opsec.public_attribution from {agent_home}/.maceff/config.json.
+
+    Gates the calling-card footer on public GitHub close-out comments
+    (GH issue #156). Default False: operators running agents in proxy mode
+    (public artifacts authored under the operator's identity) must not leak
+    agent monikers, id fragments, or breadcrumbs to public surfaces.
+
+    🚨 OPSEC: setting this to true publishes the agent's calling card and
+    breadcrumb on public issues. The pair is only traceable by the agent's
+    operator (it links public artifacts back to private task/transcript
+    context) and is innocuous to third parties, but it still reveals that an
+    agent produced the work and gives it a stable public identity. Enable it
+    deliberately — e.g. for dogfooding agents contributing to MacEff itself —
+    never by default.
+    """
+    try:
+        from .utils.paths import find_agent_home
+        config_file = find_agent_home() / ".maceff" / "config.json"
+        if config_file.exists():
+            data = json.loads(config_file.read_text())
+            opsec = data.get("opsec", {}) or {}
+            return bool(opsec.get("public_attribution", False))
+    except (OSError, ValueError) as e:
+        print(f"⚠️ MACF: opsec config read failed: {e}", file=sys.stderr)
+    return False
+
+
 def _gh_issue_closeout(task_id: int, mtmd, args, breadcrumb: str) -> None:
     """Post close-out comment and close GitHub issue.
 
     The --report is the agent's conscious, professional contribution — passed
     through as the comment body. Automation adds structured metadata (commits,
-    verification) and a calling card footer for agent traceability.
+    verification) and — only when opsec.public_attribution is enabled — a
+    calling card footer for agent traceability (GH issue #156).
 
     Closure semantics (GH issue #79): the upstream issue is closed ONLY if at
     least one of the supplied --commit hashes is verifiably in a merged PR on
@@ -6518,20 +6547,12 @@ def _gh_issue_closeout(task_id: int, mtmd, args, breadcrumb: str) -> None:
         print("   ⚠️  Missing GitHub metadata — skipping GitHub closeout")
         return
 
-    # Resolve agent identity for calling card
-    try:
-        from .utils.identity import get_agent_identity
-        agent_name = get_agent_identity()
-    except (ImportError, OSError) as e:
-        print(f"⚠️ MACF: agent identity resolution failed: {e}", file=sys.stderr)
-        agent_name = "unknown"
-
     repo_slug = f"{gh_owner}/{gh_repo}"
 
     # Compose close-out comment:
     # - Report body (agent's conscious contribution)
     # - Structured commits and verification
-    # - Calling card footer
+    # - Calling card footer (opt-in via opsec.public_attribution — issue #156)
     comment_lines = ["## Close-out Report", ""]
     comment_lines.append(args.report)
 
@@ -6545,9 +6566,17 @@ def _gh_issue_closeout(task_id: int, mtmd, args, breadcrumb: str) -> None:
         comment_lines.append("")
         comment_lines.append(f"**Verification:** {args.verified}")
 
-    comment_lines.append("")
-    comment_lines.append("---")
-    comment_lines.append(f"*[{agent_name}: task#{task_id} {breadcrumb}]*")
+    if _public_attribution_enabled():
+        # Resolve agent identity for calling card
+        try:
+            from .utils.identity import get_agent_identity
+            agent_name = get_agent_identity()
+        except (ImportError, OSError) as e:
+            print(f"⚠️ MACF: agent identity resolution failed: {e}", file=sys.stderr)
+            agent_name = "unknown"
+        comment_lines.append("")
+        comment_lines.append("---")
+        comment_lines.append(f"*[{agent_name}: task#{task_id} {breadcrumb}]*")
 
     comment_body = "\n".join(comment_lines)
 

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -686,8 +686,16 @@ class TestGHIssueCompletionGate:
 class TestGHIssueCloseoutFunction:
     """Test _gh_issue_closeout helper directly with mocked subprocess."""
 
-    def test_posts_comment_with_calling_card(self):
-        """Verify comment format includes report, commits, verification, calling card."""
+    @staticmethod
+    def _closeout_body(mock_run):
+        """Extract the --body payload from the gh issue comment call."""
+        comment_call = [c for c in mock_run.call_args_list
+                        if c[0][0][:3] == ['gh', 'issue', 'comment']][0]
+        cmd = comment_call[0][0]
+        return cmd[cmd.index('--body') + 1]
+
+    def test_posts_comment_with_calling_card_when_attribution_enabled(self):
+        """With opsec.public_attribution on: report, commits, verification, calling card."""
         from macf.cli import _gh_issue_closeout
         from macf.task.models import MacfTaskMetaData
 
@@ -699,20 +707,41 @@ class TestGHIssueCloseoutFunction:
         args.verified = 'Unit tests pass'
         bc = 's_test/c_1/g_abc/p_def/t_123'
 
-        with patch('subprocess.run', return_value=Mock(returncode=0, stdout='', stderr='')) as mock_run:
+        with patch('subprocess.run', return_value=Mock(returncode=0, stdout='', stderr='')) as mock_run, \
+             patch('macf.cli._public_attribution_enabled', return_value=True):
             _gh_issue_closeout(42, mtmd, args, bc)
             assert mock_run.call_count >= 2
-            # Find the comment call (gh issue comment ...)
-            comment_call = [c for c in mock_run.call_args_list
-                            if c[0][0][:3] == ['gh', 'issue', 'comment']][0]
-            cmd = comment_call[0][0]
-            body = cmd[cmd.index('--body') + 1]
+            body = self._closeout_body(mock_run)
             assert 'Close-out Report' in body
             assert 'Fixed the API bug' in body
             assert 'abc12345' in body  # truncated hash link
             assert 'Unit tests pass' in body
             assert 'task#42' in body
             assert bc in body
+
+    def test_omits_calling_card_by_default(self):
+        """OPSEC default (issue #156): no agent attribution on public comments."""
+        from macf.cli import _gh_issue_closeout
+        from macf.task.models import MacfTaskMetaData
+
+        mtmd = MacfTaskMetaData(task_type='GH_ISSUE', custom={
+            'gh_owner': 'testowner', 'gh_repo': 'testrepo', 'gh_issue_number': 42})
+        args = Mock()
+        args.report = 'Fixed the API bug'
+        args.commit = ['abc1234567890']
+        args.verified = 'Unit tests pass'
+        bc = 's_test/c_1/g_abc/p_def/t_123'
+
+        with patch('subprocess.run', return_value=Mock(returncode=0, stdout='', stderr='')) as mock_run, \
+             patch('macf.cli._public_attribution_enabled', return_value=False):
+            _gh_issue_closeout(42, mtmd, args, bc)
+            body = self._closeout_body(mock_run)
+            assert 'Close-out Report' in body
+            assert 'Fixed the API bug' in body
+            # No calling card, no breadcrumb, no trailing separator
+            assert 'task#42' not in body
+            assert bc not in body
+            assert not body.rstrip().endswith('---')
 
     def test_handles_missing_gh_cli(self):
         """_gh_issue_closeout handles FileNotFoundError gracefully."""


### PR DESCRIPTION
Fixes #156

The GH_ISSUE close-out comment's calling-card footer (agent moniker + id fragment + breadcrumb) is now gated behind `opsec.public_attribution` in `{agent_home}/.maceff/config.json`, default `false`.

Rationale: the footer is a useful public-to-private traceability link for the agent's operator - it walks straight back to the task and transcript moment - and it is innocuous to third parties. But it publishes the agent's identity, which operator-proxy deployments are configured to withhold, and it posted with no preview. Off by default keeps proxy mode safe out of the box; deployments that want the traceability (e.g. dogfooding agents contributing to MacEff itself) enable it deliberately:

```json
{
  "opsec": {
    "public_attribution": true
  }
}
```

Also documents the flag in the task_management policy with an OPSEC warning, and updates the close-out tests to cover both states (footer present when enabled, absent by default).

**Test evidence**: `python3 -m pytest macf/tests/test_task_cli.py -q` passes locally (45 passed). Broader suite: 914 passed; only failures are pre-existing ModuleNotFoundError (lancedb not installed locally) in search modules unrelated to this change.