### PR TITLE
fix(proxy): report who actually owns the socket in status

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -7509,13 +7509,27 @@ def cmd_proxy_status(args: argparse.Namespace) -> int:
         print(json.dumps(status, indent=2))
     else:
         running = status.get('running', False)
+        owner = status.get('socket_owner_pid')
         if running:
             print(f"✅ Proxy running (PID {status['pid']}, port {status['port']})")
+            if owner:
+                print(f"   Socket owner: PID {owner}")
             print(f"   Log: {status['log_path']}")
             print(f"   Activate: ANTHROPIC_BASE_URL=http://localhost:{status['port']} claude")
         else:
             print("⭕ Proxy not running")
-            print("   Start: macf_tools proxy start --daemon")
+            if owner:
+                # Something answers on the port that we did not start — the
+                # split-brain case where "it responds" hides an unsupervised
+                # or crash-looping service.
+                print(f"   ⚠️  But PID {owner} is listening on port {status['port']}.")
+                print(f"      Another start path (systemd unit or ad-hoc daemon) owns the socket.")
+                print(f"      Inspect: ss -tlnp | grep {status['port']}   /   systemctl --user status")
+            else:
+                print("   Start: macf_tools proxy start --daemon")
+        if status.get('socket_owner_mismatch'):
+            print(f"   ⚠️  Socket owner (PID {owner}) differs from the recorded PID "
+                  f"({status['pid']}) — the pidfile is stale or a second instance holds the port.")
     return 0
 
 

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -650,13 +650,62 @@ def stop_proxy() -> bool:
         return False
 
 
+def _socket_owner_pid(port: int) -> Optional[int]:
+    """PID actually listening on `port`, or None if that can't be determined.
+
+    The pidfile records who *we* started; this reports who actually holds the
+    socket. They diverge in the split-brain case (an ad-hoc daemon keeps
+    answering while a systemd unit crash-loops on EADDRINUSE), which is exactly
+    when the pidfile alone is misleading.
+    """
+    import re
+    import shutil
+    import subprocess as _sp
+
+    if shutil.which("ss"):
+        cmd = ["ss", "-tlnp"]
+    elif shutil.which("lsof"):
+        cmd = ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"]
+    else:
+        return None
+
+    try:
+        out = _sp.run(cmd, capture_output=True, text=True, timeout=5)
+    except (OSError, _sp.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+
+    for line in out.stdout.splitlines():
+        if f":{port}" not in line:
+            continue
+        # ss:   users:(("python3",pid=1234,fd=7))
+        m = re.search(r'pid=(\d+)', line)
+        if m:
+            return int(m.group(1))
+        # lsof: python3 1234 user ...
+        parts = line.split()
+        if len(parts) >= 2 and parts[1].isdigit():
+            return int(parts[1])
+    return None
+
+
 def get_proxy_status() -> dict:
-    """Get proxy status information."""
+    """Get proxy status information.
+
+    Includes a socket-owner cross-check: "it answers on the port" is not the
+    same as "the process we think is running owns the port".
+    """
     running = is_proxy_running()
+    pid = _read_pid() if running else None
+    owner = _socket_owner_pid(DEFAULT_PORT)
     result = {
         "running": running,
-        "pid": _read_pid() if running else None,
+        "pid": pid,
         "port": DEFAULT_PORT,
+        "socket_owner_pid": owner,
+        # True when something else holds the socket — the split-brain signature.
+        "socket_owner_mismatch": bool(owner and pid and owner != pid),
         "log_path": str(get_log_path()),
         "pid_file": str(_get_pid_file()),
     }

--- a/macf/tests/test_proxy_socket_owner.py
+++ b/macf/tests/test_proxy_socket_owner.py
@@ -1,0 +1,48 @@
+"""Socket-owner cross-check in proxy status (cversek/MacEff#161).
+
+`proxy start --daemon` and a systemd unit are two independent start paths for
+one singleton service. When both exist, the unit crash-loops on EADDRINUSE
+while the ad-hoc instance keeps answering — so the service looks healthy while
+being entirely unsupervised. Status reported the pidfile's PID, which is
+exactly the field that cannot see this.
+"""
+import os
+import socket
+
+import pytest
+
+from macf.proxy.server import _socket_owner_pid, get_proxy_status
+
+
+def test_detects_pid_actually_holding_the_port():
+    """A live listener is attributed to the process that owns it."""
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    try:
+        owner = _socket_owner_pid(port)
+        if owner is None:
+            pytest.skip("no ss/lsof available to inspect sockets")
+        assert owner == os.getpid()
+    finally:
+        s.close()
+
+
+def test_no_listener_yields_none():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()  # port now free
+    assert _socket_owner_pid(port) is None
+
+
+def test_status_exposes_socket_owner_fields():
+    """Status carries the cross-check fields even when nothing is running."""
+    status = get_proxy_status()
+    assert "socket_owner_pid" in status
+    assert "socket_owner_mismatch" in status
+    # No proxy of ours running and no owner → nothing to flag.
+    if not status["running"] and status["socket_owner_pid"] is None:
+        assert status["socket_owner_mismatch"] is False


### PR DESCRIPTION
Refs #161

Addresses the second bullet of the issue — the diagnostic half, which is what actually exposes the split-brain.

`proxy status` reported the PID from the pidfile: who *we* started. That is precisely the field that cannot detect the reported failure, where an ad-hoc daemon holds the port and keeps answering while a systemd unit crash-loops on EADDRINUSE behind it. The service looks healthy the whole time.

Status now cross-checks the socket owner (`ss -tlnp`, falling back to `lsof` on macOS) and reports:

- the owning PID alongside the recorded one when running
- a warning when we report **not running** but something *is* listening on the port — the exact signature of an unsupervised or crash-looping second start path, with `ss`/`systemctl` pointers
- an explicit mismatch line when recorded PID and socket owner disagree (stale pidfile, or a second instance)

Both `socket_owner_pid` and `socket_owner_mismatch` are in the `--json` output too.

**Deliberately not in this PR** (leaving the issue open): the `proxy start` refusal when a systemd unit claims the port, and the "migrating to supervised mode" docs. Those need real systemd to verify honestly, and this host has none — shipping the detection that can be tested rather than guessing at unit-state parsing. The cross-check here is the same one that diagnosed the original incident.

**Test evidence**: three tests — a live listener is attributed to the owning PID (skips cleanly where neither `ss` nor `lsof` exists), a freed port yields `None`, and status always carries the cross-check fields. Verified manually against a real listener on 8019: detection returned the holder's PID while `running` was `False`, which is the split-brain condition. Full suite: 1017 passed, 9 xfailed.