### PR TITLE
fix(cli): framework install now prunes links to retired framework content

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -952,6 +952,41 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
         # here and made fatal at the summary.
         problems: list[str] = []
 
+        def prune_orphaned_links(target_dir, owned_prefixes):
+            """Remove framework-owned symlinks whose target no longer exists.
+
+            Installing relinks what the source tree still has; nothing removed
+            links to what it no longer has. So every framework rename or
+            retirement left an orphan behind permanently, and Claude Code drops
+            broken symlinks from autocomplete silently — the only symptom is a
+            command quietly missing, with nothing pointing at the install as
+            the cause.
+
+            Deliberately narrow, because agents keep their own commands and
+            skills in these same directories and a prune that ate one would be
+            strictly worse than the orphan it fixes. Two guards do that work:
+            the entry must fail to resolve (which already excludes every real
+            file and every link that still points somewhere), and its name must
+            be one the framework owns. The is_symlink() check is intent rather
+            than protection — it is redundant with the resolve check, and
+            removing it does not change behaviour.
+            """
+            removed = []
+            if not target_dir.is_dir():
+                return removed
+            for entry in sorted(target_dir.iterdir()):
+                if not entry.is_symlink():
+                    continue
+                # exists() follows the link, so this is False exactly when the
+                # target is gone.
+                if entry.exists():
+                    continue
+                if not any(entry.name.startswith(p) for p in owned_prefixes):
+                    continue
+                entry.unlink()
+                removed.append(entry.name)
+            return removed
+
         # Install commands (symlink maceff*/ namespace directories)
         print("\n📦 Installing commands...")
         commands_src = framework_root / "commands"
@@ -973,6 +1008,8 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
                     md_count = sum(1 for _ in cmd_ns.rglob("*.md"))
                     installed_count["commands"] += md_count
                     print(f"   ✓ {cmd_ns.name}/ ({md_count} commands)")
