### PR TITLE
fix(hooks): name the skill in notifications and give it its own glyph

### DIFF
--- a/macf/src/macf/hooks/handle_permission_request.py
+++ b/macf/src/macf/hooks/handle_permission_request.py
@@ -63,6 +63,22 @@ def _send_permission_preview(tool_name, tool_input, send_notification, send_docu
         msg += f"\n\n<pre>{html_escape(command[:3000])}</pre>"
         send_notification(msg, parse_mode="HTML")
 
+    elif tool_name == "Skill":
+        # The skill name is the entire signal here: from a phone, a generic
+        # gear glyph says almost nothing, while "maceff:jotewr" says what the
+        # agent is about to do. Distinct glyph so skills are scannable in a
+        # channel timeline (#163).
+        skill = tool_input.get("skill", "unknown")
+        args = tool_input.get("args", "") or ""
+        msg = f"\U0001f39b\ufe0f <b>Skill</b>: <code>{html_escape(str(skill))}</code>"
+        if args:
+            args_str = str(args)
+            summary = html_escape(args_str[:200])
+            if len(args_str) > 200:
+                summary += "\u2026"
+            msg += f"\n\n<pre>{summary}</pre>"
+        send_notification(msg, parse_mode="HTML")
+
 
 def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
     """

--- a/macf/src/macf/hooks/handle_pre_tool_use.py
+++ b/macf/src/macf/hooks/handle_pre_tool_use.py
@@ -410,8 +410,12 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
                             }
                         }
 
-                # Show enriched tool name for Skill invocations, generic gear for others
-                if display_tool != tool_name:
+                # Skills get a distinct glyph plus their name — "⚙️" alone is
+                # nearly information-free when scanning a channel timeline,
+                # while the skill name is the whole signal (#163).
+                if tool_name == "Skill":
+                    message_parts.append(f"🎛️ {display_tool}")
+                elif display_tool != tool_name:
                     message_parts.append(f"🎯 {display_tool}")
                 else:
                     message_parts.append("⚙️")

--- a/macf/tests/test_skill_notification.py
+++ b/macf/tests/test_skill_notification.py
@@ -1,0 +1,52 @@
+"""Skill invocations are identifiable in notifications (cversek/MacEff#163).
+
+From a phone, "⚙️ Skill" is nearly information-free — the skill *name* is the
+entire signal. Skills also need a glyph distinct from the generic gear so they
+are scannable in a channel timeline.
+"""
+from unittest.mock import Mock
+
+from macf.hooks.handle_permission_request import _send_permission_preview
+
+
+def _capture(tool_name, tool_input):
+    sent = []
+    _send_permission_preview(
+        tool_name, tool_input,
+        send_notification=lambda msg, **kw: sent.append(msg),
+        send_document=Mock(),
+        html_escape=lambda s: s,
+    )
+    return sent
+
+
+def test_skill_notification_names_the_skill():
+    sent = _capture("Skill", {"skill": "maceff:jotewr"})
+    assert len(sent) == 1
+    assert "maceff:jotewr" in sent[0]
+
+
+def test_skill_notification_uses_distinct_glyph():
+    """Not the generic gear Bash uses — skills must stand out."""
+    skill_msg = _capture("Skill", {"skill": "maceff:ccp"})[0]
+    bash_msg = _capture("Bash", {"command": "ls"})[0]
+    assert "🎛️" in skill_msg
+    assert "⚙️" not in skill_msg
+    assert "⚙️" in bash_msg  # unchanged
+
+
+def test_skill_notification_includes_short_args():
+    sent = _capture("Skill", {"skill": "maceff:jotewr", "args": "5k reflection"})
+    assert "5k reflection" in sent[0]
+
+
+def test_skill_notification_truncates_long_args():
+    sent = _capture("Skill", {"skill": "s", "args": "x" * 500})
+    assert "…" in sent[0]
+    assert len(sent[0]) < 500
+
+
+def test_skill_notification_survives_missing_fields():
+    """A payload without skill/args must not raise."""
+    sent = _capture("Skill", {})
+    assert "unknown" in sent[0]


### PR DESCRIPTION
Fixes #163

`_send_permission_preview` had branches for Write, Edit and Bash; Skill fell through to the generic path, so a remote operator saw a gear and no indication of *which* skill was running. The skill name is the entire signal there.

- **Telegram preview**: new Skill branch showing the skill name, plus a short args summary when present (truncated at 200 chars).
- **Distinct glyph**: 🎛️ for skills in both the Telegram preview and the PreToolUse banner, so they stand out from ⚙️ Bash/other tools when scanning a channel timeline. Bash and friends are unchanged.

**Test evidence**: five tests — the name appears, the glyph is distinct from Bash's (asserted both ways), short args are included, long args are truncated, and a payload missing `skill`/`args` degrades to `unknown` rather than raising (notification code must never break the hook). Full suite: 1022 passed, 9 xfailed.