### PR TITLE
fix(proxy): raise client_max_size — aiohttp's 1 MiB default was 413ing real conversations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
           cache-dependency-path: macf/pyproject.toml
 
       - name: Install package with test dependencies
-        run: pip install -e "./macf[test]"
+        # `proxy` too: the proxy tests import aiohttp, which lives in that extra,
+        # so with [test] alone they could never pass in CI.
+        run: pip install -e "./macf[test,proxy]"
 
       - name: Create CI environment directories
         run: mkdir -p ~/.claude/projects

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -166,7 +166,22 @@ def _make_error_middleware():
             _log_error_event(request, 500, type(exc).__name__, str(exc))
             raise
         if response.status >= 400:
-            _log_error_event(request, response.status, "upstream_error_status", "")
+            # Capture the upstream error BODY, not just the status. A 429 whose
+            # message says "…required for long context" makes the client clamp
+            # its context window 1M -> 200K for the rest of the process, after
+            # which it refuses to send at ~180K while still displaying 1M. The
+            # status alone cannot distinguish that from an ordinary rate limit,
+            # and we lost days to exactly that ambiguity. Streaming responses
+            # expose no .body; record what is available and say which it was.
+            detail = ""
+            body = getattr(response, "body", None)
+            if isinstance(body, (bytes, bytearray)):
+                detail = bytes(body)[:2048].decode("utf-8", "replace")
+            elif body is not None:
+                detail = f"<unreadable body type {type(body).__name__}>"
+            else:
+                detail = "<streaming response; body not buffered>"
+            _log_error_event(request, response.status, "upstream_error_status", detail)
         return response
 
     return error_middleware

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -337,6 +337,98 @@ def _parse_sse_chunk(chunk: bytes, meta: dict) -> None:
             pass  # Partial JSON across chunk boundary — acceptable loss
 
 
+# --------------- Bounded, guarded capture ---------------
+#
+# Capture was shipped as an unbounded dump: one full request + one full response
+# per call, never evicted. Measured at 117 MB / 427 files after a single session
+# (up from 73 MB within that same session). It was also UNGUARDED -- the write
+# sat outside the handler's try block, so a full disk would have taken the proxy
+# down with a 500 rather than degrading to "no capture". A diagnostic that can
+# kill the thing it observes is a liability, and an unbounded one eventually
+# fills the disk it shares with everything else.
+#
+# Both properties are fixed here: writes never raise, and total capture size is
+# capped with oldest-first eviction (a ring buffer by bytes rather than count,
+# since request sizes vary by orders of magnitude).
+
+CAPTURE_MAX_MB = 512
+_capture_writes = 0
+# Eviction scans the directory, so amortise it rather than paying per write.
+_CAPTURE_EVICT_EVERY = 20
+
+
+def _capture_cap_bytes() -> int:
+    """Cap in bytes. MACF_PROXY_CAPTURE_MAX_MB=0 disables the bound entirely."""
+    raw = os.environ.get("MACF_PROXY_CAPTURE_MAX_MB")
+    try:
+        mb = int(raw) if raw is not None and raw.strip() != "" else CAPTURE_MAX_MB
+    except ValueError:
+        mb = CAPTURE_MAX_MB
+    return max(0, mb) * 1024 * 1024
+
+
+def _capture_evict(cap: Path) -> None:
+    """Drop oldest captures until under the cap. Never raises."""
+    limit = _capture_cap_bytes()
+    if limit <= 0:
+        return
+    try:
+        files = []
+        for f in cap.glob("*.json"):
+            try:
+                files.append((f.stat().st_mtime, f.stat().st_size, f))
+            except OSError:
+                continue
+        total = sum(s for _, s, _ in files)
+        if total <= limit:
+            return
+        files.sort(key=lambda x: x[0])  # oldest first
+        freed = removed = 0
+        for _, size, f in files:
+            if total - freed <= limit:
+                break
+            try:
+                f.unlink()
+            except OSError:
+                continue
+            freed += size
+            removed += 1
+        if removed:
+            print(
+                f"[proxy:capture] evicted {removed} file(s), freed "
+                f"{freed/1024/1024:.1f} MB (cap {limit/1024/1024:.0f} MB)",
+                file=sys.stderr,
+            )
+    except OSError as e:
+        print(f"[proxy:capture] eviction skipped: {e}", file=sys.stderr)
+
+
+def _capture_write(cap: Path, filename: str, payload) -> bool:
+    """Write one capture file (str or bytes). False on failure, never raises.
+
+    Capture is a diagnostic; losing it must never fail the request it is
+    observing. Callers log their own success line only if this returns True.
+    """
+    global _capture_writes
+    try:
+        cap.mkdir(parents=True, exist_ok=True)
+        target = cap / filename
+        if isinstance(payload, (bytes, bytearray)):
+            target.write_bytes(bytes(payload))
+        else:
+            target.write_text(payload)
+    except OSError as e:
+        print(
+            f"[proxy:capture] write FAILED, continuing without capture: {e}",
+            file=sys.stderr,
+        )
+        return False
+    _capture_writes += 1
+    if _capture_writes % _CAPTURE_EVICT_EVERY == 0:
+        _capture_evict(cap)
+    return True
+
+
 # --------------- Request metadata extraction ---------------
 
 def _extract_request_meta(body: bytes) -> dict:
@@ -368,16 +460,15 @@ def _extract_request_meta(body: bytes) -> dict:
     # Dump full request to capture dir if enabled
     capture_dir = os.environ.get("MACF_PROXY_CAPTURE_DIR")
     if capture_dir:
+        # Bounded + guarded: this call sits OUTSIDE the handler's try block, so
+        # an unguarded write here fails the request itself. See _capture_write.
         cap = Path(capture_dir)
