### PR TITLE
fix(cli): framework install reported success while installing nothing

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -945,9 +945,17 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
             print(f"ℹ️  Commands and skills NOT installed; rerun without `--hooks-only` (or use `--skip-hooks` if hooks are already in place) to install those.")
             return 0
 
+        # An install that reports success while linking nothing is
+        # indistinguishable from one that worked, and the agent only finds out
+        # much later when a command it was told it had turns out to be missing.
+        # Both an absent source tree and a present-but-empty one are recorded
+        # here and made fatal at the summary.
+        problems: list[str] = []
+
         # Install commands (symlink maceff*/ namespace directories)
         print("\n📦 Installing commands...")
         commands_src = framework_root / "commands"
+        linked_commands = 0
         if commands_src.exists():
             commands_dir.mkdir(parents=True, exist_ok=True)
             for cmd_ns in commands_src.glob("maceff*/"):
@@ -960,12 +968,19 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
                             import shutil
                             shutil.rmtree(target)
                     target.symlink_to(cmd_ns)
+                    linked_commands += 1
                     # Count .md files in namespace for reporting
                     md_count = sum(1 for _ in cmd_ns.rglob("*.md"))
                     installed_count["commands"] += md_count
                     print(f"   ✓ {cmd_ns.name}/ ({md_count} commands)")
+            if linked_commands == 0:
+                problems.append(
+                    f"commands: {commands_src} exists but contains no maceff*/ namespace directories"
+                )
+                print(f"   ❌ no maceff*/ namespaces found in {commands_src}", file=sys.stderr)
         else:
-            print(f"   No commands directory at {commands_src}")
+            problems.append(f"commands: source tree missing at {commands_src}")
+            print(f"   ❌ no commands directory at {commands_src}", file=sys.stderr)
 
         # Install skills (symlink maceff-*/ directories)
         print("\n📦 Installing skills...")
@@ -984,10 +999,28 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
                     target.symlink_to(skill_dir)
                     installed_count["skills"] += 1
                     print(f"   ✓ {skill_dir.name}/")
+            if installed_count["skills"] == 0:
+                problems.append(
+                    f"skills: {skills_src} exists but contains no maceff-*/ directories"
+                )
+                print(f"   ❌ no maceff-*/ skills found in {skills_src}", file=sys.stderr)
         else:
-            print(f"   No skills directory at {skills_src}")
+            problems.append(f"skills: source tree missing at {skills_src}")
+            print(f"   ❌ no skills directory at {skills_src}", file=sys.stderr)
 
         # Summary
+        if problems:
+            print(f"\n❌ Framework installation INCOMPLETE — nothing was installed for:", file=sys.stderr)
+            for problem in problems:
+                print(f"   • {problem}", file=sys.stderr)
+            print(f"   Framework root resolved to: {framework_root}", file=sys.stderr)
+            print(f"   Hooks: {installed_count['hooks']}   Commands: {installed_count['commands']}   Skills: {installed_count['skills']}", file=sys.stderr)
+            print(f"   This usually means the framework tree was never deployed to this", file=sys.stderr)
+            print(f"   root — on a container, check that framework/ is mounted and that", file=sys.stderr)
+            print(f"   the sync step ran ('make framework-upgrade' on the host).", file=sys.stderr)
+            print(f"   Use --hooks-only if installing hooks alone is what you intended.", file=sys.stderr)
+            return 1
+
         print(f"\n✅ Framework installation complete!")
         print(f"   Hooks: {installed_count['hooks']}")
         print(f"   Commands: {installed_count['commands']}")

