### PR TITLE
fix(agent): transfer a resolving identity instead of shadowing it

### DIFF
--- a/macf/docs/user/cli-reference.md
+++ b/macf/docs/user/cli-reference.md
@@ -393,10 +393,31 @@ Initialize agent with Primary Agent preamble.
 
 **Syntax:**
 ```bash
-macf_tools agent init
+macf_tools agent init [-y] [--mint-fresh-id]
 ```
 
+**Options:**
+- `-y`, `--yes` - Skip confirmation prompts (used by container provisioning and tests)
+- `--mint-fresh-id` - Mint a **new** agent UUID even when one already resolves from another scope
+
 **Description:** Sets up agent consciousness infrastructure and identity.
+
+**Identity handling.** The agent UUID lives in `.maceff_primary_agent.id`, resolved
+per-agent-home first and host-global (`~`) second. A per-agent-home file is the canonical
+mechanism — one `~` cannot serve several agents on a shared host or container. `agent init`
+establishes that file without ever silently changing who the agent is:
+
+| Situation | Behavior |
+|---|---|
+| Identity already in this agent home | Reported, left untouched |
+| Identity resolves from another scope (e.g. global) | Warns, offers to **transfer** that exact value |
+| No identity resolves anywhere | Offers a fresh value, previewed and re-rollable |
+
+The first six characters are the agent's public calling card (breadcrumbs, closeout
+comments, channel signatures), so a minted value is shown before it is accepted. Under
+`-y` every fork takes the safe branch: transfer when an identity resolves, mint only on
+genuine absence. Use `--mint-fresh-id` for the rare deliberate case of a distinct new
+identity in a home that would otherwise inherit one.
 
 **Related:** `config init`, `session info`
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1715,6 +1715,102 @@ def cmd_agent_sleep(args: argparse.Namespace) -> int:
     return 1
 
 
+def _ensure_agent_uuid(
+    pa_home: Path,
+    *,
+    assume_yes: bool = False,
+    mint_fresh: bool = False,
+) -> None:
+    """Establish the agent's identity file at ``pa_home`` without ever
+    silently changing who the agent is.
+
+    Without an id file the resolver returns ``unknown``, so a freshly
+    provisioned host displays ``Name@unknown`` and breadcrumbs lose their UUID
+    half (#131). The naive fix — mint whenever *this* file is missing — checks
+    the wrong thing: the resolver prefers the per-project file over the
+    host-global one, so minting into an agent home while a global identity is
+    already resolving changes the effective identity while overwriting nothing
+    (#180). Nothing on disk is damaged and the calling card changes anyway.
+
+    The per-project file is the canonical mechanism: one ``~`` cannot serve N
+    agents on a shared host or container, while a per-agent-home file can. So
+    the response to "resolves globally, project file absent" is to *carry the
+    existing value across*, not to skip the write and not to mint a stranger:
+
+        already in this file      → report, leave untouched
+        resolves from elsewhere   → warn, offer to transfer that exact value
+        nothing resolves anywhere → offer a fresh value, previewed, re-rollable
+
+    The first six characters become the agent's public calling card, so a
+    minted value is shown before it is accepted and can be re-rolled.
+
+    Non-interactive (``-y``, used by container start.py and the test suite)
+    takes the safe branch at every fork: transfer when an identity resolves,
+    mint only on genuine absence. ``mint_fresh`` is the explicit opt-in for the
+    rare deliberate case of a *new* identity in a home that would otherwise
+    inherit one.
+    """
+    import uuid as _uuid
+    from .utils.identity import _resolve_uuid_source
+
+    uuid_file = pa_home / '.maceff_primary_agent.id'
+    target_scope = 'project' if pa_home != Path.home() else 'global'
+
+    def _write(value: str, verb: str) -> None:
+        try:
+            uuid_file.write_text(value + "\n")
+            uuid_file.chmod(0o600)
+            print(f"\n🆔 {verb} agent UUID ({target_scope}): {value[:6]} → {uuid_file}")
+        except OSError as e:
+            print(f"⚠️  Could not write agent UUID at {uuid_file}: {e}", file=sys.stderr)
+
+    # Already established here — the only fully silent branch.
+    try:
+        if uuid_file.exists() and uuid_file.read_text().strip():
+            print(f"\n🆔 Agent UUID present ({target_scope}): {uuid_file}")
+            return
+    except OSError as e:
+        print(f"⚠️  Could not read agent UUID at {uuid_file}: {e}", file=sys.stderr)
+        return
+
+    resolved, resolved_scope, resolved_source = _resolve_uuid_source()
+    inherited = bool(resolved) and resolved_source != uuid_file
+
+    if inherited and not mint_fresh:
+        print(f"\n⚠️  This agent already has an identity that resolves from another scope:")
+        print(f"      {resolved[:6]}  ({resolved_scope}) ← {resolved_source}")
+        print(f"    Writing a different value to {uuid_file} would take precedence")
+        print(f"    over it and change the agent's calling card.")
+        if assume_yes:
+            print("    Non-interactive: transferring the existing identity (use "
+                  "--mint-fresh-id to mint a new one instead).")
+            _write(resolved, "Transferred")
+            return
+        answer = input(f"\n  Transfer {resolved[:6]} into {uuid_file.name}? [Y/n]: ").strip().lower()
+        if answer in ('', 'y', 'yes'):
+            _write(resolved, "Transferred")
+            return
+        print("    Keeping the resolved identity; not writing a project file.")
+        return
+
+    # Genuine absence (or an explicit --mint-fresh-id): offer a value.
+    while True:
+        candidate = str(_uuid.uuid4())
+        if assume_yes:
+            _write(candidate, "Minted")
+            return
+        print(f"\n🆔 Proposed agent UUID: {candidate}")
+        print(f"    Calling card would be: @{candidate[:6]}")
+        answer = input("  [A]ccept / [r]egenerate / [s]kip: ").strip().lower()
+        if answer in ('', 'a', 'accept', 'y', 'yes'):
+            _write(candidate, "Minted")
+            return
+        if answer in ('s', 'skip', 'n', 'no'):
+            print("    Skipped — the agent will resolve to @unknown until an id exists.")
+            return
+        # anything else re-rolls
+
+
 def cmd_agent_init(args: argparse.Namespace) -> int:
     """Initialize agent with preamble injection (idempotent)."""
     try:
@@ -1861,27 +1957,11 @@ def cmd_agent_init(args: argparse.Namespace) -> int:
                 json.dump(manifest_data, f, indent=2)
             print(f"✅ Created personal policy manifest at {personal_manifest}")
 
-        # Mint the agent UUID if absent (idempotent). Without this file the
-        # identity resolver returns 'unknown', so every freshly provisioned host
-        # displayed Name@unknown and breadcrumbs lost their UUID half until
-        # someone hand-created it (issue #131).
-        #
-        # Scope mirrors _resolve_uuid_prefix()'s own priority: a per-project home
-        # (distinct from ~) gets its own id, otherwise the host-global one — so
-        # the file is minted exactly where the resolver will look for it first.
-        import uuid as _uuid
-        uuid_scope = 'project' if pa_home != Path.home() else 'global'
-        uuid_file = pa_home / '.maceff_primary_agent.id'
-        if uuid_file.exists() and uuid_file.read_text().strip():
-            print(f"\n🆔 Agent UUID present ({uuid_scope}): {uuid_file}")
-        else:
-            try:
-                agent_uuid = str(_uuid.uuid4())
-                uuid_file.write_text(agent_uuid + "\n")
-                uuid_file.chmod(0o600)
-                print(f"\n🆔 Minted agent UUID ({uuid_scope}): {agent_uuid[:6]} → {uuid_file}")
-            except OSError as e:
-                print(f"⚠️  Could not mint agent UUID at {uuid_file}: {e}", file=sys.stderr)
+        _ensure_agent_uuid(
+            pa_home,
+            assume_yes=getattr(args, 'yes', False),
+            mint_fresh=getattr(args, 'mint_fresh_id', False),
+        )
 
         print(f"\n📍 PA Home: {pa_home}")
         print(f"📍 Personal Policies: {personal_policies_dir}")
@@ -8226,6 +8306,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
     agent_init_parser = agent_sub.add_parser("init", help="initialize agent with PA preamble")
     agent_init_parser.add_argument("-y", "--yes", action="store_true", help="skip confirmation prompt")
+    agent_init_parser.add_argument(
+        "--mint-fresh-id", action="store_true",
+        help="mint a NEW agent UUID even if one already resolves from another "
+             "scope (default is to transfer the existing identity, preserving "
+             "the calling card)",
+    )
     agent_init_parser.set_defaults(func=cmd_agent_init)
 
     # AUTO_MODE auth token bootstrap (host / non-Docker installs) — #115

--- a/macf/src/macf/utils/identity.py
+++ b/macf/src/macf/utils/identity.py
@@ -182,9 +182,9 @@ def _get_gecos_name() -> Optional[str]:
         return None
 
 
