### PR TITLE
refactor(hooks): DRY MACF banner brand; SessionStart AUTO_MODE parity + resume continuation directive

### DIFF
--- a/macf/src/macf/hooks/handle_notification.py
+++ b/macf/src/macf/hooks/handle_notification.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_minimal_timestamp,
     get_current_session_id,
     get_breadcrumb
@@ -65,7 +66,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Format message (Pattern C: top-level for user + hookSpecificOutput for agent)
         timestamp = get_minimal_timestamp()
         breadcrumb = get_breadcrumb()
-        message = f"🏗️ MACF | {timestamp} | {breadcrumb} | 📢 Notification: {notification_type}"
+        message = f"{format_macf_brand()} | {timestamp} | {breadcrumb} | 📢 Notification: {notification_type}"
 
         # Note: Notification hook doesn't support hookSpecificOutput
         # (only PreToolUse, UserPromptSubmit, PostToolUse do)
@@ -84,7 +85,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         })
         return {
             "continue": True,
-            "systemMessage": f"🏗️ MACF | ❌ Notification hook error: {e}"
+            "systemMessage": f"{format_macf_brand()} | ❌ Notification hook error: {e}"
         }
 
 

--- a/macf/src/macf/hooks/handle_permission_request.py
+++ b/macf/src/macf/hooks/handle_permission_request.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_minimal_timestamp,
     get_current_session_id,
     get_breadcrumb
@@ -112,7 +113,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # (only PreToolUse, UserPromptSubmit, PostToolUse do)
         timestamp = get_minimal_timestamp()
         breadcrumb = get_breadcrumb()
-        message = f"🏗️ MACF | {timestamp} | {breadcrumb} | 🔐 Permission: {tool_name}"
+        message = f"{format_macf_brand()} | {timestamp} | {breadcrumb} | 🔐 Permission: {tool_name}"
 
         # Send file preview to Telegram (non-blocking, never fails the hook)
         try:
@@ -142,7 +143,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         })
         return {
             "continue": True,
-            "systemMessage": f"🏗️ MACF | ❌ PermissionRequest hook error: {e}"
+            "systemMessage": f"{format_macf_brand()} | ❌ PermissionRequest hook error: {e}"
         }
 
 

--- a/macf/src/macf/hooks/handle_pre_compact.py
+++ b/macf/src/macf/hooks/handle_pre_compact.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_temporal_context,
     format_macf_footer,
     get_current_session_id,
@@ -72,7 +73,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Format message
         # Note: PreCompact hook doesn't support hookSpecificOutput
         # (only PreToolUse, UserPromptSubmit, PostToolUse do)
-        message = f"""🏗️ MACF | Pre-Compact
+        message = f"""{format_macf_brand()} | Pre-Compact
 Time: {temporal_ctx['timestamp_formatted']}
 Breadcrumb: {breadcrumb}
 CL: {token_info.get('cl_level', 'N/A')}
@@ -103,7 +104,7 @@ CL: {token_info.get('cl_level', 'N/A')}
         })
         return {
             "continue": True,
-            "systemMessage": f"🏗️ MACF | ❌ PreCompact hook error: {e}"
+            "systemMessage": f"{format_macf_brand()} | ❌ PreCompact hook error: {e}"
         }
 
 

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -11,6 +11,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_minimal_timestamp,
     get_current_session_id,
     start_deleg_drv,
@@ -214,7 +215,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             emit_warning(Warning(source="pre_tool_use", kind="mode_detection_failed", detail=f"mode detection failed, falling back: {e}"))
             auto_mode_active, _ = detect_auto_mode(session_id)
             mode_indicator = " 🤖" if auto_mode_active else ""
-        message_parts = [f"🏗️ MACF{mode_indicator} | {timestamp} | {breadcrumb}"]
+        message_parts = [f"{format_macf_brand(indicators=mode_indicator)} | {timestamp} | {breadcrumb}"]
 
         # Surface any injection errors to user
         if injection_errors:
@@ -482,7 +483,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             "error": str(e),
             "traceback": traceback.format_exc()
         })
