### PR TITLE
fix(task): derive the hierarchy marker at read; add task doctor

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -19,6 +19,7 @@ from .hooks.compaction import detect_compaction, inject_recovery
 from .agent_events_log import append_event
 from .event_queries import get_cycle_number_from_events
 from .task.reader import TaskReader
+from .task.create import subject_with_live_parent
 from .utils import (
     get_current_session_id,
     get_dev_scripts_dir,
@@ -3824,19 +3825,19 @@ def cmd_task_list(args: argparse.Namespace) -> int:
             ANSI_BROWN = "\033[38;5;137m"  # Tan/cardboard brown
             status_icon = f"{ANSI_BROWN}▪{ANSI_RESET}"
             # Dim + strikethrough for archived (strip embedded ANSI first)
-            clean_subject = _strip_ansi(t.subject)
+            clean_subject = _strip_ansi(subject_with_live_parent(t))
             line = f"{prefix}{status_icon} {ANSI_DIM}{ANSI_STRIKE}{clean_subject}{ANSI_RESET}"
         elif t.status == "completed":
             status_icon = f"{ANSI_GREEN}✔{ANSI_RESET}"
             # Strikethrough only for completed (strip embedded ANSI first)
-            clean_subject = _strip_ansi(t.subject)
+            clean_subject = _strip_ansi(subject_with_live_parent(t))
             line = f"{prefix}{status_icon} {ANSI_STRIKE}{clean_subject}{ANSI_RESET}"
         elif t.status == "in_progress":
             status_icon = f"{ANSI_RED}◼{ANSI_RESET}"
-            line = f"{prefix}{status_icon} {_dim_task_ids(t.subject)}"
+            line = f"{prefix}{status_icon} {_dim_task_ids(subject_with_live_parent(t))}"
         else:  # pending
             status_icon = "◻"
-            line = f"{prefix}{status_icon} {_dim_task_ids(t.subject)}"
+            line = f"{prefix}{status_icon} {_dim_task_ids(subject_with_live_parent(t))}"
 
         # Scope indicator (👀 for active, ✅ for completed/inactive)
         if scope_state and t.id in scope_state:
@@ -3932,7 +3933,7 @@ def cmd_task_get(args: argparse.Namespace) -> int:
     print(f"{'='*60}")
     print(f"Task #{task.id} {status_icon}")
     print(f"{'='*60}")
-    print(f"Subject: {task.subject}")
+    print(f"Subject: {subject_with_live_parent(task)}")
     print(f"Status: {task.status}")
     if task.task_type:
         print(f"Type: {task.task_type}")
@@ -4256,7 +4257,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
             # CC-style markers with colors - subject now contains #N prefix
             suffix = format_task_suffix(task)
-            subject = _truncate_subject_title(task.subject, title_width)
+            subject = _truncate_subject_title(subject_with_live_parent(task), title_width)
             if task.status == "completed":
                 status_icon = f"{ANSI_GREEN}✔{ANSI_RESET}"
                 text = f"{ANSI_DIM}{ANSI_STRIKE}{subject}{ANSI_RESET}"
@@ -4327,7 +4328,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
         # Print root specially with CC-style markers - subject now contains #N prefix
         root_suffix = format_task_suffix(root)
-        root_subject = _truncate_subject_title(root.subject, title_width)
+        root_subject = _truncate_subject_title(subject_with_live_parent(root), title_width)
         if root.status == "completed":
             status_icon = f"{ANSI_GREEN}✔{ANSI_RESET}"
             root_text = f"{ANSI_DIM}{ANSI_STRIKE}{root_subject}{ANSI_RESET}"
@@ -4941,6 +4942,64 @@ def cmd_task_reparent(args: argparse.Namespace) -> int:
     else:
         print(f"❌ Failed to reparent task #{task_id}")
         return 1
+
+
+def _doctor_check_subject_markers(tasks) -> "list[tuple[str, str, str]]":
+    """Find tasks whose stored ``[^#N]`` marker disagrees with ``parent_id``.
+
+    Returns:
+        list of (task_id, stored_subject, corrected_subject) for divergent tasks.
+    """
+    findings = []
+    for t in tasks:
+        corrected = subject_with_live_parent(t)
+        if corrected != t.subject:
+            findings.append((t.id, t.subject, corrected))
+    return findings
+
+
+def cmd_task_doctor(args: argparse.Namespace) -> int:
+    """Reconcile stored task records against the authorities they derive from.
+
+    Read-only by default: it reports divergence and exits non-zero so a caller
+    can gate on it. ``--fix`` applies the corrections.
+
+    Complements the read-time re-derivation in the renderers. Displays are
+    already truthful without this; the stored records are what other consumers
+    read, and healing them keeps the file honest for anything that does not go
+    through the render path.
+    """
+    from .task import TaskReader, update_task_file
+
+    fix = getattr(args, "fix", False)
+    tasks = TaskReader().read_all_tasks()
+    print(f"🩺 Task doctor — {len(tasks)} task(s) scanned\n")
+
+    findings = _doctor_check_subject_markers(tasks)
+    print(f"Hierarchy markers: {len(findings)} divergent")
+    if not findings:
+        print("   ✅ every [^#N] marker agrees with its parent_id")
+    for task_id, stored, corrected in findings:
+        print(f"   #{task_id}")
+        print(f"     stored:    {_strip_ansi(stored)}")
+        print(f"     corrected: {_strip_ansi(corrected)}")
+        if fix:
+            if update_task_file(task_id, {"subject": corrected}):
+                print(f"     ✅ healed")
+            else:
+                print(f"     ❌ could not write #{task_id}")
+
+    total = len(findings)
+    print()
+    if total == 0:
+        print("✅ No drift detected.")
+        return 0
+    if fix:
+        print(f"🔧 Healed {total} record(s).")
+        return 0
+    print(f"⚠️  {total} record(s) diverge from their authority. "
+          f"Re-run with --fix to heal.")
+    return 1
 
 
 def cmd_task_advance(args: argparse.Namespace) -> int:
@@ -9018,6 +9077,16 @@ def _build_parser() -> argparse.ArgumentParser:
     task_pause_parser.set_defaults(func=cmd_task_pause)
 
     # task note - append note to updates
+    task_doctor_parser = task_sub.add_parser(
+        "doctor",
+        help="reconcile stored task records against the authorities they derive from",
+    )
+    task_doctor_parser.add_argument(
+        "--fix", action="store_true",
+        help="apply the corrections (default is report-only, exits 1 on drift)",
+    )
+    task_doctor_parser.set_defaults(func=cmd_task_doctor)
+
     task_note_parser = task_sub.add_parser("note", help="add a note to task (appends to updates with type='note')")
     task_note_parser.add_argument("task_id", help="task ID (e.g., #67 or 67)")
     task_note_parser.add_argument("message", help="note text")

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -196,6 +196,72 @@ def title_from_subject(subject: str, task_type: str,
     return s.strip()
 
 
+# A hierarchy marker as it appears in a stored subject, with any surrounding
+# ANSI runs. Historical subjects padded the id inside the brackets
+# (``[^  #5]``), so the inner whitespace is tolerated on the way in even
+# though it is never produced on the way out.
+_PARENT_MARKER_RE = re.compile(
+    r'\s*(?:\033\[[0-9;]*m)*\[\^\s*#\d+\](?:\033\[[0-9;]*m)*'
+)
+
+
+def subject_with_live_parent(task) -> str:
+    """Return the task's subject with its ``[^#N]`` marker re-derived from
+    live ``parent_id``.
+
+    The stored subject is a *rendering*, not a source of truth: the marker is
+    a copy of ``parent_id`` frozen at compose time, and a later reparent moves
+    the authority without touching the copy. Callers that render a task should
+    use this rather than reading ``task.subject`` directly, so the marker
+    cannot outlive the relationship it describes. See the derived-state
+    discipline section of the coding standards policy — the authority is a
+    field on the same object, so re-deriving at read is the cheap repair.
+
+    Deliberately narrow. Only the marker is touched; the id prefix, type part
+    and title are passed through byte-for-byte. A full recomposition was
+    measured against the live corpus first and rejected: title recovery is
+    only reliable for subjects composed by current code, and on historical
+    ones it duplicated the title or stranded an old type marker. Re-deriving
+    a value must not be able to damage the values next to it.
+
+    An *absent* marker is left absent even when ``parent_id`` is set. Absence
+    is honest — a reader who needs the hierarchy goes and looks, and the tree
+    shows it structurally. A wrong marker is the failure worth repairing,
+    because it persuades a reader not to look.
+
+    Args:
+        task: A task object exposing ``subject`` and ``mtmd``.
+
+    Returns:
+        The subject with a marker that agrees with ``parent_id``, or the
+        stored subject when there is no marker to correct.
+    """
+    stored = getattr(task, "subject", "") or ""
+    mtmd = getattr(task, "mtmd", None)
+    if mtmd is None:
+        return stored
+
+    match = _PARENT_MARKER_RE.search(stored)
+    if not match:
+        return stored
+
+    parent_id = getattr(mtmd, "parent_id", None)
+    if parent_id is not None:
+        parent_id = str(parent_id)
+
+    current = re.search(r'\[\^\s*#(\d+)\]', match.group(0))
+    current_id = current.group(1) if current else None
+    if current_id == parent_id:
+        return stored
+
+    if parent_id and parent_id != SENTINEL_TASK_ID:
+        replacement = f" {ANSI_DIM}[^#{parent_id}]{ANSI_DIM_OFF}"
+    else:
+        replacement = ""
+
+    return stored[:match.start()] + replacement + stored[match.end():]
+
+
 def _ensure_sentinel_task(session_path: Path) -> None:
     """Create sentinel task #000 if it doesn't exist.
 

--- a/macf/tests/test_subject_live_parent.py
+++ b/macf/tests/test_subject_live_parent.py
@@ -1,0 +1,98 @@
+"""The hierarchy marker must never outlive the relationship it describes.
+
+`[^#N]` in a stored subject is a copy of `parent_id` frozen at compose time.
+A reparent moves the authority; without re-derivation at read the display keeps
+asserting the old parent, and a reader has no reason to doubt it.
+"""
+import re
+
+import pytest
+
+from macf.task.create import compose_subject, subject_with_live_parent
+
+
+def _clean(s):
+    return re.sub(r'\033\[[0-9;]*m', '', s or '')
+
+
+class _Mtmd:
+    def __init__(self, parent_id=None, task_type="TASK"):
+        self.parent_id = parent_id
+        self.task_type = task_type
+        self.title = None
+        self.plan_ca_ref = None
+        self.custom = None
+
+
+class _Task:
+    def __init__(self, task_id, subject, mtmd):
+        self.id = task_id
+        self.subject = subject
+        self.mtmd = mtmd
+
+
+def _task(task_id, composed_parent, live_parent, title="Do the thing"):
+    subject = compose_subject(task_id=task_id, task_type="TASK", title=title,
+                              parent_id=composed_parent)
+    return _Task(task_id, subject, _Mtmd(parent_id=live_parent))
+
+
+class TestSubjectWithLiveParent:
+
+    def test_stale_marker_is_corrected_to_live_parent(self):
+        """The regression: subject says #10, parent_id says #20."""
+        t = _task("42", composed_parent="10", live_parent="20")
+        assert "[^#10]" in _clean(t.subject), "fixture did not bake a stale marker"
+
+        assert "[^#20]" in _clean(subject_with_live_parent(t))
+        assert "[^#10]" not in _clean(subject_with_live_parent(t))
+
+    def test_agreeing_marker_is_untouched(self):
+        t = _task("42", composed_parent="10", live_parent="10")
+        assert subject_with_live_parent(t) == t.subject
+
+    def test_marker_is_dropped_when_parent_is_cleared(self):
+        t = _task("42", composed_parent="10", live_parent=None)
+        assert "[^#" not in _clean(subject_with_live_parent(t))
+
+    def test_marker_is_dropped_when_reparented_to_sentinel(self):
+        """compose_subject omits the marker for the sentinel; re-derivation agrees."""
+        t = _task("42", composed_parent="10", live_parent="000")
+        assert "[^#" not in _clean(subject_with_live_parent(t))
+
+    def test_absent_marker_stays_absent(self):
+        """Absence is honest — a reader goes and looks. A wrong marker is the lie.
+
+        Historical subjects predate the marker convention; re-derivation must not
+        rewrite 400+ of them under the banner of fixing drift.
+        """
+        t = _task("42", composed_parent=None, live_parent="20")
+        assert subject_with_live_parent(t) == t.subject
+
+    def test_padded_historical_marker_is_recognized(self):
+        """Old subjects padded the id inside the brackets: `[^  #5]`."""
+        t = _Task("6", "  #6 [^  #5] 🐛 BUG: something", _Mtmd(parent_id="20"))
+        out = _clean(subject_with_live_parent(t))
+        assert "[^#20]" in out
+        assert "#5]" not in out
+
+    def test_padded_historical_marker_that_agrees_is_left_alone(self):
+        t = _Task("6", "  #6 [^  #5] 🐛 BUG: something", _Mtmd(parent_id="5"))
+        assert subject_with_live_parent(t) == t.subject
+
+    def test_title_and_type_are_passed_through_untouched(self):
+        """Only the marker is re-derived.
+
+        A full recomposition was measured against a 1,170-task corpus and
+        rejected: title recovery is reliable only for subjects composed by
+        current code, and on historical ones it duplicated the title. Fixing one
+        derived value must not be able to damage the values beside it.
+        """
+        t = _Task("6", "  #6 [^#5] 🐛 BUG: [legacy] title with ] brackets",
+                  _Mtmd(parent_id="20"))
+        out = _clean(subject_with_live_parent(t))
+        assert out.endswith("🐛 BUG: [legacy] title with ] brackets")
+
+    def test_missing_mtmd_falls_back_to_stored(self):
+        t = _Task("42", "  #42 [^#10] 📋 phase", None)
+        assert subject_with_live_parent(t) == t.subject

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -1157,3 +1157,75 @@ class TestSubjectTitleTruncation:
         out = _truncate_subject_title(subject, 30)
         assert out.endswith("...")
         assert len(out) < len(subject)
+
+
+class TestTaskDoctor:
+    """`task doctor` reconciles stored records against their authority.
+
+    Read-time re-derivation keeps *displays* honest. The stored record is what
+    other consumers read, so it needs a reconcile pass of its own.
+    """
+
+    def _seed(self, session_dir, task_id, subject, parent_id):
+        payload = {
+            "id": task_id,
+            "subject": subject,
+            "status": "pending",
+            "description": (
+                '<macf_task_metadata version="1.0">\n'
+                'task_type: TASK\n'
+                'created_by: PA\n'
+                f'parent_id: {parent_id}\n'
+                '</macf_task_metadata>\n'
+            ),
+        }
+        (session_dir / f"{task_id}.json").write_text(json.dumps(payload))
+
+    def test_reports_divergent_marker_and_exits_nonzero(self, isolated_task_env):
+        self._seed(isolated_task_env['session_dir'], "42",
+                   "  #42 [^#10] 🔧 stale marker task", parent_id="20")
+
+        result = subprocess.run(
+            ["macf_tools", "task", "doctor"],
+            capture_output=True, text=True, env=isolated_task_env['env'],
+        )
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "1 divergent" in result.stdout
+        assert "#42" in result.stdout
+        assert "--fix" in result.stdout
+
+    def test_report_only_does_not_mutate(self, isolated_task_env):
+        session_dir = isolated_task_env['session_dir']
+        self._seed(session_dir, "42", "  #42 [^#10] 🔧 stale marker task", parent_id="20")
+        before = (session_dir / "42.json").read_text()
+
+        subprocess.run(["macf_tools", "task", "doctor"],
+                       capture_output=True, text=True, env=isolated_task_env['env'])
+
+        assert (session_dir / "42.json").read_text() == before, "report-only wrote to disk"
+
+    def test_fix_heals_the_stored_subject(self, isolated_task_env):
+        session_dir = isolated_task_env['session_dir']
+        self._seed(session_dir, "42", "  #42 [^#10] 🔧 stale marker task", parent_id="20")
+
+        result = subprocess.run(
+            ["macf_tools", "task", "doctor", "--fix"],
+            capture_output=True, text=True, env=isolated_task_env['env'],
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        healed = json.loads((session_dir / "42.json").read_text())["subject"]
+        assert "[^#20]" in healed
+        assert "[^#10]" not in healed
+        assert "stale marker task" in healed, "healing damaged the title"
+
+    def test_clean_tree_reports_no_drift(self, isolated_task_env):
+        self._seed(isolated_task_env['session_dir'], "42",
+                   "  #42 [^#20] 🔧 honest marker task", parent_id="20")
+
+        result = subprocess.run(
+            ["macf_tools", "task", "doctor"],
+            capture_output=True, text=True, env=isolated_task_env['env'],
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No drift detected" in result.stdout


### PR DESCRIPTION
MISSION "MacEff Trustworthy State", Phase 2 — the canonical instance of the family, repaired with the strategy §7 of the coding standards prescribes.

The `[^#N]` marker in a stored subject is a copy of `parent_id` frozen at compose time. Every renderer read that copy, so a reparent could leave the display asserting a relationship the record contradicts — and a reader has no reason to doubt a marker.

`subject_with_live_parent()` re-derives it, and all seven render sites route through it (list view, tree child and root, task detail). The authority is a field on the same object, so re-deriving at read is the cheap repair.

### The narrowing is the interesting part

A **full recomposition** was implemented first and measured against the live 1,170-task corpus *before* wiring it in. It would have changed **489 subjects**, and inspection showed why: title recovery is reliable only for subjects composed by current code. On historical ones it duplicated the title into itself (`🐛 BUG: [^ #5] 🐛 BUG: …`) and stranded old type markers.

So the scope narrowed to the marker alone — everything else passes through byte-for-byte. **Re-deriving one value must not be able to damage the values beside it.**

### Absence is honest; staleness is not

An *absent* marker is left absent even when `parent_id` is set. A reader who needs the hierarchy goes and looks, and the tree shows it structurally. A wrong marker is the failure worth repairing, because it persuades the reader **not** to look. That line keeps 470 historical subjects from being rewritten under the banner of fixing drift.

### `macf_tools task doctor`

Read-time derivation keeps *displays* honest; the stored record is what other consumers read, so it gets a reconcile pass of its own. Report-only by default, exits 1 on drift so a caller can gate on it; `--fix` heals.

Against the live tree it reports **zero** divergent markers — the expected result, since the write-side fix already plugged the leak. This pass is prophylactic, not remedial, and the PR says so rather than claiming a cleanup that did not happen. Phase 3 extends the same command to GitHub-state drift.

### Verification

```
$ macf_tools task doctor
🩺 Task doctor — 1170 task(s) scanned
Hierarchy markers: 0 divergent
   ✅ every [^#N] marker agrees with its parent_id
✅ No drift detected.
```

Red/green: with the source stashed, all 4 doctor tests fail and the 9 marker tests cannot even import. Full suite 1088 passed, 9 xfailed.