-        cap.mkdir(parents=True, exist_ok=True)
         ts = int(time.time())
         model = data.get("model", "unknown").replace("/", "_")
         filename = f"{ts}_{model}_request.json"
-        (cap / filename).write_text(
-            json.dumps(data, indent=2, default=str)
-        )
-        # VERBOSE: Echo captured filename
-        print(f"[proxy:capture] → {filename}", file=sys.stderr)
+        if _capture_write(cap, filename, json.dumps(data, indent=2, default=str)):
+            # VERBOSE: Echo captured filename
+            print(f"[proxy:capture] → {filename}", file=sys.stderr)
 
     return meta
 
@@ -394,7 +485,8 @@ def _capture_response(data, resp_meta: dict, model: str, streaming: bool = True)
         return
 
     cap = Path(capture_dir)
-    cap.mkdir(parents=True, exist_ok=True)
+    # mkdir happens inside _capture_write, guarded — an unguarded mkdir here
+    # would raise on a read-only or full filesystem before any write is tried.
     ts = int(time.time())
     model_safe = model.replace("/", "_")
 
@@ -456,25 +548,22 @@ def _capture_response(data, resp_meta: dict, model: str, streaming: bool = True)
         captured["ts"] = ts
 
         filename = f"{ts}_{model_safe}_response.json"
-        (cap / filename).write_text(
-            json.dumps(captured, indent=2, default=str)
-        )
-        # VERBOSE: Echo captured filename
-        print(f"[proxy:capture] ← {filename}", file=sys.stderr)
+        if _capture_write(cap, filename, json.dumps(captured, indent=2, default=str)):
+            # VERBOSE: Echo captured filename
+            print(f"[proxy:capture] ← {filename}", file=sys.stderr)
     else:
         # Non-streaming: save raw response
+        # The except clause below covers only parse failures; an OSError from the
+        # write would previously have escaped and failed the request. Both writes
+        # now go through _capture_write, which swallows OSError by contract.
         try:
             resp_data = json.loads(data) if isinstance(data, bytes) else data
             filename = f"{ts}_{model_safe}_response.json"
-            (cap / filename).write_text(
-                json.dumps(resp_data, indent=2, default=str)
-            )
-            print(f"[proxy:capture] ← {filename}", file=sys.stderr)
+            payload = json.dumps(resp_data, indent=2, default=str)
         except (json.JSONDecodeError, TypeError):
             filename = f"{ts}_{model_safe}_response.raw"
-            (cap / filename).write_bytes(
-                data if isinstance(data, bytes) else b""
-            )
+            payload = data if isinstance(data, bytes) else b""
+        if _capture_write(cap, filename, payload):
             print(f"[proxy:capture] ← {filename}", file=sys.stderr)
 
 

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -50,6 +50,12 @@ def _rewrite_enabled() -> bool:
     (accepted truthy values: on/1/true/yes) to enable for scratch-session
     experiments. Detection and stderr reporting remain active either way —
     the gate covers only the mutation.