-        error_msg = f"🏗️ MACF | ❌ PreToolUse hook error: {e}"
+        error_msg = f"{format_macf_brand()} | ❌ PreToolUse hook error: {e}"
         return {
             "continue": True,
             "systemMessage": error_msg,

--- a/macf/src/macf/hooks/handle_session_end.py
+++ b/macf/src/macf/hooks/handle_session_end.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_temporal_context,
     format_macf_footer,
     get_current_session_id,
@@ -68,7 +69,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Format message
         # Note: SessionEnd hook doesn't support hookSpecificOutput
         # (only PreToolUse, UserPromptSubmit, PostToolUse do)
-        message = f"""🏗️ MACF | Session Ended
+        message = f"""{format_macf_brand()} | Session Ended
 Time: {temporal_ctx['timestamp_formatted']}
 Session: {session_id[:8]}...
 Breadcrumb: {breadcrumb}
@@ -99,7 +100,7 @@ Breadcrumb: {breadcrumb}
         })
         return {
             "continue": True,
-            "systemMessage": f"🏗️ MACF | ❌ SessionEnd hook error: {e}"
+            "systemMessage": f"{format_macf_brand()} | ❌ SessionEnd hook error: {e}"
         }
 
 

--- a/macf/src/macf/hooks/handle_session_start.py
+++ b/macf/src/macf/hooks/handle_session_start.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_current_session_id,
     get_latest_consciousness_artifacts,
     detect_auto_mode,
@@ -524,8 +525,13 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         compaction_info = get_compaction_count_from_events(session_id)
         compaction_count = compaction_info.get('count', 0)
 
+        # AUTO_MODE detection for banner parity with other hooks (issue #164).
+        # Previously only the migration/compaction branches detected mode, so
+        # fresh and resume banners never showed the 🤖 indicator.
+        auto_mode, mode_source = detect_auto_mode(session_id)
+
         # Format temporal awareness message
-        message = f"""🏗️ MACF | Session Start
+        message = f"""{format_macf_brand(auto_mode=auto_mode)} | Session Start
 Current Time: {temporal_ctx['timestamp_formatted']}
 Day: {temporal_ctx['day_of_week']}
 Time of Day: {temporal_ctx['time_of_day']}
@@ -564,12 +570,28 @@ Session Context:
             emit_warning(Warning(source="session_start", kind="telegram_send_failed", detail=f"session-start telegram notification failed: {e}"))
 
         # Pattern C: top-level systemMessage for user + hookSpecificOutput for agent
+        additional_context = f"<system-reminder>\n{message}\n</system-reminder>"
+
+        # AUTO_MODE resume kick (issue #164): SessionStart:resume hands the turn
+        # back to the user, which strands an unattended AUTO_MODE agent. Hooks
+        # cannot submit a prompt, so inject a standing directive that tells the
+        # agent to continue its authorized work whenever the next turn fires
+        # (operator Enter, supervisor kick, or queued prompt).
+        if source == 'resume' and auto_mode:
+            additional_context += (
+                "\n<system-reminder>\n"
+                f"🤖 AUTO_MODE RESUME (source: {mode_source}): persistent AUTO_MODE is active. "
+                "Resume your authorized in-progress work immediately — do not stop to await "
+                "a new operator prompt.\n"
+                "</system-reminder>"
+            )
+
         return {
             "continue": True,
             "systemMessage": message,  # TOP LEVEL - user sees this
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",
-                "additionalContext": f"<system-reminder>\n{message}\n</system-reminder>"
+                "additionalContext": additional_context
             }
         }
 

--- a/macf/src/macf/hooks/handle_stop.py
+++ b/macf/src/macf/hooks/handle_stop.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_temporal_context,
     format_macf_footer,
     get_rich_environment_string,
@@ -141,7 +142,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             mode_indicator = " 🤖" if auto_mode else ""
 
         # Format message with full timestamp and DEV_DRV summary
-        message = f"""🏗️ MACF{mode_indicator} | DEV_DRV Complete
+        message = f"""{format_macf_brand(indicators=mode_indicator)} | DEV_DRV Complete
 Current Time: {temporal_ctx['timestamp_formatted']}
 Day: {temporal_ctx['day_of_week']}
 Time of Day: {temporal_ctx['time_of_day']}
@@ -536,7 +537,7 @@ Development Drive Stats:
             emit_warning(Warning(source="stop", kind="telegram_send_failed", detail=f"Telegram error notification also failed: {tg_e}"))
         return {
             "continue": True,
-            "systemMessage": f"🏗️ MACF | ❌ Stop hook error: {e}"
+            "systemMessage": f"{format_macf_brand()} | ❌ Stop hook error: {e}"
         }
 
 

