### PR TITLE
fix(supervisor): give each user its own auto-restart registry

### DIFF
--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -32,16 +32,42 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
-REGISTRY_DIR = Path("/tmp/macf/auto-restart")
+def _resolve_registry_dir() -> Path:
+    """Per-user supervisor registry directory.
+
+    A single global `/tmp/macf/auto-restart` is owned by whichever uid creates
+    it first, so the *second* agent user on a shared host or container dies with
+    PermissionError the moment its supervisor starts — and the symptom ("the
+    tmux session vanished instantly") reads as anything but a permissions
+    problem. A shared directory is also a shared namespace: `auto-restart list`
+    would show other users' supervisors, and lookup-by-name could match them.
+
+    Resolution order:
+    1. `$XDG_RUNTIME_DIR/macf/auto-restart` — per-user by construction, and the
+       same base the proxy already uses for its pid/log files.
+    2. `/tmp/macf-{uid}/auto-restart` — uid-qualified fallback, created 0700.
+    """
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg:
+        return Path(xdg) / "macf" / "auto-restart"
+    return Path(f"/tmp/macf-{os.getuid()}") / "auto-restart"
+
+
+REGISTRY_DIR = _resolve_registry_dir()
 
 
 def _registry_file(pid: int) -> Path:
     return REGISTRY_DIR / f"{pid}.json"
 
 
+def _ensure_registry_dir() -> None:
+    """Create the registry dir owner-only, so it can never be hijacked."""
+    REGISTRY_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+
 def _write_registry(pid: int, data: dict):
     """Write process stats to registry."""
-    REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    _ensure_registry_dir()
     _registry_file(pid).write_text(json.dumps(data, indent=2))
 
 
@@ -819,7 +845,7 @@ if __name__ == "__main__":
         error_msg = traceback.format_exc()
         print(f"\n[auto-restart] CRASH ({type(e).__name__}: {e}):\n{error_msg}", file=sys.stderr)
         # Log to file (persists after window closes)
-        REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        _ensure_registry_dir()
         with open(LOG_FILE, "a") as f:
             f.write(f"\n--- {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n")
             f.write(f"argv: {sys.argv}\n")

--- a/macf/tests/test_supervisor_registry.py
+++ b/macf/tests/test_supervisor_registry.py
@@ -1,0 +1,46 @@
+"""Per-user supervisor registry (cversek/MacEff#159).
+
+A single global `/tmp/macf/auto-restart` is owned by whichever uid gets there
+first, so a second agent user on the same host or container crashed with
+PermissionError — and the symptom ("tmux session vanished instantly") pointed
+nowhere near permissions. A shared directory is also a shared namespace.
+"""
+import importlib
+import os
+import stat
+
+
+def _reload_supervisor():
+    import macf.supervisor as s
+    return importlib.reload(s)
+
+
+def test_registry_uses_xdg_runtime_dir_when_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    s = _reload_supervisor()
+    assert s._resolve_registry_dir() == tmp_path / "macf" / "auto-restart"
+
+
+def test_registry_falls_back_to_uid_qualified_tmp(monkeypatch):
+    """No XDG_RUNTIME_DIR (common on macOS/containers) → uid-qualified path."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    s = _reload_supervisor()
+    resolved = s._resolve_registry_dir()
+    assert str(resolved) == f"/tmp/macf-{os.getuid()}/auto-restart"
+    # The uid must be in the path — that is what prevents the collision.
+    assert str(os.getuid()) in str(resolved)
+
+
+def test_registry_is_never_the_shared_global_path(monkeypatch):
+    """Regression: the old shared path is what caused the cross-user crash."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    s = _reload_supervisor()
+    assert s._resolve_registry_dir() != __import__("pathlib").Path("/tmp/macf/auto-restart")
+
+
+def test_registry_dir_created_owner_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    s = _reload_supervisor()
+    s._ensure_registry_dir()
+    mode = stat.S_IMODE(os.stat(s.REGISTRY_DIR).st_mode)
+    assert mode == 0o700, f"expected 0700, got {oct(mode)}"


### PR DESCRIPTION
Fixes #159

`REGISTRY_DIR = /tmp/macf/auto-restart` is created by whichever uid starts a supervisor first. The *second* agent user on the same host or container then dies immediately with `PermissionError` — and the symptom is "the tmux session vanished instantly", which points nowhere near a permissions problem. That is a hard blocker for the multi-agent case the framework is otherwise built for.

The shared path is also a shared *namespace*: `auto-restart list` would show other users' supervisors, and lookup-by-name could match another user's entry.

Resolution now follows the order the issue proposed:

1. `$XDG_RUNTIME_DIR/macf/auto-restart` when set — per-user by construction, and the same base the proxy already uses for its pid/log files, so the two subsystems agree
2. `/tmp/macf-{uid}/auto-restart` otherwise — uid-qualified, so the collision cannot recur

Created `0700` via a single `_ensure_registry_dir()` helper (both former `mkdir` sites now route through it), so the directory can't be pre-created and hijacked. `REGISTRY_DIR` stays a module-level value, so the eight existing call sites are unchanged.

This supersedes the `chmod 1777` workaround, which fixed the crash but left the namespace shared.

**Test evidence**: four tests — XDG path when set, uid-qualified fallback when not, `0700` creation, and an explicit regression assert that the resolved path is never the old shared `/tmp/macf/auto-restart`. Full suite: 1009 passed, 9 xfailed.

Note: only the *resolution* changed; existing supervisors keep running, but a supervisor started after this lands won't see registry entries written under the old shared path. Since entries are per-pid runtime state, that self-heals on next start.