+
+    Single source of truth: both the startup banner and the request path MUST
+    call this. The banner once read the env var while the rewrite path ignored
+    it entirely, so the proxy advertised rewrite=off while rewriting every
+    request — an instrument reporting a value nobody enforces is worse than no
+    instrument at all.
     """
     return os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower() in ("on", "1", "true", "yes")
 
@@ -191,22 +197,6 @@ def _make_error_middleware():
         return response
 
     return error_middleware
-
-
-def _rewrite_enabled() -> bool:
-    """Single source of truth for the message-rewrite gate.
-
-    Both the startup banner and the request path MUST call this. Previously the
-    banner read this env var while the rewrite path ignored it entirely, so the
-    proxy advertised rewrite=off while rewriting every request. An instrument
-    that reports a value nobody enforces is worse than no instrument at all.
-    """
-    return os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower() in (
-        "on",
-        "1",
-        "true",
-        "yes",
-    )
 
 
 # --------------- 200K-window clamp detector ---------------

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -26,6 +26,16 @@ DEFAULT_HOST = "127.0.0.1"
 PID_FILE_NAME = "macf_proxy.pid"
 LOG_FILE_NAME = "agent_api_log.jsonl"
 
+# aiohttp's web.Application defaults to client_max_size=1 MiB and rejects larger
+# bodies with 413 *before* any handler runs (so nothing is logged). Conversation
+# requests routinely exceed 1 MiB, and Claude Code renders any 413 as
+# "Request too large (max 32MB)" — a hardcoded label unrelated to the real limit.
+# Its recovery then strips images/documents; with none present the retry is
+# byte-identical, so the session wedges permanently (even /compact fails, since
+# the compaction request takes the same path). Cap generously instead: a
+# pass-through proxy must not impose a limit stricter than upstream's.
+MAX_REQUEST_BYTES = int(os.environ.get("MACF_PROXY_MAX_REQUEST_BYTES", 256 * 1024 * 1024))
+
 
 # --------------- Feature gates ---------------
 
@@ -543,7 +553,7 @@ def _create_app():
         if _client_session and not _client_session.closed:
             await _client_session.close()
 
-    app = web.Application()
+    app = web.Application(client_max_size=MAX_REQUEST_BYTES)
     app.router.add_post("/v1/messages", handle_messages)
     app.router.add_route("*", "/{path_info:.*}", handle_catchall)
     app.on_cleanup.append(on_cleanup)

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -105,6 +105,12 @@ def _log_event(event: dict) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with open(log_path, "a") as f:
         f.write(json.dumps(event) + "\n")
+    # Single choke point for response metadata, so the clamp detector hangs here
+    # rather than being duplicated across the streaming and non-streaming paths.
+    # The guard also terminates the one-level recursion: the detector's own event
+    # is not an "api_response", so it cannot re-enter.
+    if event.get("type") == "api_response":
+        _warn_if_approaching_clamp(event.get("usage") or {})
 
 
 # --------------- Failure-path observability ---------------
@@ -203,6 +209,64 @@ def _rewrite_enabled() -> bool:
     )
 
 
+# --------------- 200K-window clamp detector ---------------
+#
+# This proxy's own existence downgrades the client's context window, silently.
+#
+# Observed behaviour: when ANTHROPIC_BASE_URL points at a host that is not
+# api.anthropic.com, the client stops extending the 1M long-context window and
+# falls back to 200K -- so it auto-compacts around 167K while every UI surface
+# still reports 1M. Nothing is logged, warned, or errored on the client side;
+# the only symptom is compacting early. That is what made it cost months.
+#
+# Established by A/B, not by assumption: same conversation, proxy ON compacted
+# at 166,403 and again at 167,108 (a 700-token spread); proxy OFF ran past 180K
+# with no compaction at all. The undocumented env var below restores the window
+# with the proxy in place. Its name is the clue to the rule -- the client wants
+# to know the endpoint is first-party, and decides that from the base URL host.
+#
+# The proxy cannot read the client's env, so it cannot check the flag directly.
+# What it CAN see is every request's true input size. So it says the actionable
+# thing at the moment the evidence first exists, rather than leaving a silence to
+# be misread later. Warn once per process; this is a config fault, not an event.
+
+CLAMPED_WINDOW = 200_000
+# Warn below the ~167K compaction point so the message lands BEFORE the symptom.
+WINDOW_WARN_AT = 150_000
+_window_warned = False
+
+
+def _warn_if_approaching_clamp(usage: dict) -> None:
+    """Say the actionable thing while the session is still alive to act on it."""
+    global _window_warned
+    if _window_warned or not isinstance(usage, dict):
+        return
+    total = (
+        (usage.get("input_tokens") or 0)
+        + (usage.get("cache_creation_input_tokens") or 0)
+        + (usage.get("cache_read_input_tokens") or 0)
+    )
+    if total < WINDOW_WARN_AT:
+        return
+    _window_warned = True
+    _log_event({
+        "type": "window_clamp_watch", "ts": int(time.time()),
+        "input_tokens": total, "clamped_window": CLAMPED_WINDOW,
+        "remedy_env": "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL",
+    })
+    print(
+        f"[proxy:window] ⚠️  context reached {total:,} tokens.\n"
+        f"  If this session compacts before ~{CLAMPED_WINDOW:,}, the client is on the\n"
+        f"  200K fallback window, NOT the 1M it displays. Routing through this proxy\n"
+        f"  makes ANTHROPIC_BASE_URL's host != api.anthropic.com, and the client then\n"
+        f"  withholds the 1M long-context window.\n"
+        f"  Remedy: set _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 in the client's env\n"
+        f"  (accurate here -- this proxy forwards to {ANTHROPIC_API_URL} unmodified).\n"
+        f"  Verify with the ACTUAL compaction point, never a status line/banner.",
+        file=sys.stderr,
+    )
+
+
 def _log_effective_config(port: int, host: str) -> None:
     """Log the limits actually in force. Silent defaults are invisible policy."""
     cfg = {
@@ -221,6 +285,15 @@ def _log_effective_config(port: int, host: str) -> None:
         f"[proxy:start] pid={cfg['pid']} {host}:{port} -> {ANTHROPIC_API_URL} | "
         f"client_max_size={MAX_REQUEST_BYTES:,}B | rewrite={cfg['rewrite_enabled']} | "
         f"capture={cfg['capture_dir'] or 'off'}",
+        file=sys.stderr,
+    )
+    # Stated at every start because it is a precondition of correct operation,
+    # not an incident: any client pointed here MUST also set this, or it silently
+    # runs on the 200K fallback window while displaying 1M.
+    print(
+        "[proxy:start] clients routed here MUST set "
+        "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1, else their context window "
+        f"silently falls back to {CLAMPED_WINDOW:,} (compacts ~167K, still displays 1M).",
         file=sys.stderr,
     )
 

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -12,6 +12,7 @@ Architecture:
 """
 
 import json
+import logging
 import os
 import signal
 import sys
@@ -104,6 +105,97 @@ def _log_event(event: dict) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with open(log_path, "a") as f:
         f.write(json.dumps(event) + "\n")
