### PR TITLE
feat(task): succinct tree shows finished work under a parent still open

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4104,8 +4104,33 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
                     return True
             return False
 
-        def should_show_task(task, siblings, depth):
-            """Determine if task should be shown in succinct mode."""
+        def is_fully_completed(task, _seen=None):
+            """True when this task AND every descendant are completed.
+
+            "Completed" alone is not enough to hide a subtree: a completed
+            parent can still own active children, and hiding the parent hides
+            them with it — the work disappears from the tree entirely rather
+            than merely collapsing.
+            """
+            if task.status != "completed":
+                return False
+            # Same cycle guard as count_descendants: a self-parenting task is
+            # malformed but reachable, and must not take the render down.
+            _seen = set() if _seen is None else _seen
+            if task.id in _seen:
+                return True
+            _seen.add(task.id)
+            return all(is_fully_completed(c, _seen) for c in get_children(task.id))
+
+        def should_show_task(task, siblings, depth, parent=None):
+            """Determine if task should be shown in succinct mode.
+
+            Succinct is progressive disclosure, not a completed-filter. The
+            rule that matters: a parent still open means its finished children
+            are the context that makes the remaining work legible. Hiding them
+            renders an in-progress parent as a bare line with nothing under it,
+            which reads as "nothing was done here" — the opposite of the truth.
+            """
             if not succinct:
                 return True
             # Always show root sentinel (depth 0)
@@ -4119,10 +4144,18 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
             # Show if active/pending
             if task.status in ("in_progress", "pending"):
                 return True
-            # Top tier (depth 1): hide ALL completed - too many to show siblings
+            # Top tier (depth 1): hide only a subtree that is done all the way
+            # down. A completed task with active descendants stays, or those
+            # descendants would have no path to the surface.
             if depth == 1:
-                return False
-            # Deeper tiers: show completed only if has active sibling (provides context)
+                return not is_fully_completed(task)
+            # Deeper tiers: while the parent is still open, show its completed
+            # children. Their own finished descendants collapse by the same
+            # rule one level further in, so a resolved branch costs one line
+            # rather than a subtree.
+            if parent is not None and parent.status != "completed":
+                return True
+            # Under a completed parent, fall back to sibling context.
             if task.status == "completed" and has_active_sibling(task, siblings):
                 return True
             return False
@@ -4353,7 +4386,7 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
 
             children = get_children(task.id)
             # Filter children in succinct mode
-            visible_children = [c for c in children if should_show_task(c, children, depth + 1)]
+            visible_children = [c for c in children if should_show_task(c, children, depth + 1, task)]
 
             for i, child in enumerate(visible_children):
                 print_tree(child, prefix + extension, i == len(visible_children) - 1, depth + 1, children)

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -1350,3 +1350,99 @@ class TestHierarchyCycleGuard:
         assert result.returncode == 0, result.stdout + result.stderr
         assert "RecursionError" not in result.stderr
         assert "cycle in task hierarchy" in result.stderr