--- a/macf/src/macf/hooks/handle_subagent_stop.py
+++ b/macf/src/macf/hooks/handle_subagent_stop.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_temporal_context,
     format_macf_footer,
     get_rich_environment_string,
@@ -146,7 +147,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             f"[{subagent_type}|{agent_id[:8]}]" if agent_id else
             f"[{subagent_type}]"
         )
-        message = f"""🏗️ MACF | DELEG_DRV Complete {tag_line}
+        message = f"""{format_macf_brand()} | DELEG_DRV Complete {tag_line}
 Current Time: {temporal_ctx['timestamp_formatted']}
 Day: {temporal_ctx['day_of_week']}
 Time of Day: {temporal_ctx['time_of_day']}
@@ -207,7 +208,7 @@ Delegation Drive Stats:
         })
         # Note: SubagentStop hook doesn't support hookSpecificOutput
         # (only PreToolUse, UserPromptSubmit, PostToolUse do)
-        error_msg = f"🏗️ MACF | ❌ SubagentStop hook error: {e}"
+        error_msg = f"{format_macf_brand()} | ❌ SubagentStop hook error: {e}"
         return {
             "continue": True,
             "systemMessage": error_msg

--- a/macf/src/macf/hooks/handle_user_prompt_submit.py
+++ b/macf/src/macf/hooks/handle_user_prompt_submit.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from macf.utils import (
+    format_macf_brand,
     get_temporal_context,
     format_macf_footer,
     get_rich_environment_string,
@@ -194,7 +195,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             mode_indicator = " 🤖" if auto_mode else ""
 
         # Format temporal section with breadcrumb
-        temporal_section = f"""🏗️ MACF{mode_indicator} | DEV_DRV Started
+        temporal_section = f"""{format_macf_brand(indicators=mode_indicator)} | DEV_DRV Started
 Current Time: {temporal_ctx['timestamp_formatted']}
 Day: {temporal_ctx['day_of_week']}
 Time of Day: {temporal_ctx['time_of_day']}
@@ -292,7 +293,7 @@ Breadcrumb: {breadcrumb}"""
             "error": str(e),
             "traceback": traceback.format_exc()
         })
-        error_msg = f"🏗️ MACF | ❌ UserPromptSubmit hook error: {e}"
+        error_msg = f"{format_macf_brand()} | ❌ UserPromptSubmit hook error: {e}"
         return {
             "continue": True,
             "systemMessage": error_msg,

--- a/macf/src/macf/utils/__init__.py
+++ b/macf/src/macf/utils/__init__.py
@@ -86,6 +86,7 @@ from .manifest import (
     list_policy_files,
 )
 from .formatting import (
+    format_macf_brand,
     format_macf_footer,
     format_proprioception_awareness,
     get_claude_code_version,
@@ -124,6 +125,7 @@ __all__ = [
     "find_project_root",
     "format_breadcrumb",
     "format_duration",
+    "format_macf_brand",
     "format_macf_footer",
     "format_proprioception_awareness",
     "get_agent_identity",

--- a/macf/src/macf/utils/formatting.py
+++ b/macf/src/macf/utils/formatting.py
@@ -212,3 +212,33 @@ def format_proprioception_awareness() -> str:
         print(f"⚠️ MACF: macf_tools env failed during proprioception: {e}", file=sys.stderr)
 
     return "\n\n".join(sections)
+
+
+def format_macf_brand(session_id=None, auto_mode=None, indicators=None) -> str:
+    """
+    Canonical MACF brand segment — the first token of every hook banner.
+
+    Single source of truth for "🏗️ MACF" plus mode indicators, replacing
+    per-hook hand-rolled f-string prefixes.
+
+    Args:
+        session_id: If given (and auto_mode is None), AUTO_MODE is detected
+            hierarchically via detect_auto_mode(session_id).
+        auto_mode: Explicit AUTO_MODE flag; appends " 🤖" when True.
+        indicators: Pre-computed indicator string (e.g. from
+            format_mode_indicators). Takes precedence; appended verbatim.
+
+    Returns:
+        "🏗️ MACF", "🏗️ MACF 🤖", or "🏗️ MACF{indicators}".
+    """
+    if indicators is not None:
+        return f"🏗️ MACF{indicators}"
+    if auto_mode is None:
+        auto_mode = False
+        if session_id:
+            try:
+                from .cycles import detect_auto_mode
+                auto_mode, _ = detect_auto_mode(session_id)
+            except Exception:
+                auto_mode = False
+    return "🏗️ MACF 🤖" if auto_mode else "🏗️ MACF"

--- a/macf/src/macf/utils/temporal.py
+++ b/macf/src/macf/utils/temporal.py
@@ -231,4 +231,5 @@ def format_minimal_temporal_message(timestamp: str) -> str:
     Returns:
         Formatted message with 🏗️ MACF tag
     """
-    return f"🏗️ MACF | {timestamp}"
+    from .formatting import format_macf_brand
+    return f"{format_macf_brand()} | {timestamp}"

--- a/macf/tests/test_formatting.py
+++ b/macf/tests/test_formatting.py
@@ -98,3 +98,37 @@ class TestStrategy1HookRecursionRegression:
         monkeypatch.setenv("MACF_CC_VERSION", "1.2.3")
 
         assert get_claude_code_version() == "1.2.3"
+
+
+class TestFormatMacfBrand:
+    """format_macf_brand — canonical banner first segment (issue #164)."""
+
+    def test_bare_brand(self):
+        from macf.utils.formatting import format_macf_brand
+        assert format_macf_brand() == "🏗️ MACF"
+
+    def test_auto_mode_true_appends_robot(self):
+        from macf.utils.formatting import format_macf_brand
+        assert format_macf_brand(auto_mode=True) == "🏗️ MACF 🤖"
+
+    def test_auto_mode_false_bare(self):
+        from macf.utils.formatting import format_macf_brand
+        assert format_macf_brand(auto_mode=False) == "🏗️ MACF"
+
+    def test_indicators_verbatim(self):
+        from macf.utils.formatting import format_macf_brand
+        assert format_macf_brand(indicators=" 🤖 ⚙️") == "🏗️ MACF 🤖 ⚙️"
+
+    def test_indicators_take_precedence(self):
+        from macf.utils.formatting import format_macf_brand
+        assert format_macf_brand(auto_mode=True, indicators="") == "🏗️ MACF"
+
+    def test_session_id_detection(self):
+        from macf.utils.formatting import format_macf_brand
+        with patch('macf.utils.cycles.detect_auto_mode', return_value=(True, "event")):
+            assert format_macf_brand(session_id="s-123") == "🏗️ MACF 🤖"
+
+    def test_detection_failure_falls_back_to_bare(self):
+        from macf.utils.formatting import format_macf_brand
+        with patch('macf.utils.cycles.detect_auto_mode', side_effect=OSError("boom")):
+            assert format_macf_brand(session_id="s-123") == "🏗️ MACF"

--- a/macf/tests/test_handle_session_start.py
+++ b/macf/tests/test_handle_session_start.py
@@ -461,3 +461,69 @@ def test_source_resume_skips_compaction_detection(mock_dependencies):
 
 # NOTE: test_cycle_increments_on_compaction removed - tested deleted increment_agent_cycle function
 # Event-first architecture: cycle tracked via compaction_detected events, not state mutations
+
+
+def _run_shared_path(mock_dependencies, stdin_json, auto_mode):
+    """Drive the fresh/resume shared banner path with all IO mocked."""
+    from macf.hooks.handle_session_start import run
+    from unittest.mock import patch
+
+    mock_dependencies['detect_compaction'].return_value = False
+    mock_dependencies['auto_mode'].return_value = (auto_mode, "event" if auto_mode else "default")
+
+    with patch('macf.hooks.handle_session_start.get_temporal_context') as mock_temporal, \
+         patch('macf.hooks.handle_session_start.get_rich_environment_string') as mock_env, \
+         patch('macf.hooks.handle_session_start.get_breadcrumb') as mock_breadcrumb, \
+         patch('macf.hooks.handle_session_start.get_last_session_end_time_from_events') as mock_last_end, \
+         patch('macf.hooks.handle_session_start.get_token_info') as mock_token, \
+         patch('macf.hooks.handle_session_start.format_token_context_full') as mock_token_fmt, \
+         patch('macf.hooks.handle_session_start.format_manifest_awareness') as mock_manifest, \
+         patch('macf.hooks.handle_session_start.format_macf_footer') as mock_footer, \
+         patch('macf.hooks.handle_session_start.get_compaction_count_from_events') as mock_compact_count:
+
+        mock_temporal.return_value = {
+            'timestamp_formatted': 'Wednesday, July 29, 2026 at 06:00:00 PM EDT',
+            'day_of_week': 'Wednesday',
+            'time_of_day': 'Evening'
+        }
+        mock_env.return_value = 'Host System'
+        mock_breadcrumb.return_value = 's_test/c_1/p_x/t_0'
+        mock_last_end.return_value = None
+        mock_token.return_value = {}
+        mock_token_fmt.return_value = 'Token section'
+        mock_manifest.return_value = 'Manifest'
+        mock_footer.return_value = 'Footer'
+        mock_compact_count.return_value = {'count': 0}
+
+        return run(stdin_json, testing=True)
+
+
+def test_banner_shows_auto_mode_indicator(mock_dependencies):
+    """Fresh-session banner carries 🤖 when AUTO_MODE is active (issue #164)."""
+    result = _run_shared_path(mock_dependencies, '{"source": "startup"}', auto_mode=True)
+    assert "🏗️ MACF 🤖 | Session Start" in result["systemMessage"]
+
+
+def test_banner_plain_when_manual_mode(mock_dependencies):
+    result = _run_shared_path(mock_dependencies, '{"source": "startup"}', auto_mode=False)
+    assert "🏗️ MACF | Session Start" in result["systemMessage"]
+    assert "🤖" not in result["systemMessage"].split("\n")[0]
+
+
+def test_resume_auto_mode_injects_resumption_prompt(mock_dependencies):
+    """SessionStart:resume + AUTO_MODE injects the continue-work directive."""
+    result = _run_shared_path(mock_dependencies, '{"source": "resume"}', auto_mode=True)
+    ctx = result["hookSpecificOutput"]["additionalContext"]
+    assert "AUTO_MODE RESUME" in ctx
+    assert "🏗️ MACF 🤖 | Session Start" in result["systemMessage"]
+
+
+def test_resume_manual_mode_no_resumption_prompt(mock_dependencies):
+    result = _run_shared_path(mock_dependencies, '{"source": "resume"}', auto_mode=False)
+    assert "AUTO_MODE RESUME" not in result["hookSpecificOutput"]["additionalContext"]
+
+
+def test_fresh_auto_mode_no_resumption_prompt(mock_dependencies):
+    """The kick is resume-specific: fresh startups don't get it."""
+    result = _run_shared_path(mock_dependencies, '{"source": "startup"}', auto_mode=True)
+    assert "AUTO_MODE RESUME" not in result["hookSpecificOutput"]["additionalContext"]


### PR DESCRIPTION
Closes #165. Related: #164 (supervisor-side half of unattended resume).

## What

- **New API**: `macf.utils.formatting.format_macf_brand(session_id=None, auto_mode=None, indicators=None)` — single source of truth for the banner first segment (`🏗️ MACF`, `🏗️ MACF 🤖`, or `🏗️ MACF{indicators}`). Exported via `macf.utils`.
- **Refactor**: 20 hand-rolled `🏗️ MACF` f-string sites replaced across `handle_notification`, `handle_permission_request`, `handle_session_end`, `handle_user_prompt_submit`, `handle_stop`, `handle_pre_tool_use`, `handle_subagent_stop`, `handle_pre_compact`, and `utils/temporal.py`. Hooks that compute rich mode indicators pass them through `indicators=`; error paths use the bare brand.
- **SessionStart parity**: the shared fresh/resume path now calls `detect_auto_mode()` and brands the banner accordingly (previously only migration/compaction branches detected mode — that's *why* the resume banner never showed 🤖).
- **Resume kick (context half)**: `source == 'resume'` + AUTO_MODE appends a `🤖 AUTO_MODE RESUME` system-reminder to `additionalContext`, so when the supervisor (or operator) fires the next turn, the agent knows to continue its authorized work instead of awaiting instructions.

Deliberately untouched: `hooks/recovery.py` trauma banners (content blocks, not banner segments) and `cli.py` print sites — candidates for a follow-up.

## Testing

- 12 new tests: `format_macf_brand` matrix (bare/auto/indicators/detection/failure-fallback) + SessionStart banner and resume-injection behavior for auto/manual × fresh/resume.
- `pytest -k 'handle or temporal or formatting or utils or modes'`: **114 passed** (excluded pre-existing broken collections: `test_recommend.py` missing `lancedb`, `test_proxy_server.py`).

*[TheHarborMaster@ee5cd8: task#27 s_cd1f76a9/c_3/t_1785366040]*

🤖 Generated with [Claude Code](https://claude.com/claude-code)