+
+
+# --------------- Failure-path observability ---------------
+#
+# Every instrument in this proxy used to sit *after* `await request.read()` in
+# the handler — which is precisely the call that fails when a request exceeds
+# client_max_size. Rejected requests therefore produced no log line at all, and
+# that silence was repeatedly misread as "the request never reached the proxy".
+# An empty log is only evidence of absence if the log is known to cover the
+# failure mode. These three additions make it cover them.
+
+
+def _log_error_event(request, status: int, kind: str, detail: str) -> None:
+    """Record a failed request in the SAME log readers already watch.
+
+    Idempotent per request: a handler may log a precise diagnosis before the
+    middleware sees the same exception, and one failure should be one record.
+    """
+    try:
+        if request.get("_macf_error_logged"):
+            return
+        request["_macf_error_logged"] = True
+    except (AttributeError, TypeError):
+        pass  # not a mutable request mapping — log anyway
+
+    _log_event({
+        "type": "api_error",
+        "ts": int(time.time()),
+        "status": status,
+        "kind": kind,
+        "detail": detail[:500],
+        "method": getattr(request, "method", "?"),
+        "path": str(getattr(request, "path", "?")),
+        "content_length": getattr(request, "content_length", None),
+        "client_max_size": MAX_REQUEST_BYTES,
+    })
+    print(f"[proxy:error] {status} {kind}: {detail[:200]}", file=sys.stderr)
+
+
+def _make_error_middleware():
+    """Middleware logging every failed request, including framework rejections.
+
+    aiohttp enforces client_max_size inside request.read(), raising
+    HTTPRequestEntityTooLarge. Without this, that exception becomes a bare 413
+    on the wire with zero telemetry.
+    """
+    from aiohttp import web
+
+    @web.middleware
+    async def error_middleware(request, handler):
+        try:
+            response = await handler(request)
+        except web.HTTPException as exc:
+            kind = ("request_too_large_REJECTED_BY_THIS_PROXY"
+                    if exc.status == 413 else "http_exception")
+            _log_error_event(request, exc.status, kind, str(exc.reason or exc))
+            raise
+        except Exception as exc:
+            _log_error_event(request, 500, type(exc).__name__, str(exc))
+            raise
+        if response.status >= 400:
+            _log_error_event(request, response.status, "upstream_error_status", "")
+        return response
+
+    return error_middleware
+
+
+def _log_effective_config(port: int, host: str) -> None:
+    """Log the limits actually in force. Silent defaults are invisible policy."""
+    cfg = {
+        "type": "proxy_start",
+        "ts": int(time.time()),
+        "pid": os.getpid(),
+        "host": host,
+        "port": port,
+        "upstream": ANTHROPIC_API_URL,
+        "client_max_size": MAX_REQUEST_BYTES,
+        # Read the env directly rather than calling a gate helper: that helper
+        # lives on a feature branch, and a startup banner must never be the
+        # thing that crashes the server it is describing.
+        "rewrite_enabled": os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower()
+        in ("on", "1", "true", "yes"),
+        "capture_dir": os.environ.get("MACF_PROXY_CAPTURE_DIR") or None,
+    }
+    _log_event(cfg)
+    print(
+        f"[proxy:start] pid={cfg['pid']} {host}:{port} -> {ANTHROPIC_API_URL} | "
+        f"client_max_size={MAX_REQUEST_BYTES:,}B | rewrite={cfg['rewrite_enabled']} | "
+        f"capture={cfg['capture_dir'] or 'off'}",
+        file=sys.stderr,
+    )
 
 
 # --------------- SSE metadata extraction ---------------
@@ -355,7 +447,17 @@ def _create_app():
 
     async def handle_messages(request: web.Request) -> web.StreamResponse:
         """Proxy /v1/messages with metadata logging."""
-        body = await request.read()
+        # Guarded explicitly: this is the call that raises when a request
+        # exceeds client_max_size, and it is the FIRST statement in the handler
+        # — so an unguarded failure here skips every instrument below it.
+        try:
+            body = await request.read()
+        except web.HTTPRequestEntityTooLarge as exc:
+            _log_error_event(
+                request, 413, "request_too_large_REJECTED_BY_THIS_PROXY",
+                f"body exceeds client_max_size={MAX_REQUEST_BYTES}: {exc}",
+            )
+            raise
 
         # Log request metadata
         req_meta = _extract_request_meta(body)
@@ -553,7 +655,10 @@ def _create_app():
         if _client_session and not _client_session.closed:
             await _client_session.close()
 
-    app = web.Application(client_max_size=MAX_REQUEST_BYTES)
+    app = web.Application(
+        client_max_size=MAX_REQUEST_BYTES,
+        middlewares=[_make_error_middleware()],
+    )
     app.router.add_post("/v1/messages", handle_messages)
     app.router.add_route("*", "/{path_info:.*}", handle_catchall)
     app.on_cleanup.append(on_cleanup)
