### PR TITLE
feat(idea): accept wiki-link flags on `idea update`

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -7892,12 +7892,23 @@ def cmd_idea_get(args: argparse.Namespace) -> int:
 
 
 def cmd_idea_update(args: argparse.Namespace) -> int:
-    """Update idea status."""
+    """Update idea status, promotion target, or wiki-links."""
     from .ideas import update_idea
+
+    # Same combining rule as `idea create`: repeatable --wiki-link plus
+    # comma-separated --wiki-links, merged into one list.
+    wiki_links_raw = list(getattr(args, "wiki_link", None) or [])
+    wiki_links_csv = getattr(args, "wiki_links", "") or ""
+    if wiki_links_csv:
+        wiki_links_raw.extend(s for s in wiki_links_csv.split(",") if s.strip())
+    remove_raw = list(getattr(args, "remove_wiki_link", None) or [])
+
     result = update_idea(
         args.id,
         status=getattr(args, "status", None),
         promoted_to=getattr(args, "promoted_to", None),
+        wiki_links=wiki_links_raw,
+        remove_wiki_links=remove_raw,
     )
     if not result:
         print(f"Idea #{args.id} not found.")
@@ -7906,6 +7917,9 @@ def cmd_idea_update(args: argparse.Namespace) -> int:
     print(f"✅ Idea #{idea['id']:03d} updated: status={idea['status']}")
     if idea.get("links", {}).get("promoted_to"):
         print(f"   Promoted to: {idea['links']['promoted_to']}")
+    if wiki_links_raw or remove_raw:
+        current = idea.get("links", {}).get("wiki_links") or []
+        print(f"   Wiki-links: {', '.join(current) if current else '(none)'}")
     return 0
 
 
@@ -9169,10 +9183,19 @@ def _build_parser() -> argparse.ArgumentParser:
     idea_get.add_argument("id", type=int, help="idea ID")
     idea_get.set_defaults(func=cmd_idea_get)
 
-    idea_update = idea_sub.add_parser("update", help="update idea status")
+    idea_update = idea_sub.add_parser("update", help="update idea status or wiki-links")
     idea_update.add_argument("id", type=int, help="idea ID")
     idea_update.add_argument("--status", choices=["captured", "exploring", "promoted", "archived"], help="new status")
     idea_update.add_argument("--promoted-to", dest="promoted_to", help="what the idea became (path/ref)")
