### PR TITLE
fix(proxy): name the systemd unit when refusing an occupied port

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -7402,6 +7402,36 @@ def cmd_task_metadata_validate(args: argparse.Namespace) -> int:
         return 0
 
 
+def _systemd_unit_for_pid(pid: int) -> "str | None":
+    """Name of the systemd unit owning `pid`, or None.
+
+    Read from /proc/<pid>/cgroup, where the unit appears verbatim in the path.
+    That is a plain file read, unlike parsing `systemctl` output whose format
+    varies by version — and it returns None on any non-systemd host (macOS has
+    no /proc at all), so callers get a clean "not applicable".
+
+    Matters because the remedy differs entirely: a unit-owned port must be
+    handled with `systemctl --user stop`, and killing the PID just feeds a
+    Restart=always loop.
+    """
+    import re
+    try:
+        with open(f"/proc/{pid}/cgroup") as f:
+            content = f.read()
+    except (OSError, ValueError):
+        return None
+    # A cgroup path nests several .service components, e.g.
+    #   /user.slice/user-1000.slice/user@1000.service/app.slice/macf-proxy.service
+    # The leaf is the unit actually running the process; the `user@NNNN.service`
+    # ancestor is the session manager, and naming it would send the operator to
+    # `systemctl status user@1000.service` — true, useless, and confusing.
+    units = re.findall(r'([A-Za-z0-9_@.\-]+\.service)', content)
+    for unit in reversed(units):
+        if not re.fullmatch(r'user@\d+\.service', unit):
+            return unit
+    return units[-1] if units else None
+
+
 def _check_port_available(port: int, host: str = "127.0.0.1") -> tuple:
     """Check if port is available. Returns (available: bool, owner_pid: int|None)."""
     import socket
@@ -7445,9 +7475,21 @@ def cmd_proxy_start(args: argparse.Namespace) -> int:
 
     # Pre-check port availability (catches zombies without PID files)
     available, owner_pid = _check_port_available(port)
-    if not available:
+    if not available and not getattr(args, 'force', False):
+        unit = _systemd_unit_for_pid(owner_pid) if owner_pid else None
         print(f"❌ Port {port} is already in use", file=sys.stderr)
-        if owner_pid:
+        if unit:
+            # Two start paths for one singleton service. Killing a unit-managed
+            # PID just feeds Restart=always: the unit respawns, loses the race
+            # for the port, and crash-loops while the old instance keeps
+            # answering — supervision that looks healthy but isn't (#161).
+            print(f"   Held by PID {owner_pid}, managed by systemd unit '{unit}'", file=sys.stderr)
+            print(f"   That service is already supervised — starting a second ad-hoc", file=sys.stderr)
+            print(f"   instance would split-brain the port.", file=sys.stderr)
+            print(f"   Inspect: systemctl --user status {unit}", file=sys.stderr)
+            print(f"   Migrate: systemctl --user stop {unit}   # then start ad-hoc", file=sys.stderr)
+            print(f"   Override: macf_tools proxy start --force", file=sys.stderr)
+        elif owner_pid:
             print(f"   Held by PID {owner_pid}", file=sys.stderr)
             print(f"   Fix: kill {owner_pid} && macf_tools proxy start --daemon", file=sys.stderr)
         else:
@@ -8985,6 +9027,10 @@ def _build_parser() -> argparse.ArgumentParser:
                                     help="run in background (daemonize)")
     proxy_start_parser.add_argument("--port", type=int, default=8019,
                                     help="port to listen on (default: 8019)")
+    proxy_start_parser.add_argument("--force", action="store_true",
+                                    help="start even if the port is already held (skips the "
+                                         "occupied-port refusal; the bind will still fail if "
+                                         "the holder keeps it)")
     proxy_start_parser.set_defaults(func=cmd_proxy_start)
 
     # proxy stop