@@ -579,6 +684,18 @@ def run_proxy(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> None:
     print(f"[proxy] listening on {host}:{port}", file=sys.stderr)
     print(f"[proxy] Log: {get_log_path()}", file=sys.stderr)
     print(f"[proxy] Activate: ANTHROPIC_BASE_URL=http://{host}:{port} claude", file=sys.stderr)
+
+    # aiohttp's access logger is enabled by default but emits at INFO, and
+    # nothing here ever configured logging — so every access record, including
+    # the 413s this proxy was issuing, was discarded before reaching the
+    # journal. Default-on instrumentation that is never wired up is worse than
+    # none: it looks like coverage. Wire it to stderr, which systemd captures.
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    _log_effective_config(port, host)
 
     try:
         web.run_app(app, host=host, port=port, print=None)

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -172,6 +172,22 @@ def _make_error_middleware():
     return error_middleware
 
 
+def _rewrite_enabled() -> bool:
+    """Single source of truth for the message-rewrite gate.
+
+    Both the startup banner and the request path MUST call this. Previously the
+    banner read this env var while the rewrite path ignored it entirely, so the
+    proxy advertised rewrite=off while rewriting every request. An instrument
+    that reports a value nobody enforces is worse than no instrument at all.
+    """
+    return os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower() in (
+        "on",
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def _log_effective_config(port: int, host: str) -> None:
     """Log the limits actually in force. Silent defaults are invisible policy."""
     cfg = {
@@ -182,11 +198,7 @@ def _log_effective_config(port: int, host: str) -> None:
         "port": port,
         "upstream": ANTHROPIC_API_URL,
         "client_max_size": MAX_REQUEST_BYTES,
-        # Read the env directly rather than calling a gate helper: that helper
-        # lives on a feature branch, and a startup banner must never be the
-        # thing that crashes the server it is describing.
-        "rewrite_enabled": os.environ.get("MACF_PROXY_REWRITE", "off").strip().lower()
-        in ("on", "1", "true", "yes"),
+        "rewrite_enabled": _rewrite_enabled(),
         "capture_dir": os.environ.get("MACF_PROXY_CAPTURE_DIR") or None,
     }
     _log_event(cfg)
@@ -480,7 +492,8 @@ def _create_app():
                 # 1. Detect injections BEFORE rewrite
                 pre_injections = _detect_current_injections(messages)
 
-                # 2. Run stateless rewrite (retract inactive + dedup active)
+                # 2. Run stateless rewrite (retract inactive + dedup active),
+                #    but ONLY when the gate the banner advertises is actually on.
                 # EXPERIMENTAL — gated OFF by default: mutating the message-array
                 # prefix can invalidate Anthropic prompt-cache prefix stability,
                 # causing cache misses, inflated token burn, and premature forced
@@ -550,7 +563,11 @@ def _create_app():
             print(f"[proxy:injection] ERROR: {e}", file=sys.stderr)
 
         headers = _forward_headers(request)
-        target_url = f"{ANTHROPIC_API_URL}{request.path}"
+        # path_qs, NOT path: the client sends /v1/messages?beta=true, and dropping
+        # that query string changes what upstream grants. A rejected/limited beta
+        # request can come back 429, which the client treats as a permanent
+        # entitlement clamp for the life of the process. (Diagnosed 2026-07-29.)
+        target_url = f"{ANTHROPIC_API_URL}{request.path_qs}"
         start_time = time.time()
 
         session = await _get_client()
@@ -636,7 +653,7 @@ def _create_app():
         """Proxy any non-messages request transparently."""
         body = await request.read()
         headers = _forward_headers(request)
-        target_url = f"{ANTHROPIC_API_URL}{request.path}"
+        target_url = f"{ANTHROPIC_API_URL}{request.path_qs}"  # see handle_messages
 
         session = await _get_client()
         async with session.request(

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -342,3 +342,72 @@ class TestWindowClampDetector:
         kinds = [_json.loads(x)["type"] for x in lines]
         assert kinds.count("window_clamp_watch") == 1
         assert kinds.count("api_response") == 1
+
+
+class TestCaptureBounded:
+    """Capture must not be able to fill the disk or kill the request it observes.
+
+    Shipped unbounded and unguarded: measured 117MB/427 files after one session,
+    with the request-side write sitting OUTSIDE the handler's try block.
+    """
+
+    def _mk(self, tmp_path, n, size=1000):
+        import os as _os
+        for i in range(n):
+            f = tmp_path / f"{1000+i}_m_request.json"
+            f.write_text("x" * size)
+            _os.utime(f, (1000 + i, 1000 + i))  # deterministic age ordering
+        return sorted(tmp_path.glob("*.json"))
+
+    def test_cap_default_and_override(self, monkeypatch):
+        from macf.proxy import server
+        monkeypatch.delenv("MACF_PROXY_CAPTURE_MAX_MB", raising=False)
+        assert server._capture_cap_bytes() == server.CAPTURE_MAX_MB * 1024 * 1024
+        monkeypatch.setenv("MACF_PROXY_CAPTURE_MAX_MB", "3")
+        assert server._capture_cap_bytes() == 3 * 1024 * 1024
+
+    def test_zero_disables_the_bound(self, monkeypatch, tmp_path):
+        """0 must mean unbounded, not 'evict everything'."""
+        from macf.proxy import server
+        monkeypatch.setenv("MACF_PROXY_CAPTURE_MAX_MB", "0")
+        self._mk(tmp_path, 5)
+        server._capture_evict(tmp_path)
+        assert len(list(tmp_path.glob("*.json"))) == 5
+
+    def test_garbage_env_falls_back_to_default(self, monkeypatch):
+        from macf.proxy import server
+        monkeypatch.setenv("MACF_PROXY_CAPTURE_MAX_MB", "not-a-number")
+        assert server._capture_cap_bytes() == server.CAPTURE_MAX_MB * 1024 * 1024
+
+    def test_evicts_oldest_first_until_under_cap(self, monkeypatch, tmp_path):
+        from macf.proxy import server
+        # 10 files x 1000B = ~10KB; cap to roughly 4KB worth
+        self._mk(tmp_path, 10, size=1000)
+        monkeypatch.setattr(server, "_capture_cap_bytes", lambda: 4000)
+        server._capture_evict(tmp_path)
+        left = sorted(p.name for p in tmp_path.glob("*.json"))
+        assert sum(p.stat().st_size for p in tmp_path.glob("*.json")) <= 4000
+        # the SURVIVORS must be the newest ones
+        assert left == sorted(f"{1000+i}_m_request.json" for i in range(6, 10))
+
+    def test_write_failure_returns_false_and_does_not_raise(self, tmp_path):
+        """A full/read-only disk must degrade to 'no capture', not fail the request."""
+        from macf.proxy import server
+        blocked = tmp_path / "afile"
+        blocked.write_text("not a directory")
+        assert server._capture_write(blocked, "x.json", "data") is False
+
+    def test_writes_bytes_payload(self, tmp_path):
+        from macf.proxy import server
+        assert server._capture_write(tmp_path, "r.raw", b"\x00\x01raw") is True
+        assert (tmp_path / "r.raw").read_bytes() == b"\x00\x01raw"
+
+    def test_eviction_is_amortised_not_every_write(self, tmp_path, monkeypatch):
+        """Scanning the dir on every write would add O(n) stats to the hot path."""
+        from macf.proxy import server
+        calls = []
+        monkeypatch.setattr(server, "_capture_evict", lambda c: calls.append(1))
+        server._capture_writes = 0
+        for i in range(server._CAPTURE_EVICT_EVERY):
+            server._capture_write(tmp_path, f"f{i}.json", "x")
+        assert len(calls) == 1

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -1,0 +1,27 @@
+
+
+class TestClientMaxSize:
+    """The proxy must not impose a stricter body limit than upstream.
+
+    aiohttp's web.Application defaults to client_max_size=1 MiB and rejects
+    larger bodies with 413 before any handler runs. Claude Code renders any
+    413 as "Request too large (max 32MB)" and its only recovery is stripping
+    images/documents — so a media-free session wedges permanently.
+    """
+
+    def test_app_configured_above_aiohttp_default(self):
+        from macf.proxy.server import _create_app, MAX_REQUEST_BYTES
+        assert MAX_REQUEST_BYTES > 1024 * 1024
+        app = _create_app()
+        assert app._client_max_size == MAX_REQUEST_BYTES
+
+    def test_limit_overridable_by_env(self, monkeypatch):
+        monkeypatch.setenv("MACF_PROXY_MAX_REQUEST_BYTES", "12345678")
+        import importlib
+        from macf.proxy import server
+        importlib.reload(server)
+        try:
+            assert server.MAX_REQUEST_BYTES == 12345678
+        finally:
+            monkeypatch.delenv("MACF_PROXY_MAX_REQUEST_BYTES", raising=False)
+            importlib.reload(server)

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -261,3 +261,84 @@ class TestQueryStringReachesUpstreamLive:
         # Entitlement also rides on these; the hop-by-hop filter must not eat them.
         assert seen["beta"] == "context-1m-2025-08-07"
         assert seen["auth"] == "Bearer test-token"
+
+
+class TestWindowClampDetector:
+    """The 200K-window clamp is silent on the client side; the proxy must not be.
+
+    This is the instrument that would have collapsed a months-long hunt into one
+    log line. It is tested for the property that actually matters: it fires
+    BEFORE the ~167K compaction point, so the warning arrives while the session
+    is still alive to act on it.
+    """
+
+    def _reset(self):
+        from macf.proxy import server
+        server._window_warned = False
+
+    def test_fires_before_the_167k_compaction_point(self):
+        """A warning that arrives after the symptom is useless."""
+        from macf.proxy import server
+        assert server.WINDOW_WARN_AT < 167_000, (
+            "warn threshold must sit below the observed ~167K compaction point"
+        )
+
+    def test_warns_when_context_crosses_threshold(self, capsys):
+        from macf.proxy import server
+        self._reset()
+        server._warn_if_approaching_clamp({"input_tokens": 160_000})
+        err = capsys.readouterr().err
+        assert "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL" in err, (
+            "the warning must name the remedy, not just report a number"
+        )
+        assert "160,000" in err
+
+    def test_silent_below_threshold(self, capsys):
+        from macf.proxy import server
+        self._reset()
+        server._warn_if_approaching_clamp({"input_tokens": 1_000})
+        assert capsys.readouterr().err == ""
+
+    def test_sums_cache_tokens_not_just_input_tokens(self, capsys):
+        """input_tokens alone is ~2 on a cached turn; summing is the whole point."""
+        from macf.proxy import server
+        self._reset()
+        server._warn_if_approaching_clamp({
+            "input_tokens": 2,
+            "cache_read_input_tokens": 155_000,
+            "cache_creation_input_tokens": 1_000,
+        })
+        assert "156,002" in capsys.readouterr().err
+
+    def test_warns_only_once_per_process(self, capsys):
+        from macf.proxy import server
+        self._reset()
+        server._warn_if_approaching_clamp({"input_tokens": 160_000})
+        capsys.readouterr()
+        server._warn_if_approaching_clamp({"input_tokens": 170_000})
+        assert capsys.readouterr().err == ""
+
+    def test_wired_into_log_event_for_api_responses(self, capsys, tmp_path,
+                                                    monkeypatch):
+        """Negative control on the wiring: the detector is useless if unreachable."""
+        from macf.proxy import server
+        self._reset()
+        monkeypatch.setattr(server, "get_log_path",
+                            lambda: tmp_path / "proxy.jsonl")
+        server._log_event({"type": "api_response",
+                           "usage": {"input_tokens": 160_000}})
+        assert "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL" in capsys.readouterr().err
+
+    def test_log_event_does_not_recurse(self, capsys, tmp_path, monkeypatch):
+        """The detector logs an event itself; that must not re-enter the guard."""
+        from macf.proxy import server
+        self._reset()
+        monkeypatch.setattr(server, "get_log_path",
+                            lambda: tmp_path / "proxy.jsonl")
+        server._log_event({"type": "api_response",
+                           "usage": {"input_tokens": 160_000}})
+        import json as _json
+        lines = (tmp_path / "proxy.jsonl").read_text().strip().split("\n")
+        kinds = [_json.loads(x)["type"] for x in lines]
+        assert kinds.count("window_clamp_watch") == 1
+        assert kinds.count("api_response") == 1

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -157,3 +157,51 @@ class TestRewriteGate:
         assert "if _rewrite_enabled():" in src
         gated = src.split("if _rewrite_enabled():", 1)[1]
         assert "rewrite_messages(messages)" in gated.split("# 3.", 1)[0]
+
+
+class TestUpstreamErrorBodyCaptured:
+    """A 4xx status without its body is not a diagnosis.
+
+    The middleware logged upstream_error_status with detail="" hardcoded. When
+    a 429 arrived, we could see that it happened but not what it said -- and
+    the distinction mattered enormously: a long-context-credits 429 makes the
+    client permanently clamp its context window to 200K, while an ordinary rate
+    limit is harmless. Same status, opposite meaning, no way to tell them apart.
+    """
+
+    def _log(self, tmp_path, monkeypatch, response):
+        import asyncio, json
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        from macf.proxy import server
+
+        class FakeRequest(dict):
+            method = "POST"
+            path = "/v1/messages"
+            headers = {}
+
+        async def handler(_req):
+            return response
+
+        mw = server._make_error_middleware()
+        asyncio.run(mw(FakeRequest(), handler))
+
+        log = tmp_path / ".maceff" / "agent_api_log.jsonl"
+        if not log.exists():
+            log = next(tmp_path.rglob("agent_api_log.jsonl"))
+        recs = [json.loads(x) for x in log.read_text().splitlines() if x.strip()]
+        return [r for r in recs if r.get("kind") == "upstream_error_status"][-1]
+
+    def test_body_is_recorded(self, tmp_path, monkeypatch):
+        class Resp:
+            status = 429
+            body = b'{"error":{"message":"Extra usage is required for long context"}}'
+        rec = self._log(tmp_path, monkeypatch, Resp())
+        assert "long context" in rec["detail"]
+
+    def test_streaming_body_is_named_not_silently_empty(self, tmp_path, monkeypatch):
+        class Resp:
+            status = 429
+            body = None
+        rec = self._log(tmp_path, monkeypatch, Resp())
+        assert rec["detail"], "an empty detail is indistinguishable from 'no body existed'"
+        assert "streaming" in rec["detail"]

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -205,3 +205,59 @@ class TestUpstreamErrorBodyCaptured:
         rec = self._log(tmp_path, monkeypatch, Resp())
         assert rec["detail"], "an empty detail is indistinguishable from 'no body existed'"
         assert "streaming" in rec["detail"]
+
+
+class TestQueryStringReachesUpstreamLive:
+    """End-to-end proof, against a real upstream, that ?beta=true survives.
+
+    The source-level assertions above catch the regression, but only this
+    catches it if the URL is ever built somewhere new. Verified to FAIL when
+    request.path_qs is reverted to request.path -- an assertion never observed
+    failing is not evidence.
+    """
+
+    def test_query_string_and_entitlement_headers_survive(self, tmp_path, monkeypatch):
+        import asyncio, json
+        from aiohttp import web, ClientSession
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        from macf.proxy import server
+
+        seen = {}
+
+        async def echo(request):
+            seen["path_qs"] = request.path_qs
+            seen["beta"] = request.headers.get("anthropic-beta")
+            seen["auth"] = request.headers.get("authorization")
+            return web.json_response({"ok": True})
+
+        async def scenario():
+            up = web.Application()
+            up.router.add_route("*", "/{p:.*}", echo)
+            r1 = web.AppRunner(up); await r1.setup()
+            s1 = web.TCPSite(r1, "127.0.0.1", 8741); await s1.start()
+
+            monkeypatch.setattr(server, "ANTHROPIC_API_URL", "http://127.0.0.1:8741")
+            r2 = web.AppRunner(server._create_app()); await r2.setup()
+            s2 = web.TCPSite(r2, "127.0.0.1", 8742); await s2.start()
+            try:
+                async with ClientSession() as c:
+                    await c.post(
+                        "http://127.0.0.1:8742/v1/messages?beta=true",
+                        data=json.dumps({"model": "claude-opus-5", "messages": []}),
+                        headers={
+                            "anthropic-beta": "context-1m-2025-08-07",
+                            "authorization": "Bearer test-token",
+                            "content-type": "application/json",
+                        },
+                    )
+            finally:
+                await r2.cleanup(); await r1.cleanup()
+
+        asyncio.run(scenario())
+
+        # The query string carries the beta opt-in. Dropping it caused upstream
+        # to answer as if the long-context entitlement were absent.
+        assert seen["path_qs"] == "/v1/messages?beta=true"
+        # Entitlement also rides on these; the hop-by-hop filter must not eat them.
+        assert seen["beta"] == "context-1m-2025-08-07"
+        assert seen["auth"] == "Bearer test-token"

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -25,3 +25,64 @@ class TestClientMaxSize:
         finally:
             monkeypatch.delenv("MACF_PROXY_MAX_REQUEST_BYTES", raising=False)
             importlib.reload(server)
+
+
+class TestFailurePathObservability:
+    """Failures must appear in the same log readers already watch.
+
+    The original bug survived months because every instrument sat AFTER
+    `await request.read()` — the exact call that fails on oversized bodies.
+    An empty log was read as "the request never arrived" when it meant
+    "the request died upstream of the instruments".
+    """
+
+    def test_rejection_is_logged_with_unambiguous_kind(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        from macf.proxy import server
+
+        class FakeRequest(dict):
+            method = "POST"
+            path = "/v1/messages"
+            content_length = 8200
+
+        server._log_error_event(FakeRequest(), 413,
+                                "request_too_large_REJECTED_BY_THIS_PROXY", "too big")
+
+        import json
+        lines = (tmp_path / ".maceff" / "agent_api_log.jsonl").read_text().splitlines()
+        rec = json.loads(lines[-1])
+        assert rec["type"] == "api_error"
+        assert rec["status"] == 413
+        # names the culprit, so silence can never again be read as innocence
+        assert "REJECTED_BY_THIS_PROXY" in rec["kind"]
+        assert rec["client_max_size"] == server.MAX_REQUEST_BYTES
+
+    def test_error_logging_is_idempotent_per_request(self, tmp_path, monkeypatch):
+        """Handler diagnosis + middleware catch = one failure, one record."""
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        from macf.proxy import server
+
+        class FakeRequest(dict):
+            method = "POST"
+            path = "/v1/messages"
+            content_length = 8200
+
+        req = FakeRequest()
+        server._log_error_event(req, 413, "precise_diagnosis", "from handler")
+        server._log_error_event(req, 413, "http_exception", "from middleware")
+
+        lines = (tmp_path / ".maceff" / "agent_api_log.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_startup_logs_effective_limits(self, tmp_path, monkeypatch):
+        """Silent defaults are invisible policy — log what is actually in force."""
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        from macf.proxy import server
+
+        server._log_effective_config(8019, "127.0.0.1")
+
+        import json
+        rec = json.loads((tmp_path / ".maceff" / "agent_api_log.jsonl").read_text().splitlines()[-1])
+        assert rec["type"] == "proxy_start"
+        assert rec["client_max_size"] == server.MAX_REQUEST_BYTES
+        assert rec["port"] == 8019

--- a/macf/tests/test_proxy_server.py
+++ b/macf/tests/test_proxy_server.py
@@ -86,3 +86,74 @@ class TestFailurePathObservability:
         assert rec["type"] == "proxy_start"
         assert rec["client_max_size"] == server.MAX_REQUEST_BYTES
         assert rec["port"] == 8019
+
+
+class TestQueryStringPreservation:
+    """The upstream URL must carry the client's query string.
+
+    Both handlers built target_url from `request.path`, which silently drops
+    everything after `?`. The client sends `/v1/messages?beta=true`; upstream
+    therefore never saw the long-context beta flag. A beta request stripped of
+    its flag is the shape that draws a 429 — and one 429 latches a sticky,
+    process-lifetime clamp of the client's context window from 1M down to 200K.
+    The client then refuses to send at ~180K while its own banner still shows
+    1M, fabricating "Prompt is too long" locally without calling the API.
+
+    Nothing about that failure points back here, so it is asserted at the source.
+    """
+
+    def _handler_sources(self):
+        import inspect
+        from macf.proxy import server
+        src = inspect.getsource(server)
+        return [
+            line for line in src.splitlines()
+            if "target_url" in line and "ANTHROPIC_API_URL" in line
+        ]
+
+    def test_handlers_exist(self):
+        # Guards the assertions below against silently matching nothing.
+        assert len(self._handler_sources()) >= 2
+
+    def test_no_handler_uses_bare_request_path(self):
+        for line in self._handler_sources():
+            assert "request.path_qs" in line, (
+                f"target_url must preserve the query string, got: {line.strip()}"
+            )
+            assert "{request.path}" not in line
+
+
+class TestRewriteGate:
+    """The advertised gate and the enforced gate must be the same value.
+
+    The startup banner reported `rewrite_enabled` from MACF_PROXY_REWRITE while
+    the request path called rewrite_messages unconditionally — so the proxy
+    printed rewrite=off while rewriting every request. A reported value that
+    diverges from the enforced value, with nothing reconciling them, is the
+    antipattern this whole investigation kept rediscovering.
+    """
+
+    def test_gate_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("MACF_PROXY_REWRITE", raising=False)
+        from macf.proxy.server import _rewrite_enabled
+        assert _rewrite_enabled() is False
+
+    def test_gate_accepts_truthy_spellings(self, monkeypatch):
+        from macf.proxy.server import _rewrite_enabled
+        for val in ("on", "1", "true", "yes", "ON", " True "):
+            monkeypatch.setenv("MACF_PROXY_REWRITE", val)
+            assert _rewrite_enabled() is True, val
+        for val in ("off", "0", "false", "no", ""):
+            monkeypatch.setenv("MACF_PROXY_REWRITE", val)
+            assert _rewrite_enabled() is False, val
+
+    def test_request_path_consults_the_same_helper_as_the_banner(self):
+        import inspect
+        from macf.proxy import server
+        src = inspect.getsource(server)
+        # The banner reports it...
+        assert '"rewrite_enabled": _rewrite_enabled()' in src
+        # ...and the request path must gate on it, not run unconditionally.
+        assert "if _rewrite_enabled():" in src
+        gated = src.split("if _rewrite_enabled():", 1)[1]
+        assert "rewrite_messages(messages)" in gated.split("# 3.", 1)[0]


### PR DESCRIPTION
Closes #167. Context for #162 (flight recorder) — this is what the recorder would have caught on day one.

## The bug

`_create_app()` used `web.Application()` with no `client_max_size`. aiohttp's default is **1 MiB**, enforced *before* any handler runs — so oversized requests were rejected with 413 and never reached our logging. That absence was misread for days as "the request never left the client".

## Why it looked like a Claude Code 32 MB limit

Unpacked the CC 2.1.220 Bun binary with `js-demini` (unpack → beautify → classify, 33,824 statements, esbuild):

```js
var Bls = 33554432;              // only 3 uses in the entire 20MB bundle
EIu = Bls - 8388608;             // media byte cap
function Qcs() { return `Request too large (max ${pl(Bls)}). Accumulated images and attachments...` }
if (e instanceof hi && e.status === 413) { ... return _u({content: Qcs(), ...}) }
function nU_() { return { [Qcs()]: new Set(["document","image"]) } }   // recovery: strip media
```

No client-side size check exists — "32MB" is a hardcoded label for **any** 413. And since recovery only strips media, a media-free session retries byte-identically and wedges permanently (`/compact` included), which is exactly how a session was lost to a forced `/clear`.

## Fix

- `web.Application(client_max_size=MAX_REQUEST_BYTES)`, default **256 MiB**, override via `MACF_PROXY_MAX_REQUEST_BYTES`.
- Rationale documented at the constant so nobody reintroduces a stricter-than-upstream cap.

## Verification

| | before | after |
|---|---|---|
| 1.5 MiB POST | 413 `Maximum request body size 1048576 exceeded` | passes through (401 from upstream on dummy body) |
| 8 MiB POST | 413 | passes through |

Plus 2 regression tests (limit above aiohttp default; env override), `test_proxy_server.py` green.

Forensics: EXP-003 `data/009`.

*[TheHarborMaster@ee5cd8: task#27 s_cd1f76a9/c_3/t_1785366820]*

🤖 Generated with [Claude Code](https://claude.com/claude-code)