### PR TITLE
feat(container): give every agent an amail mailbox at init

### DIFF
--- a/docker/scripts/start.py
+++ b/docker/scripts/start.py
@@ -143,6 +143,78 @@ def provision_agent_identity(username: str, home_dir: str, display_name: Optiona
     return agent_uuid
 
 
+AMAIL_README = """# amail/ — inter-agent mailbox (v0)
+
+A simple file-based inter-agent communications channel. Deliberately plain so
+the convention can be exercised before any infrastructure is committed to.
+
+## Convention (provisional, v0)
+
+- `inbox/` — messages addressed TO the owning agent land here.
+- `outbox/` — copies of what the owner sends out.
+- One message per file. HTML (`.html`) renders richly; plain `.md` is fine too.
+  Name: `YYYY-MM-DD_<from-shortname>_<slug>_NNN.html`.
+- Email-style headers inside the message: From / To / Date / Subject / Msg-ID /
+  Broker. Sender and recipient are MacEff calling cards (`name@6hex`).
+- A message with attachments may be a directory of the same name, or a `.zip`
+  beside the message file.
+
+## Permissions
+
+Both boxes are owned by the agent and group `agents_all` at mode 750: the owner
+reads and writes, peer agents on the same host can traverse and read. A peer
+delivering to this agent writes into `inbox/`.
+
+## Known gaps (v0, on purpose)
+
+- **No notification/watcher.** Dropping a file here does not alert the owner.
+  Discovery is manual or brokered by the operator.
+- **No delivery guarantee, threading, or auth.** Replying into the sender's
+  inbox with an `In-Reply-To` header is proposed but not enforced.
+- **Cross-machine placement is manual** (copy into the recipient's agent home).
+- **No signing.** Authorship rests entirely on trusting the relay.
+
+If you extend the convention, leave a note here so it stays shared.
+"""
+
+
+def create_amail_tree(public: Path, username: str) -> Path:
+    """Create the agent's amail mailbox under agent/public/.
+
+    Like task_archives this is MACF infrastructure rather than a consciousness
+    artifact type, so it is created unconditionally rather than opted into via
+    the agent spec — an agent with no mailbox cannot be written to, and the
+    absence is only discovered by the agent trying to send.
+
+    Must run at init time: agent/public/ is 550 under immutable_structure, so
+    nothing can be added afterwards.
+
+    Group `agents_all` at mode 750 so peers can traverse and read, and deliver
+    into inbox/. The README ships with the tree because two empty directories
+    do not tell a fresh agent what a message looks like or where a reply goes.
+    """
+    amail = public / 'amail'
+    amail.mkdir(mode=0o750, exist_ok=True)
+
+    for box in ('inbox', 'outbox'):
+        box_dir = amail / box
+        box_dir.mkdir(mode=0o750, exist_ok=True)
+        run_command(['chown', f'{username}:agents_all', str(box_dir)])
+        run_command(['chmod', '750', str(box_dir)])
+
+    readme = amail / 'README.md'
+    if not readme.exists():
+        readme.write_text(AMAIL_README)
+        run_command(['chown', f'{username}:agents_all', str(readme)])
+        run_command(['chmod', '640', str(readme)])
+
+    # mkdir's mode= is unreliable under umask, so set it explicitly — and after
+    # the contents, since the dir must stay writable while they are created.
+    run_command(['chown', f'{username}:agents_all', str(amail)])
+    run_command(['chmod', '750', str(amail)])
+    return amail
+
+
 def create_pa_user(agent_name: str, agent_spec: AgentSpec, defaults_dict: Optional[Dict] = None) -> None:
     """Create Primary Agent Linux user."""
     username = agent_spec.username
@@ -469,6 +541,9 @@ def create_agent_tree(username: str, agent_spec: AgentSpec, defaults_config: Opt
     task_archives.mkdir(mode=0o750, exist_ok=True)
     run_command(['chown', f'{username}:agents_all', str(task_archives)])
     run_command(['chmod', '750', str(task_archives)])
+
+    # Create the amail mailbox (MACF infrastructure, always needed).
+    create_amail_tree(public, username)
 
     # Create subagents directory (owner-only, like private)
     subagents = agent / 'subagents'

--- a/macf/tests/test_container_amail_tree.py
+++ b/macf/tests/test_container_amail_tree.py
@@ -1,0 +1,113 @@
+"""Tests for the container's amail mailbox creation.
+
+The mailbox has to exist before ``agent/public/`` is locked to 550, or it can
+never be added — an agent whose container came up without one has no place to
+receive messages and no way to make one. A peer agent hit exactly that: it
+hand-staged outbound messages from a temp directory and relayed them through a
+human, because the tree its convention assumed had never been built.
+
+``docker/scripts/start.py`` is a container entrypoint, not a package module, so
+it is loaded by path here.
+"""
+
+import importlib.util
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+START_PY = (
+    Path(__file__).resolve().parents[2] / "docker" / "scripts" / "start.py"
+)
+
+
+@pytest.fixture(scope="module")
+def start_module():
+    """Load start.py by path; it lives outside the importable package."""
+    spec = importlib.util.spec_from_file_location("maceff_start", START_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def public_dir(tmp_path):
+    d = tmp_path / "agent" / "public"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def calls(start_module):
+    """Capture run_command instead of running it — chown needs root."""
+    recorded = []
+    with patch.object(start_module, "run_command", side_effect=lambda cmd, **kw: recorded.append(cmd)):
+        yield recorded
+
+
+def test_creates_both_boxes(start_module, public_dir, calls):
+    start_module.create_amail_tree(public_dir, "pa_test")
+    assert (public_dir / "amail" / "inbox").is_dir()
+    assert (public_dir / "amail" / "outbox").is_dir()
+
+
+def test_ships_the_convention_with_the_tree(start_module, public_dir, calls):
+    """Two empty directories do not tell a fresh agent what a message is."""
+    start_module.create_amail_tree(public_dir, "pa_test")
+    readme = public_dir / "amail" / "README.md"
+    assert readme.is_file()
+    body = readme.read_text()
+    assert "inbox/" in body and "outbox/" in body
+    # The naming convention is the part a sender actually needs.
+    assert "YYYY-MM-DD" in body
+
+
+def test_group_is_agents_all_so_peers_can_deliver(start_module, public_dir, calls):
+    start_module.create_amail_tree(public_dir, "pa_test")
+    chowns = [c for c in calls if c[0] == "chown"]
+    targets = {Path(c[2]).name: c[1] for c in chowns}
+    for name in ("amail", "inbox", "outbox", "README.md"):
+        assert targets.get(name) == "pa_test:agents_all", f"{name} not group agents_all"
+
+
+def test_directories_are_owner_writable_group_readable(start_module, public_dir, calls):
+    """750 on the boxes: the owner writes, peers traverse and read."""
+    start_module.create_amail_tree(public_dir, "pa_test")
+    chmods = {Path(c[2]).name: c[1] for c in calls if c[0] == "chmod"}
+    assert chmods["amail"] == "750"
+    assert chmods["inbox"] == "750"
+    assert chmods["outbox"] == "750"
+    assert chmods["README.md"] == "640"
+
+
+def test_parent_permissions_are_set_after_its_contents(start_module, public_dir, calls):
+    """Ordering matters: locking the parent first would block the contents."""
+    start_module.create_amail_tree(public_dir, "pa_test")
+    order = [Path(c[2]).name for c in calls if c[0] == "chmod"]
+    assert order.index("amail") > order.index("inbox")
+    assert order.index("amail") > order.index("outbox")
+    assert order.index("amail") > order.index("README.md")
+
+
+def test_is_idempotent_across_restarts(start_module, public_dir, calls):
+    """The container re-runs init on every boot; a second pass must not wipe
+    messages already delivered."""
+    start_module.create_amail_tree(public_dir, "pa_test")
+    message = public_dir / "amail" / "inbox" / "2026-07-31_peer_hello_001.html"
+    message.write_text("<p>hello</p>")
+    (public_dir / "amail" / "README.md").write_text("# locally amended\n")
+
+    start_module.create_amail_tree(public_dir, "pa_test")
+
+    assert message.is_file(), "existing message was destroyed by re-init"
+    assert message.read_text() == "<p>hello</p>"
+    # A local amendment to the convention survives too — the README is seeded,
+    # not managed.
+    assert (public_dir / "amail" / "README.md").read_text() == "# locally amended\n"
+
+
+def test_returns_the_mailbox_path(start_module, public_dir, calls):
+    result = start_module.create_amail_tree(public_dir, "pa_test")
+    assert result == public_dir / "amail"


### PR DESCRIPTION
## Why

A peer agent asked for this, having spent the previous day hand-staging outbound messages from a temp directory and relaying a zip through a human — because the mailbox its convention assumed had never been built.

It could not build one itself. `agent/public/` is chmod **550** under `immutable_structure`, so anything absent at init is absent permanently. An agent whose container came up without a mailbox has no place to receive and no way to make one, and finds out only when it first tries to send.

## What

`agent/public/amail/{inbox,outbox}/` is created at init, **unconditionally**, alongside `task_archives` — not opted into via the agent spec's `consciousness_artifacts` list.

A mailbox is a channel, not an artifact type. Making it optional leaves the failure above reachable by omission, and the 550 lock means an omission cannot be corrected later.

| | |
|---|---|
| Owner | the agent |
| Group | `agents_all` |
| Mode | `750` on the directories, `640` on the README |

That matches the surrounding public tree: the owner reads and writes, peers on the host traverse and read, and a peer delivering writes into `inbox/`. The parent's mode is applied *after* its contents — locking it first would block them.

### The README ships with the tree

Two empty directories don't tell a fresh agent what a message looks like, how to name it, or where a reply goes. It's **seeded, not managed**: a local amendment to the convention survives re-init, as do delivered messages. The container re-runs init on every boot, so that isn't hypothetical.

## Verification

Creation moved into `create_amail_tree()` so it is testable at all — `start.py` is a container entrypoint rather than a package module, so the tests load it by path and patch `run_command`, since `chown` needs root.

7 tests. The two that could plausibly pass vacuously were confirmed against deliberately broken variants:

- hoisting the parent `chmod` above its contents → the ordering test fails
- dropping the README existence guard → the idempotence test fails

The idempotence test writes a message into `inbox/`, re-runs init, and asserts the message and a locally-amended README both survive.

## Note for downstream forks

A fork building its image with `COPY MacEff/docker/scripts/start.py` picks this up only when its submodule is advanced past this commit — a rebuild against a stale submodule will look like the fix didn't work.