### PR TITLE
fix(session): prefer the hook's own session id over the shared event log

### DIFF
--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -136,7 +136,10 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Get tool details
         tool_name = data.get("tool_name", "unknown")
         tool_input = data.get("tool_input", {})
-        session_id = get_current_session_id()
+        # Pass the payload: CC tells each hook its own session id, which beats
+        # the globally-shared session_started event when a second session is
+        # running under the same agent home (#158).
+        session_id = get_current_session_id(data)
 
         # Append tool_call_started event
         event_data = {

--- a/macf/src/macf/utils/session.py
+++ b/macf/src/macf/utils/session.py
@@ -3,26 +3,52 @@ Session utilities.
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Optional
 from .paths import find_project_root
 # Events are sole source of truth - state file reads removed
 
-def get_current_session_id() -> str:
+def get_current_session_id(hook_input: Optional[dict] = None) -> str:
     """Get current session ID.
 
-    PRIMARY: Query event log for most recent session_started event (authoritative).
-    FALLBACK: Use mtime-based JSONL file detection (for first run before events).
+    Resolution order, most authoritative first:
 
-    The event-based approach is deterministic and consistent across all hooks,
-    unlike mtime-based detection which can vary when multiple session files
-    are being written concurrently (e.g., after `claude -c`).
+    1. ``hook_input['session_id']`` — CC hands every hook its own session id;
+       when the caller has it, nothing else can be more correct.
+    2. ``MACF_SESSION_ID`` / ``CLAUDE_CODE_SESSION_ID`` env — covers CLI
+       invocations made from inside a session (and test isolation).
+    3. Most recent ``session_started`` event — out-of-band CLI with no env.
+    4. mtime-based JSONL detection — first run, before any events exist.
+
+    Tiers 1-2 exist because the event log is a *global* last-writer-wins
+    singleton: the moment a second session starts under the same agent home,
+    its ``session_started`` makes every hook in every session — including the
+    original, still-live one — stamp the newcomer's id. Ordinary hooks never
+    write ``session_started``, so the original could never reclaim its identity
+    (cversek/MacEff#159's sibling, #158). The hook process already holds the
+    right answer; prefer it over the shared log.
+
+    Args:
+        hook_input: Parsed hook stdin payload, when the caller is a hook.
 
     Returns:
         Session ID string or "unknown" if not found
     """
-    # PRIMARY: Event-first approach - query session_started event
+    # TIER 1: the caller's own session, straight from CC.
+    if hook_input:
+        sid = hook_input.get("session_id")
+        if sid:
+            return str(sid)
+
+    # TIER 2: environment (session-scoped by construction).
+    for var in ("MACF_SESSION_ID", "CLAUDE_CODE_SESSION_ID"):
+        sid = os.environ.get(var)
+        if sid:
+            return sid
+
+    # TIER 3: Event-first approach - query session_started event
     try:
         from ..event_queries import get_current_session_id_from_events
         session_id = get_current_session_id_from_events()

--- a/macf/tests/test_session.py
+++ b/macf/tests/test_session.py
@@ -73,6 +73,17 @@ def get_session_temp_dir(session_id: str, agent_id: str = "test_agent") -> Path:
 class TestSessionIDExtraction:
     """Test suite for session ID extraction from JSONL files."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_higher_tiers(self, monkeypatch):
+        """Exercise the mtime tier specifically.
+
+        `get_current_session_id()` prefers the hook payload and then the
+        environment (#158); these tests target the filename/mtime fallback, so
+        the higher tiers must be cleared or the ambient session leaks in.
+        """
+        monkeypatch.delenv("MACF_SESSION_ID", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
     def test_get_current_session_id_from_claude_project(self, mock_claude_project):
         """
         Test extracting session ID from .claude project JSONL files.

--- a/macf/tests/test_session_id_resolution.py
+++ b/macf/tests/test_session_id_resolution.py
@@ -1,0 +1,49 @@
+"""Session-id resolution priority (cversek/MacEff#158).
+
+`get_current_session_id()` resolved from the most recent `session_started`
+event — a global last-writer-wins singleton. When a second CC session started
+under the same agent home, every hook in every session (including the original,
+still-live one) began stamping the newcomer's id, and since ordinary hooks
+never write `session_started`, the original could never reclaim its identity.
+
+The hook process already holds the authoritative answer, so prefer it.
+"""
+import pytest
+
+from macf.utils.session import get_current_session_id
+
+
+def test_hook_input_session_id_wins(monkeypatch):
+    """Tier 1: CC tells each hook its own session id — nothing beats that."""
+    monkeypatch.setenv("MACF_SESSION_ID", "from-env")
+    assert get_current_session_id({"session_id": "from-hook"}) == "from-hook"
+
+
+def test_env_used_when_no_hook_input(monkeypatch):
+    """Tier 2: CLI invoked from inside a session."""
+    monkeypatch.setenv("MACF_SESSION_ID", "from-env")
+    assert get_current_session_id() == "from-env"
+
+
+def test_claude_code_session_id_env_honored(monkeypatch):
+    monkeypatch.delenv("MACF_SESSION_ID", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "from-cc-env")
+    assert get_current_session_id() == "from-cc-env"
+
+
+def test_empty_hook_input_falls_through(monkeypatch):
+    """A payload without session_id must not shadow the env tier."""
+    monkeypatch.setenv("MACF_SESSION_ID", "from-env")
+    assert get_current_session_id({}) == "from-env"
+    assert get_current_session_id({"session_id": ""}) == "from-env"
+
+
+def test_concurrent_session_cannot_hijack_a_live_hook(monkeypatch):
+    """The reported failure: a newcomer's session_started must not rename us.
+
+    With the hook's own payload in hand, the shared event log is irrelevant —
+    whatever it says, this hook reports the session CC handed it.
+    """
+    monkeypatch.setenv("MACF_SESSION_ID", "throwaway-newcomer")
+    live = get_current_session_id({"session_id": "original-live-session"})
+    assert live == "original-live-session"


### PR DESCRIPTION
Fixes #158

`get_current_session_id()` resolved the current session as the most recent `session_started` event — a global last-writer-wins singleton. Start a second CC session under the same agent home (a scratch session, a harness test, a subagent shell) and its SessionStart hook makes **every hook in every session**, including the original live one, stamp the newcomer's id. It is self-perpetuating too: ordinary hooks never write `session_started`, so the original can't reclaim its identity by doing work.

The hook process already holds the right answer twice over — CC passes `session_id` in the stdin payload, and it is in the environment — and the resolver ignored both. New order:

1. `hook_input['session_id']` — the caller's own session, straight from CC
2. `MACF_SESSION_ID` / `CLAUDE_CODE_SESSION_ID` — CLI invoked from inside a session
3. most recent `session_started` event — out-of-band CLI with no env (cron)
4. mtime-based JSONL detection — first run, before any events

The parameter is optional, so every existing call site keeps working and picks up tier 2 immediately; `handle_pre_tool_use` (the highest-frequency hook) now passes its payload for tier 1.

**Follow-up, deliberately not in this PR**: twelve other hook modules still call `get_current_session_id()` bare. They are already correct via tier 2 whenever the env is set; threading `data` through each is mechanical but touches every hook file at once, and hook-substrate changes are safer in a reviewable batch of their own.

**Test evidence**: five new tests — payload beats env, env used without a payload, `CLAUDE_CODE_SESSION_ID` honored, an empty/missing payload falls through rather than shadowing, and the reported scenario (a newcomer's id in the environment cannot rename a hook that was handed its own). Also fixed four pre-existing `test_session.py` tests that targeted the mtime tier without isolating the environment — they were passing only because the ambient env happened to be unset in CI; they now clear the higher tiers explicitly. Full suite: 1014 passed, 9 xfailed.