### PR TITLE
feat(task): migrate-store — one command from the legacy store to the home store

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -5021,6 +5021,143 @@ def _doctor_check_subject_markers(tasks) -> "list[tuple[str, str, str]]":
     return findings
 
 
+def cmd_task_migrate_store(args: argparse.Namespace) -> int:
+    """Move the legacy per-session task store into the project-scoped home store.
+
+    The legacy store lives under CC's ``~/.claude/tasks/{session_uuid}/`` and is
+    keyed by session: a continue, rewind or fork gets a *copy* that then
+    diverges, and CC deletes completed task files once the last open task
+    closes. The home store is a single directory under the agent home, so it
+    survives all of that.
+
+    Done by hand this is: copy every file including the dot-prefixed completed
+    ones, edit the config, then hope. The ordering is what matters — **copy,
+    verify, then flip** — because a config flipped before verification points
+    the agent at a store that may be incomplete, and the failure looks like
+    amnesia rather than like a bad migration.
+
+    The legacy directory is never deleted. Reverting is a one-line config edit
+    as long as it is still there.
+    """
+    import hashlib
+    from .task import TaskReader
+
+    dry_run = getattr(args, "dry_run", False)
+    force = getattr(args, "force", False)
+
+    mode, rel = TaskReader._load_task_store_config()
+    if mode == "home" and not force:
+        print("✅ Already on the home store — nothing to migrate.")
+        print("   Re-run with --force to copy the current session's legacy "
+              "files in anyway.")
+        return 0
+
+    legacy = TaskReader(session_uuid=TaskReader()._detect_current_session())
+    source = legacy.session_path
+    if not source or not source.exists():
+        print(f"❌ No legacy task store found for the current session.")
+        return 1
+
+    agent_home = find_agent_home()
+    target = agent_home / rel
+    config_path = agent_home / ".maceff" / "config.json"
+
+    files = legacy.list_task_files(include_hidden=True)
+    hidden = [f for f in files if f.name.startswith(".")]
+    print(f"📦 Migrate task store")
+    print(f"   from: {source}  ({len(files)} files, {len(hidden)} hidden)")
+    print(f"   to:   {target}")
+    print(f"   config: {config_path}")
+
+    if not files:
+        print("❌ Legacy store is empty — refusing to migrate nothing.")
+        return 1
+
+    collisions = []
+    if target.exists():
+        for f in files:
+            if (target / f.name).exists():
+                collisions.append(f.name)
+    if collisions and not force:
+        print(f"\n❌ {len(collisions)} file(s) already exist in the target "
+              f"(e.g. {collisions[:3]}).")
+        print("   Refusing to overwrite. Re-run with --force if that is intended.")
+        return 1
+
+    if dry_run:
+        print("\n🔍 Dry run — nothing copied, config untouched.")
+        return 0
+
+    # 1. COPY
+    target.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for f in files:
+        try:
+            (target / f.name).write_bytes(f.read_bytes())
+            copied += 1
+        except OSError as e:
+            print(f"❌ Copy failed at {f.name}: {e}", file=sys.stderr)
+            print("   Config NOT flipped; the legacy store is untouched.")
+            return 1
+
+    # 2. VERIFY before flipping. A config pointed at an unverified store fails
+    #    later, elsewhere, and looks like data loss rather than a bad copy.
+    def _digest(p):
+        return hashlib.sha256(p.read_bytes()).hexdigest()
+
+    mismatched = []
+    for f in files:
+        dest = target / f.name
+        if not dest.exists() or _digest(dest) != _digest(f):
+            mismatched.append(f.name)
+    if mismatched:
+        print(f"\n❌ Verification failed for {len(mismatched)} file(s): "
+              f"{mismatched[:5]}")
+        print("   Config NOT flipped. The legacy store remains authoritative.")
+        return 1
+    print(f"\n✅ Copied and verified {copied} file(s) (sha256, byte-for-byte)")
+
+    # 3. FLIP
+    try:
+        config = json.loads(config_path.read_text()) if config_path.exists() else {}
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"❌ Could not read {config_path}: {e}", file=sys.stderr)
+        print("   Files are copied and verified; set task_store.mode=home by hand.")
+        return 1
+
+    config.setdefault("task_store", {})
+    config["task_store"]["mode"] = "home"
+    config["task_store"].setdefault("path", rel)
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+    except OSError as e:
+        print(f"❌ Could not write {config_path}: {e}", file=sys.stderr)
+        print("   Files are copied and verified; set task_store.mode=home by hand.")
+        return 1
+
+    print(f"✅ Config flipped: task_store.mode = home")
+
+    # Only now does the store read as "home", which is what the gitignore
+    # helper gates on — calling it before the flip would silently no-op.
+    _ensure_store_gitignored_for_migration(target)
+
+    print(f"\n📁 The legacy store is retained at:\n   {source}")
+    print("   Nothing was deleted — revert by setting task_store.mode back to "
+          "\"legacy\".")
+    print("\n▶️  Verify with: macf_tools task tree")
+    return 0
+
+
+def _ensure_store_gitignored_for_migration(target: Path) -> None:
+    """Gitignore a store created by migration rather than by first task write."""
+    try:
+        from .task.create import _ensure_store_gitignored
+        _ensure_store_gitignored(target)
+    except (ImportError, OSError) as e:
+        print(f"Warning: could not gitignore {target}: {e}", file=sys.stderr)
+
+
 def _gh_live_state(kind: str, repo_slug: str, number: str) -> "Optional[str]":
     """Query GitHub for the current state of an issue or PR.
 
@@ -9283,6 +9420,20 @@ def _build_parser() -> argparse.ArgumentParser:
     task_pause_parser.set_defaults(func=cmd_task_pause)
 
     # task note - append note to updates
+    task_migrate_parser = task_sub.add_parser(
+        "migrate-store",
+        help="move the legacy per-session task store into the home store",
+    )
+    task_migrate_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="report what would be copied without touching anything",
+    )
+    task_migrate_parser.add_argument(
+        "--force", action="store_true",
+        help="proceed even if the target already holds files of the same name",
+    )
+    task_migrate_parser.set_defaults(func=cmd_task_migrate_store)
+
     task_doctor_parser = task_sub.add_parser(
         "doctor",
         help="reconcile stored task records against the authorities they derive from",

--- a/macf/tests/test_papercuts.py
+++ b/macf/tests/test_papercuts.py
@@ -93,3 +93,104 @@ class TestHomeStoreIsGitignored:
         result = self._create_task(home, "first", tmp_path / "ev.jsonl")
         assert result.returncode == 0, result.stdout + result.stderr
         assert not (home / ".gitignore").exists(), "opt-out was ignored"
+
+
+class TestMigrateStore:
+    """Moving the legacy per-session store into the home store.
+
+    Done by hand this is: copy every file including the dot-prefixed completed
+    ones, edit the config, then hope. The ordering is the whole point — copy,
+    verify, then flip — because a config flipped before verification points the
+    agent at a possibly-incomplete store, and that failure reads like amnesia
+    rather than like a bad migration.
+    """
+
+    def _legacy_setup(self, tmp_path, mode="legacy"):
+        home = tmp_path / "home"
+        (home / ".maceff").mkdir(parents=True)
+        (home / ".maceff" / "config.json").write_text(json.dumps(
+            {"task_store": {"mode": mode, "path": "agent/public/tasks"}}))
+        subprocess.run(["git", "init", "-q", str(home)], check=True)
+
+        session = tmp_path / "tasks" / "sess-abc"
+        session.mkdir(parents=True)
+        for tid in ("000", "1", "2"):
+            (session / f"{tid}.json").write_text(json.dumps(
+                {"id": tid, "subject": f"  #{tid} t", "status": "pending",
+                 "description": "<macf_task_metadata version=\"1.0\">\n"
+                                "task_type: TASK\nparent_id: null\n"
+                                "</macf_task_metadata>\n"}))
+        # Completed tasks are dot-prefixed; a shell glob misses them and a
+        # hand migration loses the entire completed history.
+        (session / ".3.json").write_text(json.dumps(
+            {"id": "3", "subject": "  #3 done", "status": "completed",
+             "description": "x"}))
+        return home, session
+
+    def _run(self, home, tmp_path, *extra):
+        return subprocess.run(
+            ["macf_tools", "task", "migrate-store", *extra],
+            capture_output=True, text=True,
+            env={**os.environ,
+                 "MACEFF_AGENT_HOME_DIR": str(home),
+                 "MACF_TASKS_DIR": str(tmp_path / "tasks"),
+                 "MACF_SESSION_ID": "sess-abc",
+                 "MACF_EVENTS_LOG_PATH": str(tmp_path / "ev.jsonl")},
+        )
+
+    def test_migrates_including_hidden_completed_tasks(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path)
+        result = self._run(home, tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        target = home / "agent" / "public" / "tasks"
+        names = {p.name for p in target.iterdir()}
+        assert names == {"000.json", "1.json", "2.json", ".3.json"}, names
+        assert ".3.json" in names, "hidden completed task was dropped"
+
+    def test_config_is_flipped_to_home(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path)
+        self._run(home, tmp_path)
+        config = json.loads((home / ".maceff" / "config.json").read_text())
+        assert config["task_store"]["mode"] == "home"
+
+    def test_legacy_store_is_retained(self, tmp_path):
+        """Nothing is deleted — reverting is a one-line config edit."""
+        home, session = self._legacy_setup(tmp_path)
+        self._run(home, tmp_path)
+        assert len(list(session.iterdir())) == 4
+
+    def test_dry_run_touches_nothing(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path)
+        result = self._run(home, tmp_path, "--dry-run")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Dry run" in result.stdout
+        assert not (home / "agent" / "public" / "tasks").exists()
+        config = json.loads((home / ".maceff" / "config.json").read_text())
+        assert config["task_store"]["mode"] == "legacy", "dry run flipped the config"
+
+    def test_refuses_when_already_on_home_store(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path, mode="home")
+        result = self._run(home, tmp_path)
+        assert result.returncode == 0
+        assert "Already on the home store" in result.stdout
+
+    def test_refuses_to_overwrite_without_force(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path)
+        target = home / "agent" / "public" / "tasks"
+        target.mkdir(parents=True)
+        (target / "1.json").write_text('{"id": "1", "subject": "pre-existing"}')
+
+        result = self._run(home, tmp_path)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Refusing to overwrite" in result.stdout
+        assert json.loads((target / "1.json").read_text())["subject"] == "pre-existing"
+        config = json.loads((home / ".maceff" / "config.json").read_text())
+        assert config["task_store"]["mode"] == "legacy", "config flipped despite refusing"
+
+    def test_store_is_gitignored_after_migration(self, tmp_path):
+        home, _ = self._legacy_setup(tmp_path)
+        self._run(home, tmp_path)
+        ignored = subprocess.run(
+            ["git", "-C", str(home), "check-ignore", "-q", "agent/public/tasks"])
+        assert ignored.returncode == 0, "migrated store is tracked"


### PR DESCRIPTION
MISSION "MacEff Trustworthy State", Phase 4 — the fifth papercut, held out of PR #188 because a data migration deserves its own verification rather than a tail-end slot in a batch of small fixes.

The legacy store lives under CC's per-session directory and is keyed by session: a continue, rewind or fork gets a *copy* that then diverges, and CC deletes completed task files once the last open task closes. The home store is a single directory under the agent home and survives all of it.

Done by hand the migration is: copy every file including the dot-prefixed completed ones, edit the config, then hope. Two things make that risky, and both are what this command encodes.

### Ordering: copy, verify, then flip

A config flipped before verification points the agent at a possibly-incomplete store — and that failure surfaces later and elsewhere, looking like **amnesia rather than a bad migration**. Verification is a byte-for-byte sha256 comparison per file; any mismatch aborts with the config untouched and the legacy store still authoritative.

### Hidden files

Completed tasks are dot-prefixed. A shell glob misses them, so a hand migration silently drops **the entire completed history** — the part nobody notices until they go looking for it months later. A test asserts `.3.json` survives.

### Safety

- The legacy directory is **never deleted**; reverting is a one-line config edit as long as it is there.
- `--dry-run` reports without touching anything (asserted: no target dir, config unflipped).
- Pre-existing files in the target abort unless `--force`, without flipping the config.
- The migrated store is gitignored **after** the flip, not before — the helper gates on the store reading as `home`, so calling it earlier silently does nothing. That ordering bug was caught during the end-to-end run, not in review.

### Verification

End-to-end against a synthetic legacy store: 4 files including the hidden completed task, copied and verified, config flipped, `.gitignore` written, legacy retained. 7 new tests. Full suite 1110 passed, 9 xfailed.