### PR TITLE
fix(docker): image was missing tmux and rsync, both load-bearing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,12 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
 SHELL ["/bin/bash","-lc"]
 
+# tmux and rsync are load-bearing, not conveniences: macf.supervisor's
+# --tmux-session is how a detached, joinable agent session runs at all (agents'
+# own harness functions call tmux directly), and every maceff_tools/*-sync
+# script invokes rsync. Both had been hand-installed into a running container,
+# which worked right up until a rebuild removed them and left two agents unable
+# to start, with nothing recording what had gone missing.
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -13,6 +19,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
       nodejs npm \
       acl jq tini \
       tree \
+      tmux rsync \
       libgl1 libxrender1 libxext6 libx11-6 libosmesa6 \
  && rm -rf /var/lib/apt/lists/* \
  && git lfs install --system

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -15,6 +15,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
       nodejs npm \
       acl jq tini \
       tree \
+      tmux rsync \
  && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI (gh) for automation


### PR DESCRIPTION
## What happened

A container rebuild brought the image up **without tmux**, and both agents on it became unstartable — `tmux: command not found`, no session, no way to launch one.

tmux appears in **neither Dockerfile** and is absent from the base image. It had been `apt install`ed by hand into a running container at some point. That worked right up until a rebuild removed it, with nothing recording what had gone missing or that anything depended on it.

This is the failure mode the harness work already named: undocumented manual state that is indistinguishable from working configuration until the thing is rebuilt.

## Why these two specifically

Neither is a convenience.

- **tmux** — `macf.supervisor`'s `--tmux-session` is how a detached, joinable agent session runs *at all*, and agents' own harness functions in `~/.bashrc` call `tmux new-session` directly. An image that cannot run tmux cannot run an agent.
- **rsync** — every `maceff_tools/*-sync` script invokes it. Those work today only because they are being run host-side; a framework sync from *inside* a container would fail on a missing binary.

They go in the **base** rather than the derived image, since the supervisor and the sync scripts are both MacEff-general rather than fork-specific.

## Verification

Built a fresh base image and checked inside it rather than reading the Dockerfile:

```
tmux     /usr/bin/tmux      tmux 3.4
rsync    /usr/bin/rsync     rsync version 3.2.7
```

against a prior measurement on the old base image that returned `absent in base` for tmux.

The comment sits **above** the `RUN` rather than inside its line continuation — a `#` line spliced into a continued `apt-get install` is exactly the sort of thing that either breaks the parse or gets read as a package name, and there is no reason to find out which.

Both packages are installed in the affected container now so its agents run, but that is the same undocumented manual state this PR exists to eliminate — it disappears again on the next rebuild unless the image carries them.

> **Correction (2026-08-01):** an earlier version of this paragraph said both packages were installed live. Only tmux was — I ran a one-package install and wrote a two-package claim, and rsync was still absent the following morning. It is installed now (3.2.7) and verified alongside tmux 3.4. Recording the slip rather than quietly amending it, because a reviewer could have relied on that sentence to judge how urgent this PR is.