--- a/macf/tests/test_framework_install_verification.py
+++ b/macf/tests/test_framework_install_verification.py
@@ -68,8 +68,15 @@ def fake_framework_root(tmp_path, monkeypatch):
     """
     from macf.utils.paths import find_maceff_root
     root = tmp_path / "MacEff"
-    (root / "framework" / "commands").mkdir(parents=True)
-    (root / "framework" / "skills").mkdir()
+    # Seed one real namespace in each tree. An empty tree is now an install
+    # failure in its own right, so a fixture with empty dirs would make every
+    # success-path test fail for a reason unrelated to what it is testing.
+    ns = root / "framework" / "commands" / "maceff"
+    ns.mkdir(parents=True)
+    (ns / "sample.md").write_text("# sample command\n")
+    skill = root / "framework" / "skills" / "maceff-sample"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# sample skill\n")
     monkeypatch.setenv("MACEFF_ROOT_DIR", str(root))
     monkeypatch.chdir(tmp_path)
     find_maceff_root.cache_clear()
@@ -142,3 +149,122 @@ def test_framework_install_reports_actual_count_on_success(fake_framework_root, 
     assert f"Hooks: {expected_count}" in out
     # Must not have hit the failure path
     assert "Hook installation reported success" not in out
+
+
+# --- silent no-op when source trees are absent or empty --------------------
+#
+# The install printed "📦 Installing commands..." and, when the source tree was
+# missing, a quiet stdout line before exiting 0 with "✅ Framework installation
+# complete!". On a container whose framework tree had never been deployed this
+# reported success while installing nothing, and the gap only surfaced later as
+# missing commands — a peer agent lost real diagnosis time to it.
+
+
+def _seed_hooks_settings():
+    """Write a settings file with the canonical hook count, so the hook stage
+    passes and the test exercises the commands/skills stage."""
+    settings_file = Path.cwd() / ".claude" / "settings.local.json"
+    events = [f"Event{i}" for i in range(len(_hooks_to_install_list()))]
+    _write_settings(settings_file, {"hooks": {e: [] for e in events}})
+
+
+def _run_install(**namespace_kwargs):
+    real_exists = Path.exists
+
+    def fake_exists(self):
+        if str(self) == "/.dockerenv":
+            return False
+        return real_exists(self)
+
+    with patch("macf.cli.cmd_hook_install", return_value=0), \
+         patch.object(Path, "exists", fake_exists):
+        return cmd_framework_install(argparse.Namespace(**namespace_kwargs))
+
+
+def test_install_fails_when_commands_source_is_absent(fake_framework_root, capsys):
+    import shutil
+    shutil.rmtree(fake_framework_root / "framework" / "commands")
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "no commands directory" in captured.err
+    assert "INCOMPLETE" in captured.err
+    assert "Framework installation complete" not in captured.out
+
+
+def test_install_fails_when_skills_source_is_absent(fake_framework_root, capsys):
+    import shutil
+    shutil.rmtree(fake_framework_root / "framework" / "skills")
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "no skills directory" in captured.err
+    assert "Framework installation complete" not in captured.out
+
+
+def test_install_fails_when_source_exists_but_holds_no_namespaces(fake_framework_root, capsys):
+    """Present-but-empty is the same failure wearing a directory.
+
+    An existence check passes, the loop body never runs, and the summary is
+    identical to a successful install.
+    """
+    import shutil
+    shutil.rmtree(fake_framework_root / "framework" / "commands" / "maceff")
+    shutil.rmtree(fake_framework_root / "framework" / "skills" / "maceff-sample")
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "no maceff*/ namespaces found" in captured.err
+    assert "no maceff-*/ skills found" in captured.err
+
+
+def test_install_names_every_missing_tree_not_just_the_first(fake_framework_root, capsys):
+    import shutil
+    shutil.rmtree(fake_framework_root / "framework" / "commands")
+    shutil.rmtree(fake_framework_root / "framework" / "skills")
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    err = capsys.readouterr().err
+    assert result == 1
+    assert "commands: source tree missing" in err
+    assert "skills: source tree missing" in err
+
+
+def test_install_succeeds_and_links_when_trees_are_populated(fake_framework_root, capsys):
+    """Positive control: the failure path must not fire on a good tree."""
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 0, captured.err
+    assert "Framework installation complete" in captured.out
+    assert "INCOMPLETE" not in captured.err
+    assert (Path.cwd() / ".claude" / "commands" / "maceff").is_symlink()
+    assert (Path.cwd() / ".claude" / "skills" / "maceff-sample").is_symlink()
+
+
+def test_hooks_only_does_not_fail_on_absent_command_trees(fake_framework_root, capsys):
+    """--hooks-only returns before the commands/skills stage, and must keep
+    doing so — installing hooks alone is a legitimate intent."""
+    import shutil
+    shutil.rmtree(fake_framework_root / "framework" / "commands")
+    shutil.rmtree(fake_framework_root / "framework" / "skills")
+    _seed_hooks_settings()
+
+    result = _run_install(hooks_only=True)
+
+    captured = capsys.readouterr()
+    assert result == 0, captured.err
+    assert "Hooks-only installation complete" in captured.out


### PR DESCRIPTION
## The defect

`cmd_framework_install` guarded each source tree with `if src.exists():`. When the tree was absent — exactly the case on a container whose framework had never been deployed — the command printed its banner, one quiet stdout line, then:

```
✅ Framework installation complete!
   Hooks: 11
   Commands: 0
   Skills: 0
```

and exited **0**. An operator reading that has been told the install happened.

This was found while verifying a peer agent's bug report. That agent had spent real diagnosis time working from thirty dangling symlinks and a command set that had never been installed, with nothing in the output suggesting the install was the thing to doubt.

**Present-but-empty is the same failure wearing a directory.** The existence check passes, the glob matches nothing, the loop body never runs, and the summary is byte-identical to a successful install. That case is now caught too — it was not in the original report, and it is the one more likely to recur.

## What changed

- An absent **or** empty `commands/` / `skills/` tree is recorded, named on **stderr**, and returns **non-zero**.
- **Every** missing tree is reported, not just the first. An operator who fixes `commands/` and re-runs should not then discover `skills/`.
- The failure message names the resolved framework root and points at the host-side sync step, because a missing tree here almost always means the deploy upstream never ran.
- `--hooks-only` still returns before this stage. Installing hooks alone is a legitimate intent, and there is now a test keeping it that way.

## Verification

Six new tests, and the existing fixture updated — it built *empty* `commands/` and `skills/` directories, which would now fail for a reason unrelated to what those tests assert, so it seeds one real namespace in each.

Negative-controlled rather than merely observed passing: the fix was reverted and the suite re-run.

- **4 of the 6 fail** against the unfixed command.
- The other 2 assert *unchanged* behaviour (the success path and `--hooks-only`) and pass either way — stated rather than counted as evidence.

Full suite: 1085 passed. The 12 failures on this host are confined to `test_lancedb_search.py`, `test_hybrid_search.py`, and `test_search_service.py` — `lancedb` is not installed here. Pre-existing and untouched.

## Related

Companion to #192, which repairs the host-side sync scripts that were supposed to put those trees in place. Together they close both ends of the same gap: the sync that never ran, and the install that did not say so.