### PR TITLE
fix(cli): papercuts — cycle guard, CI extras check, source in --version, ignore the task store

### DIFF
--- a/macf/pyproject.toml
+++ b/macf/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "psutil>=5.9.0",  # For performance testing
     "pydantic>=2.0.0",  # For agent/project spec validation tests
     "lancedb>=0.26.0",  # For hybrid search / recommend tests
+    "tomli>=2.0.0; python_version < '3.11'",  # pyproject introspection in test_ci_extras_coverage (tomllib is 3.11+)
 ]
 viz = [
     "markdown>=3.0",  # Markdown-to-HTML for CA presentation

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1716,6 +1716,44 @@ def cmd_agent_sleep(args: argparse.Namespace) -> int:
     return 1
 
 
+def _editable_source_suffix() -> str:
+    """Describe the live source checkout when running from an editable install.
+
+    A bare dev version string says nothing about *which* checkout is running.
+    Dogfooding a feature branch or a worktree, `macf_tools --version` reported
+    the same `0.5.1.dev0` whether the code under it was main, a branch, or a
+    dirty tree — so "is my fix actually loaded?" could not be answered from the
+    tool itself.
+
+    Returns:
+        `` (empty) for a normal wheel install, or e.g.
+        `` (main @ 9dbeab3, dirty)`` when the package resolves to a git
+        checkout.
+    """
+    import subprocess as _subprocess
+    try:
+        pkg_root = Path(__file__).resolve().parent
+        r = _subprocess.run(
+            ["git", "-C", str(pkg_root), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5)
+        if r.returncode != 0:
+            return ""  # installed from a wheel, not a checkout
+        repo = r.stdout.strip()
+
+        def _git(*a):
+            out = _subprocess.run(["git", "-C", repo, *a],
+                                  capture_output=True, text=True, timeout=5)
+            return out.stdout.strip() if out.returncode == 0 else ""
+
+        branch = _git("rev-parse", "--abbrev-ref", "HEAD") or "?"
+        commit = _git("rev-parse", "--short", "HEAD") or "?"
+        dirty = ", dirty" if _git("status", "--porcelain") else ""
+        return f" ({branch} @ {commit}{dirty})"
+    except (FileNotFoundError, _subprocess.TimeoutExpired, OSError):
+        # No git, or it hung: the version string is still useful without this.
+        return ""
+
+
 def _ensure_agent_uuid(
     pa_home: Path,
     *,
@@ -4089,9 +4127,20 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                 return True
             return False
 
-        def count_descendants(task_id):
+        def count_descendants(task_id, _seen=None):
+            # A task whose parent_id points at itself (or a cycle of them) is
+            # malformed but reachable — a hand-edited file, a bad fixture, an
+            # interrupted reparent. Without the guard this recurses until the
+            # interpreter dies, taking the whole tree render with it, and the
+            # traceback names recursion rather than the malformed task.
+            _seen = set() if _seen is None else _seen
+            if task_id in _seen:
+                print(f"Warning: cycle in task hierarchy at #{task_id} — "
+                      f"descendant count truncated", file=sys.stderr)
+                return 0
+            _seen.add(task_id)
             children = get_children(task_id)
-            return len(children) + sum(count_descendants(c.id) for c in children)
+            return len(children) + sum(count_descendants(c.id, _seen) for c in children)
 
         def get_task_notes(task):
             """Extract notes from task MTMD updates."""
@@ -4251,7 +4300,21 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                     else:
                         print(f"{detail_prefix}{fmt('✅ ' + truncate(report, 60))}")
 
+        _rendered = set()
+
         def print_tree(task, prefix="", is_last=True, depth=0, siblings=None):
+            # A cyclic parent chain — a hand-edited file, a bad fixture, an
+            # interrupted reparent — otherwise recurses until the interpreter
+            # dies, and the traceback blames recursion rather than naming the
+            # malformed task. Render the node once, say so, and stop descending.
+            if task.id in _rendered:
+                print(f"{prefix}{'└── ' if is_last else '├── '}"
+                      f"⚠️  #{task.id} — cycle in task hierarchy, not descended")
+                print(f"Warning: cycle in task hierarchy at #{task.id}; "
+                      f"check parent_id", file=sys.stderr)
+                return
+            _rendered.add(task.id)
+
             connector = "└── " if is_last else "├── "
             extension = "    " if is_last else "│   "
 
@@ -8395,7 +8458,23 @@ def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="macf_tools", description="macf demo CLI (no external deps)"
     )
-    p.add_argument("--version", action="version", version=f"%(prog)s {_ver}")
+    class _VersionAction(argparse.Action):
+        """Print the version, resolving the source checkout only when asked.
+
+        The suffix costs a few `git` calls; computing it eagerly would charge
+        every `macf_tools` invocation — including the ones hooks make on every
+        tool use — for information only `--version` displays.
+        """
+
+        def __init__(self, option_strings, dest, **kwargs):
+            super().__init__(option_strings, dest, nargs=0, **kwargs)
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            print(f"{parser.prog} {_ver}{_editable_source_suffix()}")
+            parser.exit()
+
+    p.add_argument("--version", action=_VersionAction,
+                   help="show version (with source checkout when editable)")
     sub = p.add_subparsers(dest="cmd")  # keep non-required for compatibility
 
     # cmd-tree: introspect parser structure (like unix tree command)

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -196,6 +196,74 @@ def title_from_subject(subject: str, task_type: str,
     return s.strip()
 
 
+def _ensure_store_gitignored(store_path: Path) -> None:
+    """Add the home task store to .gitignore when it lands inside a repo.
+
+    The home store is a project-scoped directory alongside the other
+    consciousness artifacts, which means it can sit inside a tracked repo — and
+    it accumulates a JSON file per task. Left tracked, an ordinary ``git add -A``
+    stages thousands of files nobody meant to commit, and the noise is
+    discovered only at review time.
+
+    Opt out with ``task_store.track: true`` in the agent config; some projects
+    genuinely want the history versioned.
+
+    No-ops for the legacy per-session store (which lives under ``~/.claude``,
+    outside any project repo), outside a git repo, when the path is already
+    ignored, or when git is unavailable. Never rewrites an existing rule.
+    """
+    import subprocess as _subprocess
+
+    try:
+        mode, _rel = TaskReader._load_task_store_config()
+        if mode != "home":
+            return
+        from ..utils.paths import find_agent_home
+        config_file = find_agent_home() / ".maceff" / "config.json"
+        if config_file.exists():
+            track = (json.loads(config_file.read_text())
+                     .get("task_store", {}) or {}).get("track", False)
+            if track:
+                return  # the project has opted into versioning its task history
+    except (AttributeError, OSError, ValueError) as e:
+        print(f"Warning: could not read task store config: {e}", file=sys.stderr)
+        return
+
+    try:
+        r = _subprocess.run(
+            ["git", "-C", str(store_path.parent), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5)
+        if r.returncode != 0:
+            return  # not inside a repo — nothing to ignore it from
+        repo_root = Path(r.stdout.strip())
+
+        check = _subprocess.run(
+            ["git", "-C", str(repo_root), "check-ignore", "-q", str(store_path)],
+            capture_output=True, timeout=5)
+        if check.returncode == 0:
+            return  # already ignored
+
+        # Resolve both sides: `git rev-parse` reports the real path, while
+        # store_path may still carry a symlink (/var vs /private/var on macOS),
+        # and relative_to() compares them literally.
+        rule = f"{store_path.resolve().relative_to(repo_root.resolve()).as_posix()}/"
+        gitignore = repo_root / ".gitignore"
+        existing = gitignore.read_text() if gitignore.exists() else ""
+        if rule in existing.splitlines():
+            return
+        prefix = "" if (not existing or existing.endswith("\n")) else "\n"
+        gitignore.write_text(
+            existing + prefix
+            + "\n# MACF task store (one JSON file per task). Set task_store.track\n"
+            + "# to true in the agent config if you want this history versioned.\n"
+            + rule + "\n"
+        )
+        print(f"📝 Added {rule} to .gitignore (task store is not tracked by default)")
+    except (OSError, ValueError, FileNotFoundError, _subprocess.TimeoutExpired) as e:
+        print(f"Warning: could not gitignore the task store at {store_path}: {e}",
+              file=sys.stderr)
+
+
 # A hierarchy marker as it appears in a stored subject, with any surrounding
 # ANSI runs. Historical subjects padded the id inside the brackets
 # (``[^  #5]``), so the inner whitespace is tolerated on the way in even
@@ -485,7 +553,10 @@ def _create_task_file(
     # This temporarily unprotects if needed, then re-protects after
     with _unprotect_for_creation(reader.session_path):
         # Ensure session directory exists
+        existed = reader.session_path.exists()
         reader.session_path.mkdir(parents=True, exist_ok=True)
+        if not existed:
+            _ensure_store_gitignored(reader.session_path)
 
         # Ensure sentinel task exists (belt-and-suspenders CC purge protection)
         _ensure_sentinel_task(reader.session_path)

--- a/macf/tests/test_ci_extras_coverage.py
+++ b/macf/tests/test_ci_extras_coverage.py
@@ -1,0 +1,141 @@
+"""Every dependency the test suite imports must be one CI actually installs.
+
+The motivating gap: `aiohttp` was declared in the `proxy` extra while CI
+installed only `[test]`. The proxy tests could therefore never run — on any
+branch, ever — and the failure surfaced as an opaque collection error that
+read like the fault of whichever pull request happened to touch that area.
+
+Checking at *runtime* ("can I import it?") would not have caught it, because a
+developer's machine usually has the package. The check has to compare the
+declaration in `pyproject.toml` against the install line in the workflow,
+statically, so it fails the same way everywhere.
+"""
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 — provided by the `test` extra
+    import tomli as tomllib
+
+MACF_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = MACF_ROOT / "pyproject.toml"
+WORKFLOW = MACF_ROOT.parent / ".github" / "workflows" / "test.yml"
+
+# Imports that are not third-party distributions: the package under test, and
+# names resolved from the test tree itself.
+LOCAL_ROOTS = {"macf", "conftest", "tests"}
+
+
+def _installed_extras_from_workflow(text: str) -> set:
+    """Extras named in the workflow's editable install of this package.
+
+    Matches e.g. `pip install -e "./macf[test,proxy]"`.
+    """
+    extras = set()
+    for m in re.finditer(r'pip install[^\n]*\[([^\]]+)\]', text):
+        extras.update(part.strip() for part in m.group(1).split(","))
+    return extras
+
+
+def _top_level_imports(path: Path) -> set:
+    """Top-level module names imported anywhere in a Python file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as e:  # pragma: no cover
+        pytest.fail(f"could not parse {path}: {e}")
+
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — local by definition
+                continue
+            if node.module:
+                names.add(node.module.split(".")[0])
+    return names
+
+
+def _module_to_distributions() -> dict:
+    """Map top-level module name -> distribution names providing it."""
+    from importlib.metadata import packages_distributions
+    return packages_distributions()
+
+
+def test_test_suite_imports_are_covered_by_ci_extras():
+    """Fail the build on a dependency CI could never install.
+
+    A test that cannot run is worse than a missing test: the suite reports a
+    count that implies coverage it does not have.
+    """
+    assert PYPROJECT.exists(), f"missing {PYPROJECT}"
+    if not WORKFLOW.exists():
+        pytest.skip("no CI workflow in this checkout")
+
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    project = config.get("project", {})
+    optional = project.get("optional-dependencies", {})
+
+    installed_extras = _installed_extras_from_workflow(
+        WORKFLOW.read_text(encoding="utf-8"))
+    assert installed_extras, (
+        "could not find an extras-bearing `pip install -e` line in the CI "
+        "workflow; this check cannot verify coverage without it"
+    )
+
+    def _dist_names(specs):
+        # "aiohttp>=3.9.0" -> "aiohttp"; normalize for comparison
+        return {re.split(r'[<>=!~\[; ]', s, 1)[0].strip().lower().replace("_", "-")
+                for s in specs}
+
+    available = _dist_names(project.get("dependencies", []))
+    for extra in installed_extras:
+        available |= _dist_names(optional.get(extra, []))
+
+    declared_elsewhere = {}
+    for extra, specs in optional.items():
+        if extra in installed_extras:
+            continue
+        for dist in _dist_names(specs):
+            declared_elsewhere.setdefault(dist, set()).add(extra)
+
+    mod_to_dists = _module_to_distributions()
+    stdlib = getattr(sys, "stdlib_module_names", set())
+
+    problems = []
+    for test_file in sorted((MACF_ROOT / "tests").glob("*.py")):
+        for mod in sorted(_top_level_imports(test_file)):
+            if mod in LOCAL_ROOTS or mod in stdlib:
+                continue
+            dists = {d.lower().replace("_", "-") for d in mod_to_dists.get(mod, [])}
+            # A module we cannot attribute to a distribution is out of scope:
+            # it is either vendored or not installed here, and the import
+            # itself will fail loudly if it matters.
+            if not dists:
+                continue
+            if dists & available:
+                continue
+            missing_from = sorted(set().union(
+                *(declared_elsewhere.get(d, set()) for d in dists)
+            )) if any(d in declared_elsewhere for d in dists) else []
+            problems.append(
+                f"  {test_file.name}: imports `{mod}` (distribution "
+                f"{sorted(dists)}) which CI does not install"
+                + (f" — it is declared in extra(s) {missing_from}, "
+                   f"not in {sorted(installed_extras)}" if missing_from
+                   else " — it is not declared in any extra")
+            )
+
+    assert not problems, (
+        "Tests import dependencies the CI install does not provide, so those "
+        "tests can never run in CI:\n" + "\n".join(problems) +
+        f"\n\nFix by adding the extra to the workflow's install line "
+        f"(currently installs {sorted(installed_extras)}) or by moving the "
+        f"dependency into an installed extra."
+    )

--- a/macf/tests/test_papercuts.py
+++ b/macf/tests/test_papercuts.py
@@ -1,0 +1,95 @@
+"""Small independent fixes, each with a documented trigger."""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestVersionShowsSourceCheckout:
+    """`--version` must say which checkout is running.
+
+    Dogfooding a feature branch, the bare dev version string was identical
+    whether the code under it was main, a branch, or a dirty tree — so
+    "is my fix actually loaded?" could not be answered from the tool.
+    """
+
+    def test_reports_branch_and_commit_for_a_git_checkout(self):
+        from macf.cli import _editable_source_suffix
+        suffix = _editable_source_suffix()
+        # The test suite itself runs from a checkout, so a suffix is expected.
+        assert suffix.startswith(" ("), f"no source info reported: {suffix!r}"
+        assert " @ " in suffix
+
+    def test_absent_outside_a_repo(self, tmp_path, monkeypatch):
+        """A wheel install has no checkout and must print the plain version."""
+        from macf import cli
+        monkeypatch.setattr(cli, "__file__", str(tmp_path / "cli.py"))
+        assert cli._editable_source_suffix() == ""
+
+    def test_resolution_is_lazy(self, monkeypatch):
+        """Resolving the checkout must not be charged to every invocation.
+
+        Hooks shell out to macf_tools on every tool use; three git calls per
+        invocation, for a string only --version prints, is not free.
+        """
+        from macf import cli
+        calls = []
+        monkeypatch.setattr(cli, "_editable_source_suffix",
+                            lambda: calls.append(1) or "")
+        cli._build_parser()
+        assert calls == [], "source checkout resolved while merely building the parser"
+
+
+class TestHomeStoreIsGitignored:
+    """Creating the home store inside a repo must not silently stage it.
+
+    The store accumulates one JSON file per task; left tracked, a routine
+    `git add -A` stages thousands of files nobody meant to commit.
+    """
+
+    def _agent_home(self, tmp_path, track=False):
+        home = tmp_path / "home"
+        (home / ".maceff").mkdir(parents=True)
+        store = {"mode": "home", "path": "agent/public/tasks"}
+        if track:
+            store["track"] = True
+        (home / ".maceff" / "config.json").write_text(
+            json.dumps({"task_store": store}))
+        subprocess.run(["git", "init", "-q", str(home)], check=True)
+        return home
+
+    def _create_task(self, home, title, log):
+        return subprocess.run(
+            ["macf_tools", "task", "create", "task", title, "--plan", "smoke"],
+            capture_output=True, text=True,
+            env={**os.environ, "MACEFF_AGENT_HOME_DIR": str(home),
+                 "MACF_EVENTS_LOG_PATH": str(log)},
+        )
+
+    def test_store_is_ignored_after_first_task(self, tmp_path):
+        home = self._agent_home(tmp_path)
+        result = self._create_task(home, "first", tmp_path / "ev.jsonl")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        ignored = subprocess.run(
+            ["git", "-C", str(home), "check-ignore", "-q", "agent/public/tasks"])
+        assert ignored.returncode == 0, (
+            f"task store is tracked:\n{(home / '.gitignore').read_text() if (home / '.gitignore').exists() else '(no .gitignore)'}"
+        )
+
+    def test_rule_is_written_once(self, tmp_path):
+        home = self._agent_home(tmp_path)
+        self._create_task(home, "first", tmp_path / "ev.jsonl")
+        after_first = (home / ".gitignore").read_text()
+        self._create_task(home, "second", tmp_path / "ev.jsonl")
+        assert (home / ".gitignore").read_text() == after_first
+
+    def test_track_opt_in_leaves_gitignore_alone(self, tmp_path):
+        """Some projects genuinely want the task history versioned."""
+        home = self._agent_home(tmp_path, track=True)
+        result = self._create_task(home, "first", tmp_path / "ev.jsonl")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert not (home / ".gitignore").exists(), "opt-out was ignored"

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -1313,3 +1313,40 @@ class TestTaskDoctorGitHubState:
         )
         assert result.returncode == 0, result.stdout + result.stderr
         assert "skipped (--no-github)" in result.stdout
+
+
+class TestHierarchyCycleGuard:
+    """A malformed hierarchy must degrade, not take the renderer down with it.
+
+    A self-parented task is reachable in practice — a hand-edited file, a bad
+    fixture, an interrupted reparent. Unguarded, the descendant count recursed
+    until the interpreter died, and the traceback blamed recursion rather than
+    naming the malformed task.
+    """
+
+    def test_self_parented_task_does_not_hang_the_tree(self, isolated_task_env):
+        session_dir = isolated_task_env['session_dir']
+        # Quoted: an unquoted `000` parses as the integer 0 and never matches
+        # the string sentinel id (the int-coercion noted on GH #112).
+        for task_id, parent in (("000", '"000"'), ("42", '"000"')):
+            (session_dir / f"{task_id}.json").write_text(json.dumps({
+                "id": task_id,
+                "subject": f"  #{task_id} 🔧 task",
+                "status": "in_progress" if task_id == "000" else "pending",
+                "description": (
+                    '<macf_task_metadata version="1.0">\n'
+                    f'task_type: {"SENTINEL" if task_id == "000" else "TASK"}\n'
+                    'created_by: PA\n'
+                    f'parent_id: {parent}\n'
+                    '</macf_task_metadata>\n'
+                ),
+            }))
+
+        result = subprocess.run(
+            ["macf_tools", "task", "tree"],
+            capture_output=True, text=True, env=isolated_task_env['env'],
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "RecursionError" not in result.stderr
+        assert "cycle in task hierarchy" in result.stderr


### PR DESCRIPTION
MISSION "MacEff Trustworthy State", Phase 4. Four independent fixes, each with a documented trigger.

### Hierarchy cycles no longer kill the renderer

A task whose parent chain loops back on itself is malformed but reachable — a hand-edited file, a bad fixture, an interrupted reparent. The tree walk and the descendant count both recursed until the interpreter died, and the traceback blamed recursion rather than naming the task.

Writing the reproduction found the deeper of the two: **the recursion was in the render walk, not only in the counter the issue named.** Both now render the node once, print which id closed the loop, and stop descending.

### CI cannot silently stop running a test again

`aiohttp` sat in the `proxy` extra while CI installed only `[test]`, so the proxy suite could never run **on any branch, ever** — and the failure read like the fault of whichever PR happened to touch that area.

A runtime "can I import it?" check would not have caught this: a developer machine usually has the package. The new check compares pyproject's declarations against the workflow's install line **statically**, and names the extra to add.

Verified by replay — reverting the workflow to the original hole produces exactly the right diagnosis:

```
test_proxy_server.py: imports `aiohttp` (distribution ['aiohttp']) which CI does
not install — it is declared in extra(s) ['proxy'], not in ['test']
```

### `--version` says which checkout is running

Dogfooding a branch, the bare dev version was identical whether the code beneath it was main, a branch, or a dirty tree — so "is my fix actually loaded?" could not be answered from the tool itself. Now:

```
$ macf_tools --version
macf_tools 0.5.1.dev0 (fix/papercuts-batch @ 8425210, dirty)
```

Resolved **lazily**: hooks shell out to macf_tools on every tool use, and three git calls for a string only `--version` prints is not free. A test asserts building the parser does not resolve it.

### The home task store gitignores itself

It holds one JSON file per task and can sit inside a tracked repo, so a routine `git add -A` stages thousands of files nobody meant to commit. The rule is written once, when the store is first created; `task_store.track` opts back into versioning.

### Note on `tomli`

Added to the test extra so `test_ci_extras_coverage` can parse pyproject on 3.10. It skipped there at first — a check against silent skipping that silently skips is worth nothing, so the skip was removed rather than tolerated.

### Not in this batch

Idea **#107** (`task migrate-store`) is the fifth papercut and is *not* included — it is a data-migration command that deserves its own PR and its own copy-then-flip verification, not a tail-end addition to a batch of small fixes. Named here rather than quietly dropped.

### Verification

Full suite 1103 passed, 9 xfailed. Each fix has a regression test; the cycle guard's test failed with a real `RecursionError` before the fix.