+
+
+class TestTaskTreeSuccinctProgressiveDisclosure:
+    """Succinct mode is progressive disclosure, not a completed-filter.
+
+    An in-progress parent whose finished children are all hidden renders as a
+    bare line with nothing beneath it, which reads as "nothing was done here" —
+    the opposite of the truth. And hiding a completed task hides its subtree,
+    so a completed parent with active children took those children off the
+    tree entirely.
+    """
+
+    def _write_task(self, session_dir, task_id, subject, status, ts, parent="'000'"):
+        parent_line = f"parent_id: {parent}\n" if parent else ""
+        mtmd = (f"task_type: {'SENTINEL' if not parent else 'TASK'}\n"
+                f"creation_breadcrumb: s_t/c_1/g_a/p_b/t_{ts}\n"
+                f"created_cycle: 1\ncreated_by: PA\n{parent_line}")
+        desc = f'Task\n\n<macf_task_metadata version="1.0">\n{mtmd}</macf_task_metadata>'
+        (session_dir / f"{task_id}.json").write_text(json.dumps(
+            {"id": str(task_id), "subject": subject, "description": desc, "status": status}))
+
+    def _tree(self, env):
+        return subprocess.run(
+            ['macf_tools', 'task', 'tree', '--succinct'],
+            capture_output=True, text=True, env=env).stdout
+
+    def _root(self, d):
+        self._write_task(d, "000", "🛡️ MACF TASK LIST", "in_progress", 1000, parent=None)
+        # Newest-touched task, and active anyway, so the recency marker never
+        # lands on a task a test expects to be hidden.
+        self._write_task(d, 99, "🔧 newest active decoy", "in_progress", 9999999999)
+
+    def test_completed_children_show_under_an_incomplete_parent(self, isolated_task_env):
+        """Rule 1 — the reason this exists."""
+        d = isolated_task_env['session_dir']
+        self._root(d)
+        self._write_task(d, 2, "🔧 open parent", "in_progress", 2000)
+        self._write_task(d, 3, "PHASE ONE done", "completed", 2001, parent="2")
+        self._write_task(d, 4, "PHASE TWO done", "completed", 2002, parent="2")
+
+        out = self._tree(isolated_task_env['env'])
+        assert 'open parent' in out
+        assert 'PHASE ONE done' in out, f"completed child hidden under open parent:\n{out}"
+        assert 'PHASE TWO done' in out, f"completed child hidden under open parent:\n{out}"
+
+    def test_fully_completed_top_level_subtree_is_hidden(self, isolated_task_env):
+        """Rule 3 — done all the way down, so it collapses out of view."""
+        d = isolated_task_env['session_dir']
+        self._root(d)
+        self._write_task(d, 2, "FINISHED TOPLEVEL", "completed", 2000)
+        self._write_task(d, 3, "FINISHED CHILD", "completed", 2001, parent="2")
+
+        out = self._tree(isolated_task_env['env'])
+        assert 'FINISHED TOPLEVEL' not in out, f"fully-done top-level task shown:\n{out}"
+        assert 'FINISHED CHILD' not in out
+
+    def test_completed_top_level_with_active_descendant_stays(self, isolated_task_env):
+        """Rule 3, the case that made it a bug rather than a preference.
+
+        Hiding the parent hides the subtree, so an active child under a
+        completed parent had no path to the surface at all.
+        """
+        d = isolated_task_env['session_dir']
+        self._root(d)
+        self._write_task(d, 2, "COMPLETED PARENT", "completed", 2000)
+        self._write_task(d, 3, "STILL ACTIVE CHILD", "in_progress", 2001, parent="2")
+
+        out = self._tree(isolated_task_env['env'])
+        assert 'COMPLETED PARENT' in out, f"completed parent hidden despite active child:\n{out}"
+        assert 'STILL ACTIVE CHILD' in out, f"active child lost with its parent:\n{out}"
+
+    def test_resolved_branch_collapses_to_one_line(self, isolated_task_env):
+        """Rule 2 — a completed child under an open parent shows, but its own
+        finished descendants do not expand."""
+        d = isolated_task_env['session_dir']
+        self._root(d)
+        self._write_task(d, 2, "open parent", "in_progress", 2000)
+        self._write_task(d, 3, "RESOLVED BRANCH", "completed", 2001, parent="2")
+        self._write_task(d, 4, "BURIED GRANDCHILD", "completed", 2002, parent="3")
+
+        out = self._tree(isolated_task_env['env'])
+        assert 'RESOLVED BRANCH' in out, f"completed child hidden under open parent:\n{out}"
+        assert 'BURIED GRANDCHILD' not in out, f"resolved branch expanded instead of collapsing:\n{out}"
+
+    def test_branch_with_active_grandchild_does_not_collapse(self, isolated_task_env):
+        """The interaction case: collapsing keys on the subtree being finished,
+        not on the child being completed."""
+        d = isolated_task_env['session_dir']
+        self._root(d)
+        self._write_task(d, 2, "open parent", "in_progress", 2000)
+        self._write_task(d, 3, "COMPLETED MIDDLE", "completed", 2001, parent="2")
+        self._write_task(d, 4, "ACTIVE GRANDCHILD", "in_progress", 2002, parent="3")
+
+        out = self._tree(isolated_task_env['env'])
+        assert 'COMPLETED MIDDLE' in out
+        assert 'ACTIVE GRANDCHILD' in out, f"active grandchild hidden by collapse:\n{out}"


### PR DESCRIPTION
Operator-filed. `--succinct` filtered on completed-ness rather than doing progressive disclosure, and the result is most misleading exactly where the tree is most consulted.

## Before / after

An in-progress parent whose four phases are all complete:

```
BEFORE
├── ◼ #41 🔧 amail from Manny2: restore container framework tree, fix...

AFTER
├── ◼ #41 🔧 amail from Manny2: restore container framework tree, fix...
│   ├── ✔ #42 - Phase 1: Restore owner-write on container ~/ag...
│   ├── ✔ #43 - Phase 2: Ship framework commands/, skills/, ma...
│   ├── ✔ #44 - Phase 3: Create amail inbox/outbox tree in con...
│   └── ✔ #45 - Phase 4: Reply to Manny2 by amail (after the f...
```

The old rendering reads as *"nothing was done here"* — the opposite of the truth.

## The three rules

| | Rule | Was |
|---|---|---|
| 1 | Completed children **show** while their parent is still open | Hidden unless a sibling happened to be active |
| 2 | A completed child's own finished descendants **collapse** | n/a — the child was hidden anyway |
| 3 | A top-level task hides only when finished **all the way down** | Every completed top-level task hidden outright |

Rule 3 was a bug, not a preference. Hiding a task hides its subtree, so **a completed parent with active children took those children off the tree entirely** — no path to the surface at any depth. Hiding now requires `is_fully_completed`, which is what "fully completed" was always supposed to mean.

Rule 2 keys on *the subtree being resolved*, not on the child being completed — a completed task with an active grandchild still expands.

`is_fully_completed` carries the same cycle guard as `count_descendants`: a self-parenting task is malformed but reachable, and must not take the render down with it.

## Verification

Five new tests, run against the real CLI in an isolated task env.

Negative-controlled — the renderer was reverted and the suite re-run:

- **4 of 5 fail** against the old renderer.
- The 5th (a fully-resolved top-level subtree stays hidden) passes either way. It asserts *preserved* behaviour, and previously passed for the weaker reason that anything completed was hidden regardless of descendants. Stated rather than counted as evidence.

Each test seeds a newest-touched *active* decoy so the recency-marker exemption never lands on a task the test expects hidden — otherwise the hiding assertions would pass or fail for an unrelated reason.

`test_task_cli.py`: 74 passed. Full suite: 1091 passed; the 12 failures on this host are confined to `test_lancedb_search.py`, `test_hybrid_search.py`, `test_search_service.py` (`lancedb` not installed) — pre-existing and untouched.

The existing recency-marker test from #150 still passes.