### PR TITLE
fix(hooks): derive user activity from the submit payload, not a poller

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -2948,10 +2948,14 @@ def cmd_mode_show(args: argparse.Namespace) -> int:
         from .transcript_monitor.daemon import is_running as tm_is_running
         tm_running = tm_is_running()
         print(f"  Transcript Monitor: {'✅ running' if tm_running else '⏹️  stopped'}")
-        print(f"  USER_IDLE detection: {'✅ active (via TM)' if tm_running else '⚠️  disabled (TM not running)'}")
+        if tm_running:
+            print("  USER_IDLE detection: ✅ active (transcript monitor + prompt hook)")
+        else:
+            print("  USER_IDLE detection: ⚠️  partial (prompt hook only — no mid-turn "
+                  "or channel activity while TM is stopped)")
     except (ImportError, OSError) as e:
         print(f"  Transcript Monitor: ❌ unavailable ({e})")
-        print(f"  USER_IDLE detection: ⚠️  disabled")
+        print("  USER_IDLE detection: ⚠️  partial (prompt hook only)")
 
     return 0
 

--- a/macf/src/macf/hooks/handle_user_prompt_submit.py
+++ b/macf/src/macf/hooks/handle_user_prompt_submit.py
@@ -135,6 +135,55 @@ def get_policy_injection(prompt: str) -> str:
         return ""  # Fail gracefully - don't block session
 
 
+def record_user_activity_from_payload(prompt: str) -> bool:
+    """Record user activity when *this* invocation carries a typed prompt.
+
+    USER_IDLE is derived from ``user_activity_detected`` events, which the
+    Transcript Monitor writes on an interval. This hook fires the instant the
+    user submits — before TM has polled — so a staleness computation here reads
+    the *previous* activity and can render 😴 on the very prompt that disproves
+    it (cversek/MacEff#181). The hook does not need to ask a monitor whether
+    the user is active: the user just acted, and the payload proves it.
+
+    ``dev_drv_started`` was deliberately removed as an idle source because it
+    fires on *all* UserPromptSubmit invocations, including system-generated
+    ones, which reset the idle timer from the agent's own activity. That
+    constraint still holds, so the discrimination is made from the payload
+    rather than by trusting every invocation: a typed prompt (direct, slash
+    command, or channel message) is present only for genuine user input.
+    Empirically the split is near-even across a long event log, and every
+    non-empty prompt corresponds to real user input.
+
+    Emitting here (rather than only suppressing the indicator) also corrects
+    the clock for the renders that follow — Stop, PreToolUse — instead of
+    leaving them a TM poll interval behind.
+
+    Args:
+        prompt: The ``prompt`` field of the hook payload.
+
+    Returns:
+        True when an activity event was recorded.
+    """
+    if not prompt or not prompt.strip():
+        return False
+
+    source = "channel" if prompt.lstrip().startswith("<channel ") else "direct"
+    try:
+        from macf.agent_events_log import append_event
+        append_event("user_activity_detected", {
+            "source": source,
+            "detector": "user_prompt_submit_hook",
+        })
+        return True
+    except (OSError, ValueError, ImportError) as e:
+        emit_warning(Warning(
+            source="user_prompt_submit",
+            kind="user_activity_emit_failed",
+            detail=f"could not record user activity from payload: {e}",
+        ))
+        return False
+
+
 def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
     """
     Run UserPromptSubmit hook logic.
@@ -169,6 +218,11 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         # Extract prompt preview for forensic recovery (first 200 chars)
         prompt = hook_input.get('prompt', '') if hook_input else ''
         prompt_preview = prompt[:200] if prompt else None
+
+        # Record activity from the payload in hand before anything derives
+        # staleness from the event log, so this render and the ones after it
+        # agree with the event that produced them (#181).
+        record_user_activity_from_payload(prompt)
 
         # Start Development Drive tracking with current UUID and prompt preview
         # Note: start_dev_drv() emits dev_drv_started event internally

--- a/macf/src/macf/modes/detection.py
+++ b/macf/src/macf/modes/detection.py
@@ -533,13 +533,21 @@ def format_recommendation(
 def _get_last_user_activity_timestamp(session_id: str) -> Optional[float]:
     """Get epoch timestamp of last user activity from event log.
 