--- a/macf/tests/test_proxy_systemd_detection.py
+++ b/macf/tests/test_proxy_systemd_detection.py
@@ -1,0 +1,50 @@
+"""Unit-aware refusal when the proxy port is already held (cversek/MacEff#161).
+
+`proxy start --daemon` and a systemd unit are two start paths for one singleton
+service. When a unit owns the port, killing its PID just feeds Restart=always:
+the unit respawns, loses the race, and crash-loops while the stale instance
+keeps answering — supervision that looks healthy but isn't. The remedy is
+`systemctl --user stop`, so the refusal has to name the unit, not say "kill".
+"""
+from unittest.mock import mock_open, patch
+
+from macf.cli import _systemd_unit_for_pid
+
+
+def _with_cgroup(content):
+    return patch("builtins.open", mock_open(read_data=content))
+
+
+def test_returns_leaf_unit_not_session_manager():
+    """The nested user@NNNN.service ancestor is the session manager, not the unit.
+
+    Naming it would send the operator to `systemctl status user@1000.service` —
+    true, useless, and confusing.
+    """
+    with _with_cgroup(
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/macf-proxy.service\n"
+    ):
+        assert _systemd_unit_for_pid(4242) == "macf-proxy.service"
+
+
+def test_returns_unit_for_simple_system_scope():
+    with _with_cgroup("0::/system.slice/macf-proxy.service\n"):
+        assert _systemd_unit_for_pid(1) == "macf-proxy.service"
+
+
+def test_returns_none_when_no_unit_in_path():
+    """An ad-hoc daemon has no .service component — that is the ad-hoc case."""
+    with _with_cgroup("0::/user.slice/user-1000.slice/session-3.scope\n"):
+        assert _systemd_unit_for_pid(1) is None
+
+
+def test_returns_none_without_proc():
+    """macOS and other non-systemd hosts have no /proc — clean 'not applicable'."""
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert _systemd_unit_for_pid(1) is None
+
+
+def test_returns_none_on_permission_error():
+    """Another user's PID is unreadable; degrade rather than raise."""
+    with patch("builtins.open", side_effect=PermissionError):
+        assert _systemd_unit_for_pid(1) is None


### PR DESCRIPTION
Fixes #161

Completes the issue. #175 shipped the diagnostic half (socket-owner cross-check in `status`); this is the refusal half, plus `--force`.

The occupied-port refusal already existed, but when a **systemd unit** owns the port it advised `kill <PID>` — the one remedy that makes things worse. Killing a unit-managed process feeds `Restart=always`: the unit respawns, loses the race for the port, and crash-loops while the stale ad-hoc instance keeps answering. That is the reported failure exactly — restart counter 28, `systemctl is-active` flapping, and the service looking healthy the entire time.

Now the refusal identifies the owning unit and points at `systemctl --user stop <unit>` / `status <unit>`, with `--force` to override.

**On the detection method**, since I said in #175 I would not guess at this: it reads `/proc/<pid>/cgroup`, where the unit name appears verbatim in the path. That is a plain file read rather than parsing `systemctl` output whose format varies by version, and it returns `None` on any host without `/proc` — so non-systemd hosts (this one included) get a clean "not applicable" and fall through to the existing advice.

Writing the test caught a real bug before it shipped: a cgroup path nests several `.service` components —

```
/user.slice/user-1000.slice/user@1000.service/app.slice/macf-proxy.service
```

— and my first regex returned `user@1000.service`, the session manager. It would have sent operators to `systemctl status user@1000.service`: true, useless, confusing. Now takes the leaf, skipping the `user@NNNN.service` ancestor.

**Test evidence**: five tests — leaf unit vs session manager (the bug above), simple `system.slice` path, no-unit path (the ad-hoc case, correctly `None`), missing `/proc`, and an unreadable PID belonging to another user. Full suite: 1069 passed, 9 xfailed.

**Still not verified on real systemd**, honestly: this host has none, so the cgroup format is exercised against fixtures rather than a live unit. The format is stable and documented, and every failure path degrades to the previous behavior rather than misfiring — but a confirmation from a systemd deployment would be welcome.