+            for orphan in prune_orphaned_links(commands_dir, ("maceff",)):
+                print(f"   🧹 removed orphaned link {orphan} (target no longer in framework)")
             if linked_commands == 0:
                 problems.append(
                     f"commands: {commands_src} exists but contains no maceff*/ namespace directories"
@@ -999,6 +1036,8 @@ def cmd_framework_install(args: argparse.Namespace) -> int:
                     target.symlink_to(skill_dir)
                     installed_count["skills"] += 1
                     print(f"   ✓ {skill_dir.name}/")
+            for orphan in prune_orphaned_links(skills_dir, ("maceff-",)):
+                print(f"   🧹 removed orphaned link {orphan} (target no longer in framework)")
             if installed_count["skills"] == 0:
                 problems.append(
                     f"skills: {skills_src} exists but contains no maceff-*/ directories"

--- a/macf/tests/test_framework_install_verification.py
+++ b/macf/tests/test_framework_install_verification.py
@@ -268,3 +268,69 @@ def test_hooks_only_does_not_fail_on_absent_command_trees(fake_framework_root, c
     captured = capsys.readouterr()
     assert result == 0, captured.err
     assert "Hooks-only installation complete" in captured.out
+
+
+# --- orphaned symlink pruning ----------------------------------------------
+#
+# Installing relinked what the source tree still had, but nothing removed links
+# to what it no longer had. Every framework rename or retirement therefore left
+# an orphan behind permanently. Claude Code drops broken symlinks from
+# autocomplete silently, so the only symptom is a command quietly missing —
+# one agent was found carrying seven, another had hand-cleaned thirty.
+
+
+def test_orphaned_framework_links_are_pruned(fake_framework_root, capsys):
+    _seed_hooks_settings()
+    commands_dir = Path.cwd() / ".claude" / "commands"
+    skills_dir = Path.cwd() / ".claude" / "skills"
+    commands_dir.mkdir(parents=True)
+    skills_dir.mkdir(parents=True)
+    # Links to framework content that has since been renamed or retired.
+    (commands_dir / "maceff_jotewr.md").symlink_to("/nonexistent/maceff_jotewr.md")
+    (skills_dir / "maceff-todo-hygiene").symlink_to("/nonexistent/maceff-todo-hygiene")
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 0, captured.err
+    assert not (commands_dir / "maceff_jotewr.md").is_symlink(), "orphaned command link survived"
+    assert not (skills_dir / "maceff-todo-hygiene").is_symlink(), "orphaned skill link survived"
+    assert "maceff_jotewr.md" in captured.out
+    assert "orphaned link" in captured.out
+
+
+def test_pruning_never_touches_an_agents_own_files(fake_framework_root, capsys):
+    """Agents keep their own commands and skills in these same directories.
+
+    A prune that removed a real file, or a link the framework does not own,
+    would destroy the agent's work — strictly worse than the orphan it fixes.
+    """
+    _seed_hooks_settings()
+    commands_dir = Path.cwd() / ".claude" / "commands"
+    commands_dir.mkdir(parents=True)
+    # A real file, not a link.
+    (commands_dir / "manny_gist.md").write_text("# my own command\n")
+    # A broken link the framework does not own.
+    (commands_dir / "my_scratch.md").symlink_to("/nonexistent/my_scratch.md")
+    # A framework-named link that RESOLVES — must not be pruned either.
+    real_target = fake_framework_root / "framework" / "commands" / "maceff"
+    (commands_dir / "maceff_live.md").symlink_to(real_target)
+
+    result = _run_install()
+
+    assert result == 0
+    assert (commands_dir / "manny_gist.md").is_file(), "a real file was deleted"
+    assert (commands_dir / "manny_gist.md").read_text() == "# my own command\n"
+    assert (commands_dir / "my_scratch.md").is_symlink(), "a non-framework link was deleted"
+    assert (commands_dir / "maceff_live.md").is_symlink(), "a resolving link was deleted"
+
+
+def test_install_still_succeeds_when_there_is_nothing_to_prune(fake_framework_root, capsys):
+    """Positive control: the prune must be a no-op on a clean tree."""
+    _seed_hooks_settings()
+
+    result = _run_install()
+
+    captured = capsys.readouterr()
+    assert result == 0, captured.err
+    assert "orphaned link" not in captured.out


### PR DESCRIPTION
## The gap

`framework install` relinks whatever the source tree still has. Nothing removes links to what it no longer has — so **every framework rename or retirement leaves an orphan behind permanently.**

Claude Code drops broken symlinks from autocomplete silently. The symptom is a command quietly missing, with nothing pointing at the install as the cause. Same silent-failure family as #193.

## Found live

A running agent was carrying **seven** dangling links:

| orphan | why it died |
|---|---|
| `maceff_jotewr.md`, `maceff_ccp.md`, `maceff_scholar_annotate.md`, `maceff_agent_bootstrap.md` | flat command names superseded by the `maceff/` namespace directory |
| `maceff-enter-auto-mode` | renamed to `maceff-auto-mode` |
| `maceff-todo-hygiene`, `maceff-todo-restoration` | retired alongside the `todo_hygiene` deprecation |

A second agent on the same host had zero — but only because it had hand-cleaned thirty of them itself.

## The prune is narrow on purpose

Agents keep their **own** commands and skills in these same directories. A prune that ate one would be strictly worse than the orphan it fixes. Two guards do that work:

1. the entry must **fail to resolve** — which already excludes every real file and every link that still points somewhere
2. its name must be one the **framework owns** (`maceff*` / `maceff-*`)

## Verification

3 new tests, 16 in the file, 1125 in the suite.

Negative-controlled by removing each guard and watching the safety test fail:

- drop the owned-prefix check → a non-framework broken link gets eaten → **fails**
- drop the resolve check → a real file gets eaten → **fails**
- drop `is_symlink()` → **nothing changes**

That third result is reported rather than quietly dropped. `is_symlink()` is redundant with the resolve check, so it is intent, not protection, and the docstring now says so. A comment claiming a guard that isn't load-bearing is how the next reader deletes the wrong line.

The safety test seeds all three things that must survive: a real file, a broken link the framework does not own, and a framework-named link that still resolves.

**Live result**: the agent with seven orphans went to zero; both agents ended at 19 links, 0 dangling.

Full suite: 1125 passed. The 12 failures on this host are confined to `test_lancedb_search.py`, `test_hybrid_search.py`, `test_search_service.py` (`lancedb` absent) — pre-existing and untouched.