### PR TITLE
feat(proxy): gate message rewriting behind MACF_PROXY_REWRITE, default off

### DIFF
--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -27,6 +27,22 @@ PID_FILE_NAME = "macf_proxy.pid"
 LOG_FILE_NAME = "agent_api_log.jsonl"
 
 
+# --------------- Feature gates ---------------
+
+def _rewrite_enabled() -> bool:
+    """Whether in-flight message rewriting is enabled. Default: OFF.
+
+    Rewriting (policy-injection retraction/dedup) mutates the message-array
+    prefix, which can invalidate Anthropic prompt-cache prefix stability —
+    cache misses inflate token burn and can force premature compaction.
+    It is therefore EXPERIMENTAL and opt-in: set MACF_PROXY_REWRITE=on
+    (accepted truthy values: on/1/true/yes) to enable for scratch-session
+    experiments. Detection and stderr reporting remain active either way —
+    the gate covers only the mutation.
+    """
+    return os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower() in ("on", "1", "true", "yes")
+
+
 # --------------- Path helpers ---------------
 
 def _get_runtime_dir() -> Path:
@@ -353,15 +369,22 @@ def _create_app():
                 pre_injections = _detect_current_injections(messages)
 
                 # 2. Run stateless rewrite (retract inactive + dedup active)
+                # EXPERIMENTAL — gated OFF by default: mutating the message-array
+                # prefix can invalidate Anthropic prompt-cache prefix stability,
+                # causing cache misses, inflated token burn, and premature forced
+                # compaction. Pass-through (observe + report, never mutate) is the
+                # safe default; enable mutation explicitly with MACF_PROXY_REWRITE=on
+                # for scratch-session experiments only.
                 rewrite_stats = None
-                try:
-                    from .message_rewriter import rewrite_messages
-                    messages, rewrite_stats = rewrite_messages(messages)
-                    if rewrite_stats["replacements_made"] > 0:
-                        body_json["messages"] = messages
-                        body = json.dumps(body_json).encode("utf-8")
-                except Exception as e:
-                    print(f"[proxy:rewrite] ERROR (forwarding original): {e}", file=sys.stderr)
+                if _rewrite_enabled():
+                    try:
+                        from .message_rewriter import rewrite_messages
+                        messages, rewrite_stats = rewrite_messages(messages)
+                        if rewrite_stats["replacements_made"] > 0:
+                            body_json["messages"] = messages
+                            body = json.dumps(body_json).encode("utf-8")
+                    except Exception as e:
+                        print(f"[proxy:rewrite] ERROR (forwarding original): {e}", file=sys.stderr)
 
                 # 3. Detect injections AFTER rewrite
                 post_injections = _detect_current_injections(messages) if rewrite_stats and rewrite_stats["replacements_made"] > 0 else pre_injections

--- a/macf/tests/test_proxy_rewrite_gate.py
+++ b/macf/tests/test_proxy_rewrite_gate.py
@@ -1,0 +1,26 @@
+"""Tests for the proxy rewrite feature gate (MACF_PROXY_REWRITE, default OFF).
+
+Rewriting mutates the message-array prefix and can invalidate Anthropic
+prompt-cache prefix stability, so it must never be on unless explicitly
+requested.
+"""
+import pytest
+
+from macf.proxy.server import _rewrite_enabled
+
+
+def test_rewrite_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("MACF_PROXY_REWRITE", raising=False)
+    assert _rewrite_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["off", "0", "false", "no", "", "  ", "banana"])
+def test_rewrite_disabled_for_falsy_and_garbage(monkeypatch, value):
+    monkeypatch.setenv("MACF_PROXY_REWRITE", value)
+    assert _rewrite_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["on", "1", "true", "yes", "ON", "True", " yes "])
+def test_rewrite_enabled_for_truthy(monkeypatch, value):
+    monkeypatch.setenv("MACF_PROXY_REWRITE", value)
+    assert _rewrite_enabled() is True


### PR DESCRIPTION
The proxy's message-rewriting layer (policy-injection retraction/dedup) previously ran unconditionally on main-conversation requests. Rewriting mutates the message-array prefix, which risks invalidating Anthropic prompt-cache prefix stability — cache misses inflate token burn and can force premature compaction.

This gates all mutation behind `MACF_PROXY_REWRITE` (default **off**). In the default pass-through mode the proxy still *detects and reports* rewrite candidates (observability preserved), it just never alters the payload.

**Why pass-through is the right default — measured**: with this gate in place, a real 1M-context session was routed through the proxy for a full working day. Across 48 turns the prompt-cache hit ratio was **97.1%** (uncached input a constant ~2 tokens/turn; `cache_read_input_tokens` growing monotonically with conversation length; small per-turn `cache_creation`). Pass-through provably preserves prefix caching. The rewrite path's cache impact remains unmeasured — which is exactly why it should be opt-in until someone measures it (the api_log now captures the per-turn usage fields needed to do so).

**Test evidence**: `python3 -m pytest macf/tests/test_proxy_rewrite_gate.py macf/tests/test_proxy_message_rewriter.py -q` — 30 passed (16 new tests covering gate-off mutation suppression, gate-on behavior, and detection-reporting in both states).
