### PR TITLE
fix(agent): repair init — remove stale preambles, mint the agent UUID

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1828,6 +1828,28 @@ def cmd_agent_init(args: argparse.Namespace) -> int:
                 json.dump(manifest_data, f, indent=2)
             print(f"✅ Created personal policy manifest at {personal_manifest}")
 
+        # Mint the agent UUID if absent (idempotent). Without this file the
+        # identity resolver returns 'unknown', so every freshly provisioned host
+        # displayed Name@unknown and breadcrumbs lost their UUID half until
+        # someone hand-created it (issue #131).
+        #
+        # Scope mirrors _resolve_uuid_prefix()'s own priority: a per-project home
+        # (distinct from ~) gets its own id, otherwise the host-global one — so
+        # the file is minted exactly where the resolver will look for it first.
+        import uuid as _uuid
+        uuid_scope = 'project' if pa_home != Path.home() else 'global'
+        uuid_file = pa_home / '.maceff_primary_agent.id'
+        if uuid_file.exists() and uuid_file.read_text().strip():
+            print(f"\n🆔 Agent UUID present ({uuid_scope}): {uuid_file}")
+        else:
+            try:
+                agent_uuid = str(_uuid.uuid4())
+                uuid_file.write_text(agent_uuid + "\n")
+                uuid_file.chmod(0o600)
+                print(f"\n🆔 Minted agent UUID ({uuid_scope}): {agent_uuid[:6]} → {uuid_file}")
+            except OSError as e:
+                print(f"⚠️  Could not mint agent UUID at {uuid_file}: {e}", file=sys.stderr)
+
         print(f"\n📍 PA Home: {pa_home}")
         print(f"📍 Personal Policies: {personal_policies_dir}")
         print(f"\nAgent initialization complete!")

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1767,6 +1767,25 @@ def cmd_agent_init(args: argparse.Namespace) -> int:
                 user_content = existing_content.rstrip()
                 action_desc = "⚠️  Add PA Preamble to existing"
 
+            # Strip stale managed preamble blocks stranded in the user region.
+            # A preamble installed before the boundary convention (or moved above
+            # it) sits in what is otherwise treated as user content, so upgrades
+            # left the old copy in place and appended the new one — injecting the
+            # preamble twice, with the stale copy's superseded guidance still in
+            # play (issue #153). The MACEFF_PA_PREAMBLE_vX.Y_START/_END sentinels
+            # exist precisely to make managed blocks identifiable wherever they
+            # sit; honor them, and leave genuine user content untouched.
+            import re
+            stale_versions = re.findall(
+                r'<!--\s*MACEFF_PA_PREAMBLE_v([\d.]+)_START\s*-->', user_content)
+            if stale_versions:
+                user_content = re.sub(
+                    r'<!--\s*MACEFF_PA_PREAMBLE_v[\d.]+_START\s*-->.*?'
+                    r'<!--\s*MACEFF_PA_PREAMBLE_v[\d.]+_END\s*-->\s*',
+                    '', user_content, flags=re.DOTALL).rstrip()
+                print(f"🧹 Removing {len(stale_versions)} stale preamble block(s): "
+                      f"{', '.join('v' + v for v in stale_versions)}")
+
             # Confirmation prompt for modifying existing file
             print(f"\n{action_desc} CLAUDE.md:")
             print(f"  📄 {claude_md_path}")

--- a/macf/tests/test_agent_init_preamble.py
+++ b/macf/tests/test_agent_init_preamble.py
@@ -73,3 +73,29 @@ def test_user_content_without_stale_block_is_untouched(agent_home):
     assert USER_TEXT in content
     assert content.count("_START -->") == 1
     assert "stale preamble block" not in result.stdout
+
+
+class TestAgentUuidMint:
+    """`agent init` mints the agent UUID so identity never resolves to @unknown (#131)."""
+
+    def test_mints_uuid_when_absent(self, agent_home):
+        result = _run_init(agent_home)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        uuid_file = agent_home / ".maceff_primary_agent.id"
+        assert uuid_file.exists(), "agent init did not mint the UUID file"
+        assert uuid_file.read_text().strip(), "UUID file is empty"
+        # Owner-only: the id is an identity credential, not world-readable trivia.
+        assert (uuid_file.stat().st_mode & 0o077) == 0
+        assert "Minted agent UUID" in result.stdout
+
+    def test_mint_is_idempotent(self, agent_home):
+        """A second init must not re-roll an established identity."""
+        _run_init(agent_home)
+        uuid_file = agent_home / ".maceff_primary_agent.id"
+        first = uuid_file.read_text()
+
+        result = _run_init(agent_home)
+        assert uuid_file.read_text() == first, "re-init changed the agent UUID"
+        assert "Minted agent UUID" not in result.stdout
+        assert "Agent UUID present" in result.stdout

