### PR TITLE
feat(proxy): record request bytes and a per-block census

### DIFF
--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -225,6 +225,56 @@ CLAMPED_WINDOW = 200_000
 WINDOW_WARN_AT = 150_000
 _window_warned = False
 
+# The client rejects oversized requests with "Request too large (max 32MB)" —
+# a hardcoded client-side label, so 32MB is the wall we are measured against,
+# not a limit this proxy imposes. Warn at a fraction of it while the session is
+# still alive to act (compact, clear a runaway tool_result). Override the ratio
+# with MACF_PROXY_SIZE_WARN_RATIO; 0 disables the warning.
+CLIENT_REQUEST_WALL_BYTES = 32 * 1024 * 1024
+_request_size_warned = False
+
+
+def _request_warn_at() -> int:
+    """Byte threshold for the growth warning (0 = disabled)."""
+    try:
+        ratio = float(os.environ.get("MACF_PROXY_SIZE_WARN_RATIO", "0.6"))
+    except ValueError:
+        ratio = 0.6
+    if ratio <= 0:
+        return 0
+    return int(CLIENT_REQUEST_WALL_BYTES * ratio)
+
+
+def _warn_if_request_growing(request_bytes: int) -> None:
+    """Make the request-size cliff visible before it is fatal.
+
+    Hitting the wall is unrecoverable in practice: the client refuses to
+    serialize, `/compact` fails on the same wall because the compaction request
+    takes the same path, and `/clear` — total context loss — is the only exit.
+    One warning per process, on the way up, is the whole point.
+    """
+    global _request_size_warned
+    threshold = _request_warn_at()
+    if _request_size_warned or not threshold or request_bytes < threshold:
+        return
+    _request_size_warned = True
+    pct = round(100 * request_bytes / CLIENT_REQUEST_WALL_BYTES)
+    _log_event({
+        "type": "request_size_watch", "ts": int(time.time()),
+        "request_bytes": request_bytes,
+        "wall_bytes": CLIENT_REQUEST_WALL_BYTES,
+        "pct_of_wall": pct,
+    })
+    print(
+        f"[proxy:size] ⚠️  request reached {request_bytes / 1_048_576:.1f} MB "
+        f"({pct}% of the client's ~32MB wall).\n"
+        f"  At the wall the client refuses to serialize, and /compact fails the same\n"
+        f"  way (it takes this path too) — /clear becomes the only exit, losing the\n"
+        f"  whole context. Compact NOW while it still works.\n"
+        f"  See per-block bytes in this request's api_request log entry to find what grew.",
+        file=sys.stderr,
+    )
+
 
 def _warn_if_approaching_clamp(usage: dict) -> None:
     """Say the actionable thing while the session is still alive to act on it."""
@@ -421,12 +471,45 @@ def _capture_write(cap: Path, filename: str, payload) -> bool:
 
 # --------------- Request metadata extraction ---------------
 
+def _block_byte_census(messages: list) -> dict:
+    """Bytes per content-block type across all messages.
+
+    Metadata like `message_count` says how *many* blocks there are, never how
+    heavy they are — so when a session walks into the request-size wall, the log
+    cannot say what grew. A census names the culprit directly (a tool_result
+    that ballooned, images accumulating, system-reminders piling up) instead of
+    leaving it to transcript inference after the fact.
+    """
+    census: dict = {}
+    for msg in messages or []:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if isinstance(content, str):
+            census["text"] = census.get("text", 0) + len(content)
+            continue
+        for block in content or []:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "unknown")
+            # Serialized size of the block itself: images live in nested
+            # source.data, tool_results in nested content, so a top-level
+            # len() would undercount exactly the blocks that matter most.
+            try:
+                size = len(json.dumps(block))
+            except (TypeError, ValueError):
+                size = len(str(block))
+            census[btype] = census.get(btype, 0) + size
+    return census
+
+
 def _extract_request_meta(body: bytes) -> dict:
     """Extract metadata from API request body."""
     try:
         data = json.loads(body)
     except json.JSONDecodeError:
-        return {"type": "api_request", "ts": int(time.time()), "parse_error": True}
+        # Even unparseable bodies get their size recorded: a body too large or
+        # malformed to parse is precisely the case worth seeing in the log.
+        return {"type": "api_request", "ts": int(time.time()),
+                "parse_error": True, "request_bytes": len(body)}
 
     messages = data.get("messages", [])
     system = data.get("system", "")
@@ -436,6 +519,7 @@ def _extract_request_meta(body: bytes) -> dict:
     else:
         system_chars = len(str(system))
 
+    request_bytes = len(body)
     meta = {
         "type": "api_request",
         "ts": int(time.time()),
@@ -445,7 +529,14 @@ def _extract_request_meta(body: bytes) -> dict:
         "tool_count": len(data.get("tools", [])),
         "stream": data.get("stream", False),
         "max_tokens": data.get("max_tokens", 0),
+        # Tier-1 flight-recorder telemetry: the serialized size and what it is
+        # made of. The trend across a session predicts the request-size cliff
+        # many turns before it becomes fatal.
+        "request_bytes": request_bytes,
+        "block_bytes": _block_byte_census(messages),
     }
+
+    _warn_if_request_growing(request_bytes)
 
     # Dump full request to capture dir if enabled
     capture_dir = os.environ.get("MACF_PROXY_CAPTURE_DIR")