-    ONLY uses user_activity_detected events from Transcript Monitor.
+    ONLY uses user_activity_detected events. Two producers write them: the
+    Transcript Monitor (polling the transcript) and the UserPromptSubmit hook
+    (from a payload carrying a typed prompt). Both are evidence of real user
+    input; the hook's is simply the earlier of the two, which is what keeps a
+    submit from rendering as idle while TM has yet to poll (#181).
+
     dev_drv_started was removed as a source because it fires on ALL
     UserPromptSubmit invocations — including system-generated ones
     (tool results, background notifications), causing false positives
-    that reset the idle timer from the agent's own activity.
+    that reset the idle timer from the agent's own activity. The hook's
+    producer preserves that constraint by discriminating on the payload
+    rather than on the invocation.
 
-    Returns None when TM is not running (no false signals > wrong signals).
+    Returns None when neither producer has recorded anything for this agent
+    (no false signals > wrong signals).
     """
     for event in read_events(limit=200, reverse=True):
         event_type = event.get("event", "")

--- a/macf/tests/test_handle_user_prompt_submit.py
+++ b/macf/tests/test_handle_user_prompt_submit.py
@@ -131,3 +131,91 @@ def test_hook_event_name_present(mock_dependencies):
     assert "hookSpecificOutput" in result
     assert "hookEventName" in result["hookSpecificOutput"]
     assert result["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+
+class TestUserActivityFromPayload:
+    """A submit must never render as idle — the event disproves the mode (#181).
+
+    USER_IDLE is derived from ``user_activity_detected``, which the Transcript
+    Monitor writes on a poll interval. The hook fires before TM has polled, so
+    deriving staleness here read the *previous* activity and could render 😴 on
+    the very prompt that contradicts it. The hook holds the authoritative
+    signal in its own payload.
+    """
+
+    def _activity_events(self, log_path):
+        import json
+        if not log_path.exists():
+            return []
+        out = []
+        for line in log_path.read_text().splitlines():
+            try:
+                e = json.loads(line)
+            except ValueError:
+                continue
+            if e.get("event") == "user_activity_detected":
+                out.append(e)
+        return out
+
+    def test_typed_prompt_records_user_activity(self, mock_dependencies, isolated_events_log):
+        import json
+        from macf.hooks.handle_user_prompt_submit import run
+
+        run(json.dumps({"session_id": "s1", "prompt": "please fix the thing"}))
+
+        events = self._activity_events(isolated_events_log)
+        assert len(events) == 1, "a typed prompt did not record user activity"
+        assert events[0]["data"]["detector"] == "user_prompt_submit_hook"
+        assert events[0]["data"]["source"] == "direct"
+
+    def test_channel_prompt_is_tagged_as_channel(self, mock_dependencies, isolated_events_log):
+        import json
+        from macf.hooks.handle_user_prompt_submit import run
+
+        run(json.dumps({
+            "session_id": "s1",
+            "prompt": '<channel source="plugin:x:x" chat_id="1">hello</channel>',
+        }))
+
+        events = self._activity_events(isolated_events_log)
+        assert len(events) == 1
+        assert events[0]["data"]["source"] == "channel"
+
+    def test_system_generated_invocation_records_nothing(self, mock_dependencies, isolated_events_log):
+        """The constraint that removed dev_drv_started as a source still holds.
+
+        UserPromptSubmit also fires for invocations the user did not type; those
+        must not reset the idle clock from the agent's own activity.
+        """
+        import json
+        from macf.hooks.handle_user_prompt_submit import run
+
+        run(json.dumps({"session_id": "s1", "prompt": ""}))
+        run(json.dumps({"session_id": "s1", "prompt": "   \n  "}))
+        run(json.dumps({"session_id": "s1"}))
+
+        assert self._activity_events(isolated_events_log) == []
+
+    def test_submit_is_not_idle_despite_stale_monitor_event(self, mock_dependencies, isolated_events_log):
+        """The regression: a long-stale TM event must not survive a fresh submit."""
+        import json
+        import time
+        from datetime import datetime, timedelta, timezone
+        from macf.modes.detection import _get_last_user_activity_timestamp
+
+        stale = datetime.now(timezone.utc) - timedelta(minutes=45)
+        isolated_events_log.write_text(json.dumps({
+            "event": "user_activity_detected",
+            "timestamp": stale.isoformat(),
+            "data": {"source": "direct", "detector": "transcript_monitor"},
+        }) + "\n")
+
+        assert time.time() - _get_last_user_activity_timestamp("s1") > 40 * 60, (
+            "fixture did not establish a stale activity timestamp"
+        )
+
+        from macf.hooks.handle_user_prompt_submit import run
+        run(json.dumps({"session_id": "s1", "prompt": "I am right here"}))
+
+        age = time.time() - _get_last_user_activity_timestamp("s1")
+        assert age < 60, f"submit still read as {age / 60:.0f} minutes stale"


### PR DESCRIPTION
Closes #181.

The UserPromptSubmit banner rendered `😴 USER_IDLE` on the very prompt that disproves it. USER_IDLE compares now against `user_activity_detected`, which the Transcript Monitor writes on a poll interval — and the hook fires the instant the user submits, before TM has polled. So it compared against the *previous* activity, which could be well past the idle timeout.

The hook does not need to ask a monitor whether the user is active. It is holding the evidence. It now records activity from its own payload before anything derives staleness, which fixes this render **and** stops the following ones (Stop, PreToolUse) lagging a poll interval behind.

### Preserving the constraint that removed `dev_drv_started`

That source was dropped because it fires on *all* UserPromptSubmit invocations, including system-generated ones, resetting the idle timer from the agent's own activity. The fix keeps that constraint by discriminating on the **payload** rather than on the invocation — only a prompt carrying text counts.

Measured across a 6,634-event log: 3,322 invocations carry prompt text, 3,312 do not — a near-even split. Every non-empty prompt in the recent window is genuine user input (typed, slash command, or channel message), so the discriminator is empirically sound rather than assumed.

### Also

The doctor output claimed `USER_IDLE detection: disabled (TM not running)`, which is no longer true — with a second producer, idle detection degrades to *partial* rather than off. Corrected in the same batch so the diagnostic does not itself become a stale derived claim.

### Verification

Red/green: with the source changes stashed, 3 of the 4 new tests fail (no activity recorded; a fresh submit still reads 45 minutes stale). The fourth — asserting that system-generated invocations record nothing — passes both ways by design, since it guards a non-regression. Full suite 1073 passed, 9 xfailed.