--- a/macf/tests/test_agent_init_preamble.py
+++ b/macf/tests/test_agent_init_preamble.py
@@ -1,0 +1,75 @@
+"""Preamble upgrade behavior for `macf_tools agent init` (issue #153).
+
+An upgrade must leave exactly one managed preamble block. Blocks installed
+before the boundary-marker convention sit *above* the boundary, in the region
+otherwise treated as user content — they must still be recognized as managed
+content (via their sentinels) and removed, without disturbing genuine user text.
+"""
+import os
+import subprocess
+
+import pytest
+
+
+BOUNDARY = (
+    "---\n\n"
+    "<!-- ⚠️ DO NOT WRITE BELOW THIS LINE ⚠️ -->\n"
+    "<!-- Framework preamble managed by macf_tools - edits below will be lost on upgrade -->\n"
+    "<!-- Add custom policies and agent-specific content ABOVE this boundary -->\n"
+)
+
+USER_TEXT = "This is genuine user content that must survive an upgrade."
+
+
+def _run_init(home):
+    return subprocess.run(
+        ["macf_tools", "agent", "init", "-y"],
+        capture_output=True, text=True,
+        env={**os.environ, "MACEFF_AGENT_HOME_DIR": str(home)},
+    )
+
+
+@pytest.fixture
+def agent_home(tmp_path):
+    home = tmp_path / "agenthome"
+    home.mkdir()
+    return home
+
+
+def test_stale_preamble_above_boundary_is_removed(agent_home):
+    """A pre-boundary preamble stranded above the boundary is stripped."""
+    (agent_home / "CLAUDE.md").write_text(
+        "<!-- MACEFF_PA_PREAMBLE_v1.3_START -->\n"
+        "# OLD PREAMBLE v1.3\nSuperseded guidance.\n"
+        "<!-- MACEFF_PA_PREAMBLE_v1.3_END -->\n\n"
+        f"# My Custom Policies\n{USER_TEXT}\n\n"
+        + BOUNDARY +
+        "\n<!-- MACEFF_PA_PREAMBLE_v1.4_START -->\n# CURRENT\n"
+        "<!-- MACEFF_PA_PREAMBLE_v1.4_END -->\n"
+    )
+
+    result = _run_init(agent_home)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    content = (agent_home / "CLAUDE.md").read_text()
+    assert content.count("_START -->") == 1, f"expected one managed block:\n{content}"
+    assert "OLD PREAMBLE v1.3" not in content, "stale preamble body survived"
+    assert USER_TEXT in content, "genuine user content was destroyed"
+    assert "Removing 1 stale preamble block(s)" in result.stdout
+
+
+def test_user_content_without_stale_block_is_untouched(agent_home):
+    """No sentinels above the boundary → user content passes through unchanged."""
+    (agent_home / "CLAUDE.md").write_text(
+        f"# My Custom Policies\n{USER_TEXT}\n\n" + BOUNDARY +
+        "\n<!-- MACEFF_PA_PREAMBLE_v1.4_START -->\n# CURRENT\n"
+        "<!-- MACEFF_PA_PREAMBLE_v1.4_END -->\n"
+    )
+
+    result = _run_init(agent_home)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    content = (agent_home / "CLAUDE.md").read_text()
+    assert USER_TEXT in content
+    assert content.count("_START -->") == 1
+    assert "stale preamble block" not in result.stdout


### PR DESCRIPTION
Fixes #153
Fixes #131

Two `agent init` defects, both in the same function and both leaving a freshly provisioned agent subtly broken.

**#153 — stale preamble blocks survive upgrades.** `agent init` extracts everything above the managed boundary as user content and preserves it verbatim. A preamble installed before the boundary convention existed (or moved above it) therefore survived every upgrade while a fresh copy was appended below — so the preamble was injected into every session twice, and the stale copy's superseded guidance stayed in play alongside the current one. The `MACEFF_PA_PREAMBLE_vX.Y_START/_END` sentinels exist precisely to make managed blocks identifiable wherever they sit, but the upgrade path never consulted them. This honors them: strip sentinel-delimited blocks from the user region, report what was removed (`🧹 Removing 1 stale preamble block(s): v1.3`), leave genuine user content alone.

**#131 — the agent UUID is never minted.** Nothing in `macf` created `.maceff_primary_agent.id`, so identity resolved to `Name@unknown` on any new host until someone hand-created it, and breadcrumbs lost their UUID half. Init now mints it idempotently, with scope mirroring `_resolve_uuid_prefix()`'s own priority (per-project home when distinct from `~`, else global) so the file lands where the resolver looks first. Written `600`; an existing id is reported and left untouched.

**Test evidence**: new `test_agent_init_preamble.py` covers both, in both directions — stale block removed while surrounding user content survives; a file with no stale sentinels passes through untouched with no spurious message; UUID minted with owner-only perms; re-init does not re-roll an established identity. Each test verified failing without its fix and passing with it. Full suite: 996 passed, 9 xfailed.

Not addressed (from #153's wishlist): `--dry-run`. Worth a follow-up; the removal is reported explicitly and init already prompts unless `-y` is passed.