-def _resolve_uuid_prefix() -> "tuple[str, str]":
+def _resolve_uuid_source() -> "tuple[Optional[str], str, Optional[Path]]":
     """
-    Read the agent UUID prefix together with the scope it resolved from.
+    Resolve the agent UUID together with its scope and the file it came from.
 
     Resolution order:
     1. {agent_home}/.maceff_primary_agent.id when agent_home is somewhere
@@ -192,11 +192,15 @@ def _resolve_uuid_prefix() -> "tuple[str, str]":
        'project'
     2. ~/.maceff_primary_agent.id — scope 'global'
 
-    The scope feeds get_agent_identity()'s name resolution: a per-project
-    UUID must not be paired with a host-global name override.
+    This is the single implementation of that precedence; callers that only
+    need the display prefix go through _resolve_uuid_prefix(). Callers that
+    need to *move* an identity between scopes need the whole value and its
+    origin, which is what this returns — reading the file a second time from
+    a caller's own copy of the precedence rules is how identities drift.
 
     Returns:
-        tuple[str, str]: (first 6 characters of UUID or 'unknown', scope)
+        tuple: (full UUID or None when nothing resolves, scope, source path
+        or None)
     """
     try:
         agent_home = None
@@ -213,24 +217,41 @@ def _resolve_uuid_prefix() -> "tuple[str, str]":
                 if per_project.exists():
                     uuid_full = per_project.read_text().strip()
                     if uuid_full:
-                        return uuid_full[:6], 'project'
+                        return uuid_full, 'project', per_project
             except (OSError, IOError) as e:
                 print(f"Warning: could not read per-project agent ID: {e}", file=sys.stderr)
 
         # Priority 2: Global fallback
         uuid_file = Path.home() / '.maceff_primary_agent.id'
         if not uuid_file.exists():
-            return 'unknown', 'global'
+            return None, 'global', None
 
         uuid_full = uuid_file.read_text().strip()
         if not uuid_full:
-            return 'unknown', 'global'
+            return None, 'global', None
 
-        return uuid_full[:6], 'global'
+        return uuid_full, 'global', uuid_file
 
     except (OSError, IOError) as e:
         print(f"Warning: could not read agent ID: {e}", file=sys.stderr)
-        return 'unknown', 'global'
+        return None, 'global', None
+
+
+def _resolve_uuid_prefix() -> "tuple[str, str]":
+    """
+    Read the agent UUID prefix together with the scope it resolved from.
+
+    Thin projection of _resolve_uuid_source(); see that function for the
+    resolution order. The scope feeds get_agent_identity()'s name resolution:
+    a per-project UUID must not be paired with a host-global name override.
+
+    Returns:
+        tuple[str, str]: (first 6 characters of UUID or 'unknown', scope)
+    """
+    uuid_full, scope, _source = _resolve_uuid_source()
+    if not uuid_full:
+        return 'unknown', scope
+    return uuid_full[:6], scope
 
 
 def _get_uuid_prefix() -> str:

--- a/macf/tests/test_agent_init_preamble.py
+++ b/macf/tests/test_agent_init_preamble.py
@@ -21,11 +21,20 @@ BOUNDARY = (
 USER_TEXT = "This is genuine user content that must survive an upgrade."
 
 
-def _run_init(home):
+def _run_init(home, *, host_home=None, extra_args=()):
+    """Run `agent init -y` against an isolated agent home.
+
+    ``host_home`` overrides ``HOME``, which isolates the *global* identity
+    scope. Without it the developer's own ``~/.maceff_primary_agent.id`` is
+    visible to the test and identity assertions become host-dependent —
+    passing on a machine with no global id and failing on one with.
+    """
+    env = {**os.environ, "MACEFF_AGENT_HOME_DIR": str(home)}
+    if host_home is not None:
+        env["HOME"] = str(host_home)
     return subprocess.run(
-        ["macf_tools", "agent", "init", "-y"],
-        capture_output=True, text=True,
-        env={**os.environ, "MACEFF_AGENT_HOME_DIR": str(home)},
+        ["macf_tools", "agent", "init", "-y", *extra_args],
+        capture_output=True, text=True, env=env,
     )
 
 
@@ -75,11 +84,20 @@ def test_user_content_without_stale_block_is_untouched(agent_home):
     assert "stale preamble block" not in result.stdout
 
 
-class TestAgentUuidMint:
-    """`agent init` mints the agent UUID so identity never resolves to @unknown (#131)."""
+@pytest.fixture
+def host_home(tmp_path):
+    """An empty stand-in for ``~`` so the global identity scope is isolated."""
+    home = tmp_path / "hosthome"
+    home.mkdir()
+    return home
 
-    def test_mints_uuid_when_absent(self, agent_home):
-        result = _run_init(agent_home)
+
+class TestAgentUuidMint:
+    """`agent init` establishes the agent UUID so identity never resolves to
+    @unknown (#131) — without ever silently changing it (#180)."""
+
+    def test_mints_uuid_when_absent(self, agent_home, host_home):
+        result = _run_init(agent_home, host_home=host_home)
         assert result.returncode == 0, result.stdout + result.stderr
 
         uuid_file = agent_home / ".maceff_primary_agent.id"
@@ -89,13 +107,52 @@ class TestAgentUuidMint:
         assert (uuid_file.stat().st_mode & 0o077) == 0
         assert "Minted agent UUID" in result.stdout
 
-    def test_mint_is_idempotent(self, agent_home):
+    def test_mint_is_idempotent(self, agent_home, host_home):
         """A second init must not re-roll an established identity."""
-        _run_init(agent_home)
+        _run_init(agent_home, host_home=host_home)
         uuid_file = agent_home / ".maceff_primary_agent.id"
         first = uuid_file.read_text()
 
-        result = _run_init(agent_home)
+        result = _run_init(agent_home, host_home=host_home)
         assert uuid_file.read_text() == first, "re-init changed the agent UUID"
         assert "Minted agent UUID" not in result.stdout
         assert "Agent UUID present" in result.stdout
+
+    def test_transfers_resolving_global_identity_rather_than_shadowing_it(
+        self, agent_home, host_home
+    ):
+        """The #180 regression: an identity that already resolves globally is
+        carried into the project file, not shadowed by a fresh one.
+
+        Minting here overwrites nothing on disk, which is why it read as safe —
+        but the project file outranks the global one in the resolver, so the
+        agent's calling card changes anyway.
+        """
+        established = "a1b2c3d4-0000-4000-8000-000000000001"
+        (host_home / ".maceff_primary_agent.id").write_text(established + "\n")
+
+        result = _run_init(agent_home, host_home=host_home)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        uuid_file = agent_home / ".maceff_primary_agent.id"
+        assert uuid_file.read_text().strip() == established, (
+            "init minted a new identity over one that already resolved globally"
+        )
+        assert (host_home / ".maceff_primary_agent.id").read_text().strip() == established
+        assert "Transferred agent UUID" in result.stdout
+        assert "resolves from another scope" in result.stdout
+        assert "Minted agent UUID" not in result.stdout
+
+    def test_mint_fresh_id_opts_into_a_new_identity(self, agent_home, host_home):
+        """The deliberate case stays available behind an explicit flag."""
+        established = "a1b2c3d4-0000-4000-8000-000000000001"
+        (host_home / ".maceff_primary_agent.id").write_text(established + "\n")
+
+        result = _run_init(
+            agent_home, host_home=host_home, extra_args=("--mint-fresh-id",)
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        minted = (agent_home / ".maceff_primary_agent.id").read_text().strip()
+        assert minted and minted != established
+        assert "Minted agent UUID" in result.stdout


### PR DESCRIPTION
Closes #180.

`agent init` minted a per-agent-home UUID whenever *that file* was missing — the wrong thing to check. The resolver prefers the per-agent-home file over the host-global one, so on any host whose identity predates the per-project convention, init silently changed the effective identity. Nothing on disk was overwritten, which is precisely why it read as safe, and the calling card changed anyway.

Per the design direction on the issue, the fix is **not** "skip the write". The per-agent-home file is the right canonical mechanism — one `~` cannot serve N agents on a shared host or container — so the correct response to "resolves globally, project file absent" is to carry the existing value across, with consent.

| Situation | Behavior |
|---|---|
| Identity already in this agent home | Reported, left untouched |
| Resolves from another scope | Warns, offers to **transfer** that exact value |
| Nothing resolves anywhere | Offers a fresh value, previewed and re-rollable |

The first six characters are the agent's public calling card, so a minted value is shown before acceptance and can be re-rolled. Under `-y` (container provisioning, test suite) every fork takes the safe branch: transfer when an identity resolves, mint only on genuine absence. `--mint-fresh-id` is the explicit opt-in for a deliberate new identity.

### Notes

- `_resolve_uuid_source()` returns the full value, its scope and its origin file; `_resolve_uuid_prefix()` becomes a projection of it. A caller re-deriving that precedence to locate the value it wants to move would be a second copy of the same derived state.
- The uuid tests now isolate `HOME`. Without that, the developer's own global id is visible to the suite and identity assertions pass on a host with no global id, failing on one with — an environment-dependent test that would have masked this behavior.

### Verification

Red/green: with the source change stashed, both new tests fail (identity shadowed / flag unrecognized); with it applied they pass. Full suite 1071 passed, 9 xfailed.