--- a/macf/tests/test_proxy_request_telemetry.py
+++ b/macf/tests/test_proxy_request_telemetry.py
@@ -1,0 +1,88 @@
+"""Tier-1 request-size telemetry (cversek/MacEff#162).
+
+A long-lived session died unrecoverably at the client's request-size wall: the
+client refused to serialize, `/compact` failed the same way (it takes the same
+path), and `/clear` — total context loss — was the only exit. The proxy log
+proved the rejection was client-side but could not show *what* had grown,
+because it recorded only counts (message_count, tool_count), never bytes.
+"""
+import json
+
+import pytest
+
+import macf.proxy.server as server
+from macf.proxy.server import _block_byte_census, _extract_request_meta
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_state(monkeypatch):
+    monkeypatch.setattr(server, "_request_size_warned", False, raising=False)
+    monkeypatch.delenv("MACF_PROXY_CAPTURE_DIR", raising=False)
+
+
+def _body(messages, **kw):
+    return json.dumps({"model": "m", "messages": messages, "system": "", **kw}).encode()
+
+
+def test_request_bytes_matches_serialized_size():
+    body = _body([{"role": "user", "content": "hi"}])
+    assert _extract_request_meta(body)["request_bytes"] == len(body)
+
+
+def test_census_attributes_nested_image_payload():
+    """The bytes live in source.data — a top-level len() would undercount."""
+    census = _block_byte_census([
+        {"role": "user", "content": [
+            {"type": "text", "text": "x" * 10},
+            {"type": "image", "source": {"type": "base64", "data": "A" * 5000}},
+        ]},
+    ])
+    assert census["image"] > 5000
+    assert census["image"] > census["text"] * 10
+
+
+def test_census_counts_tool_results_separately():
+    census = _block_byte_census([
+        {"role": "user", "content": [{"type": "tool_result", "content": "B" * 2000}]},
+    ])
+    assert census["tool_result"] > 2000
+    assert "image" not in census
+
+
+def test_census_handles_plain_string_content():
+    """Not every message uses content blocks."""
+    assert _block_byte_census([{"role": "a", "content": "hello"}])["text"] == 5
+
+
+def test_census_survives_malformed_blocks():
+    """Telemetry must never be the thing that breaks a request."""
+    census = _block_byte_census([{"role": "u", "content": ["not-a-dict", None]}])
+    assert isinstance(census, dict)
+
+
+def test_unparseable_body_still_records_size():
+    """A body too large or malformed to parse is exactly what we want logged."""
+    meta = _extract_request_meta(b"{not json")
+    assert meta["parse_error"] is True
+    assert meta["request_bytes"] == len(b"{not json")
+
+
+def test_warning_fires_once_above_threshold(capsys, monkeypatch):
+    monkeypatch.setattr(server, "_request_size_warned", False, raising=False)
+    server._warn_if_request_growing(int(server.CLIENT_REQUEST_WALL_BYTES * 0.9))
+    first = capsys.readouterr().err
+    server._warn_if_request_growing(server.CLIENT_REQUEST_WALL_BYTES)
+    second = capsys.readouterr().err
+    assert "% of the client's" in first
+    assert second == "", "warning must be one-shot, not per-request noise"
+
+
+def test_no_warning_below_threshold(capsys, monkeypatch):
+    monkeypatch.setattr(server, "_request_size_warned", False, raising=False)
+    server._warn_if_request_growing(1024)
+    assert capsys.readouterr().err == ""
+
+
+def test_ratio_zero_disables_the_warning(monkeypatch):
+    monkeypatch.setenv("MACF_PROXY_SIZE_WARN_RATIO", "0")
+    assert server._request_warn_at() == 0


### PR DESCRIPTION
Fixes #162

Implements **Tier 1**. Tier 2 (rolling full-request capture) already landed with #168 as `MACF_PROXY_CAPTURE_DIR` + `MACF_PROXY_CAPTURE_MAX_MB`, so this completes the pair: detect (tier 1) → diagnose (tier 2).

The `api_request` record carried counts — `message_count`, `tool_count`, `system_prompt_chars` — but never bytes. In the incident that motivated this, the log was decisive for *exoneration* (zero entries in the failure window ⇒ client-side rejection) yet could not say **what grew**, leaving byte forensics to transcript inference after the context was already gone.

Added to every `api_request` record:

- `request_bytes` — the serialized body size
- `block_bytes` — a per-content-block census (`text`, `image`, `tool_result`, …)

The census measures each block **serialized**, because the bytes that matter live nested: an image's payload is in `source.data`, a tool_result's in `content`. A top-level `len()` would undercount exactly the blocks most likely to be the culprit. Verified on a synthetic payload: a 5000-char base64 image is attributed 5059 B to `image`, a 2000-char tool_result 2038 B to `tool_result`, rather than smeared into one total.

Also a one-shot growth warning at a configurable fraction of the client's ~32MB wall (`MACF_PROXY_SIZE_WARN_RATIO`, default 0.6, `0` disables). The wall is worth warning about early because it is unrecoverable in practice: the client refuses to serialize, `/compact` fails identically since it takes the same path, and `/clear` — total context loss — is the only exit. The threshold is a ratio of the client's own hardcoded label rather than an invented constant, so it tracks that limit rather than drifting from it.

**Test evidence**: nine tests — byte accounting matches the serialized body, nested image and tool_result payloads are attributed correctly, plain-string content is handled, malformed blocks degrade rather than raise (telemetry must never break a request), an unparseable body *still* records its size (that is precisely the case worth seeing), and the warning fires once above threshold, stays silent below, and can be disabled. Full suite: 1064 passed, 9 xfailed.