+    idea_update.add_argument(
+        "--wiki-link", dest="wiki_link", action="append", metavar="CONCEPT",
+        help="add a wiki-link concept (repeatable, normalized to lowercase_underscored)")
+    idea_update.add_argument(
+        "--wiki-links", dest="wiki_links", metavar="A,B,C",
+        help="add wiki-link concepts, comma-separated (combines with --wiki-link)")
+    idea_update.add_argument(
+        "--remove-wiki-link", dest="remove_wiki_link", action="append", metavar="CONCEPT",
+        help="remove a wiki-link concept (repeatable)")
     idea_update.set_defaults(func=cmd_idea_update)
 
     idea_archive = idea_sub.add_parser("archive", help="archive an idea")

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -186,8 +186,16 @@ def update_idea(
     idea_id: int,
     status: Optional[str] = None,
     promoted_to: Optional[str] = None,
+    wiki_links: Optional[List[str]] = None,
+    remove_wiki_links: Optional[List[str]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Update an idea's status or promotion target."""
+    """Update an idea's status, promotion target, or wiki-links.
+
+    `wiki_links` are normalized and merged into the existing set (order
+    preserved, duplicates dropped); `remove_wiki_links` prunes links found to be
+    spurious during curation. Both accept the same loose forms as `create_idea`
+    ("Foo Bar", "[[foo_bar]]", "foo_bar").
+    """
     result = get_idea(idea_id)
     if not result:
         return None
@@ -215,6 +223,30 @@ def update_idea(
 
     if promoted_to:
         idea.setdefault("links", {})["promoted_to"] = promoted_to
+
+    if wiki_links or remove_wiki_links:
+        links = idea.setdefault("links", {})
+        current = list(links.get("wiki_links") or [])
+        if wiki_links:
+            added = [w for w in _normalize_wiki_links(wiki_links) if w not in current]
+            current.extend(added)
+            if added:
+                idea.setdefault("history", []).append({
+                    "timestamp": ts_str,
+                    "action": f"wiki_links_added:{','.join(added)}",
+                    "breadcrumb": breadcrumb,
+                })
+        if remove_wiki_links:
+            drop = set(_normalize_wiki_links(remove_wiki_links))
+            removed = [w for w in current if w in drop]
+            current = [w for w in current if w not in drop]
+            if removed:
+                idea.setdefault("history", []).append({
+                    "timestamp": ts_str,
+                    "action": f"wiki_links_removed:{','.join(removed)}",
+                    "breadcrumb": breadcrumb,
+                })
+        links["wiki_links"] = current
 
     with open(path, "w") as f:
         json.dump(idea, f, indent=2)

--- a/macf/tests/test_ideas_wiki_links.py
+++ b/macf/tests/test_ideas_wiki_links.py
@@ -83,3 +83,73 @@ def test_create_idea_no_wiki_links_yields_empty_list(tmp_path, monkeypatch):
     )
     written = json.loads(Path(result["path"]).read_text())
     assert written["links"]["wiki_links"] == []
+
+
+# ---------- update_idea integration (#124) ----------
+#
+# `idea update` had no wiki-link surface, so links could only be set at
+# creation. Gap-driven curation operates on EXISTING ideas, so closing a
+# suggested gap meant hand-editing JSON.
+
+def _make_idea(tmp_path, monkeypatch, **kw):
+    monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+    from macf.ideas import create_idea
+    return create_idea(title="Idea under test", category="infrastructure",
+                       description="testing", **kw)
+
+
+def test_update_idea_adds_and_normalizes_wiki_links(tmp_path, monkeypatch):
+    from macf.ideas import update_idea
+    created = _make_idea(tmp_path, monkeypatch, wiki_links=["initial_concept"])
+
+    update_idea(created["idea"]["id"], wiki_links=["Foo Bar", "[[qux]]"])
+
+    written = json.loads(Path(created["path"]).read_text())
+    assert written["links"]["wiki_links"] == ["initial_concept", "foo_bar", "qux"]
+
+
+def test_update_idea_dedups_against_existing_links(tmp_path, monkeypatch):
+    """Re-adding an existing link is a no-op, not a duplicate."""
+    from macf.ideas import update_idea
+    created = _make_idea(tmp_path, monkeypatch, wiki_links=["audit_trail"])
+
+    update_idea(created["idea"]["id"], wiki_links=["Audit Trail"])
+
+    written = json.loads(Path(created["path"]).read_text())
+    assert written["links"]["wiki_links"] == ["audit_trail"]
+
+
+def test_update_idea_removes_wiki_links(tmp_path, monkeypatch):
+    """--remove-wiki-link prunes a link found spurious during curation."""
+    from macf.ideas import update_idea
+    created = _make_idea(tmp_path, monkeypatch, wiki_links=["keep_me", "drop_me"])
+
+    update_idea(created["idea"]["id"], remove_wiki_links=["Drop Me"])
+
+    written = json.loads(Path(created["path"]).read_text())
+    assert written["links"]["wiki_links"] == ["keep_me"]
+
+
+def test_update_idea_records_history_for_link_changes(tmp_path, monkeypatch):
+    """Link edits are auditable, like status changes."""
+    from macf.ideas import update_idea
+    created = _make_idea(tmp_path, monkeypatch)
+
+    update_idea(created["idea"]["id"], wiki_links=["added_one"])
+    update_idea(created["idea"]["id"], remove_wiki_links=["added_one"])
+
+    actions = [h["action"] for h in json.loads(Path(created["path"]).read_text())["history"]]
+    assert any(a.startswith("wiki_links_added:") for a in actions)
+    assert any(a.startswith("wiki_links_removed:") for a in actions)
+
+
+def test_update_idea_status_only_leaves_links_untouched(tmp_path, monkeypatch):
+    """Backward-compat: a status-only update must not disturb existing links."""
+    from macf.ideas import update_idea
+    created = _make_idea(tmp_path, monkeypatch, wiki_links=["untouched"])
+
+    update_idea(created["idea"]["id"], status="exploring")
+
+    written = json.loads(Path(created["path"]).read_text())
+    assert written["links"]["wiki_links"] == ["untouched"]
+    assert written["status"] == "exploring"


### PR DESCRIPTION
Fixes #124

`idea create` has `--wiki-link` / `--wiki-links`; `idea update` had neither, so an idea's links were frozen at creation. That is backwards for how curation actually works: `knowledge gaps` suggests missing `[[concept]]` links for ideas that already exist, and the curate skill says to update `links.wiki_links` — which, with no CLI path, meant hand-editing JSON.

Adds to `idea update`:

- `--wiki-link CONCEPT` (repeatable)
- `--wiki-links A,B,C` (comma-separated, combines with the above)
- `--remove-wiki-link CONCEPT` (repeatable) — the issue's bonus ask, for pruning a link that curation shows to be spurious

Same combining rule and normalizer as `idea create`, so `"Foo Bar"`, `[[qux]]` and `foo_bar` all land canonically. Additions **merge** into the existing set instead of replacing it and dedup against what is already there; both directions append `history` entries (`wiki_links_added:` / `wiki_links_removed:`), so link edits are as auditable as status changes. A status-only update leaves links untouched.

**Test evidence**: five new integration tests alongside the existing `#109` create-side coverage — add+normalize, dedup against existing, removal, history recording, and the status-only backward-compat case. Manually verified the issue's exact repro (`idea update <id> --wiki-link foo`, previously `unrecognized arguments`). Full suite: 1005 passed, 9 xfailed.