### PR TITLE
feat(harness): generate the persistent agent harness instead of hand-editing it

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,121 @@
+# The Persistent Agent Harness
+
+A supervised, detached, continuity-anchored Claude Code session. A systemd user
+unit creates a tmux session, tmux runs `macf.supervisor`, and the supervisor runs
+the client through a child wrapper. The session survives client restarts and
+operator detach, which is what makes unattended autonomous work possible.
+
+Everything is **generated**. Do not hand-edit the installed artifacts — the
+predecessor to this command was a hand-edited unit whose stored copy had already
+drifted from the live one, and was missing the environment flag that keeps the
+long-context window. Anyone installing from that artifact would have got a
+silently degraded harness.
+
+## Install
+
+```bash
+macf_tools harness generate --agent <slug>          # review first, writes nothing
+macf_tools harness install  --agent <slug>
+systemctl --user daemon-reload
+systemctl --user enable --now cc-harness-<slug>.service
+```
+
+`--agent` names the unit, the tmux session and the supervisor instance. Use a
+short slug, not a login name — it appears in the unit filename.
+
+Three artifacts are written:
+
+| Path | Purpose |
+|---|---|
+| `~/.config/systemd/user/cc-harness-<slug>.service` | creates the session at boot |
+| `~/.local/bin/maceff_cc_child_<slug>` | supervised child entrypoint |
+| `~/.tmux-<slug>.conf` | terminal baseline for TUI fidelity |
+
+## Operate
+
+```bash
+macf_tools harness status --agent <slug>     # unit, session, proxy attachment
+tmux attach -t <slug>                        # attach (Ctrl-b d to detach)
+systemctl --user stop cc-harness-<slug>.service   # remote kill switch
+```
+
+`stop` stops the **supervisor**, not the child. Killing the child only makes the
+supervisor restart it, so a stop that targets the child is not a stop.
+
+## Check for drift
+
+```bash
+macf_tools harness install --check --agent <slug>
+```
+
+Reports, without writing, whether each installed artifact still matches what the
+generator produces. Exits non-zero if any differs. `install` refuses to overwrite
+a differing artifact unless `--force`.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now cc-harness-<slug>.service
+rm ~/.config/systemd/user/cc-harness-<slug>.service
+rm ~/.local/bin/maceff_cc_child_<slug> ~/.tmux-<slug>.conf
+systemctl --user daemon-reload
+tmux kill-session -t <slug>    # only if you also want the running session gone
+```
+
+## Why the unit looks the way it does
+
+Each of these cost a real incident. They are asserted in
+`macf/tests/test_harness_render.py` so they cannot regress silently.
+
+**`$${BASE}` is escaped.** systemd expands `$VAR` and `${VAR}` in `Exec*` lines
+using the *unit's* environment before any shell runs. `BASE` is not a unit
+variable, so an unescaped `${BASE}` was replaced with an empty string and the
+shell's own assignment never mattered. The proxy opt-in was silently inert, with
+nothing but "Referenced but unset environment variable" in the journal.
+
+**The first-party flag is emitted in the same assignment as the base URL.** When
+the API base URL's host is not the default, the client stops extending the
+long-context window and falls back to 200K — while every surface continues to
+display the full window. There is no log line and no warning; the only symptom is
+compacting early. Setting the base URL without the flag reinstates that silently,
+so the two are never separated.
+
+**Proxy attachment is probed, not assumed.** A short `curl` decides whether to
+attach. A dead proxy must degrade to a direct agent, never to a dead one.
+
+**`StartLimit*` live in `[Unit]`.** systemd honours them nowhere else. In
+`[Service]` they read as configured and do nothing — it will tell you so with
+"Unknown key ..., ignoring", which is easy to miss because the unit still starts.
+
+**`Type=oneshot` with `RemainAfterExit=yes`.** This unit's job is to *create* the
+session, not to be it. Restart supervision belongs to `macf.supervisor`, which
+owns the client process; a `Restart=` here would fight it.
+
+**The interpreter is absolute and unversioned.** The unit's shell is
+non-interactive and inherits nothing from the operator's profile — an earlier
+boot path used `bash -lc` and resolved a python without the `macf` module,
+because `~/.bashrc` early-returns for non-interactive shells. The unversioned
+`python3` beside the interpreter is preferred so a minor-release upgrade does not
+leave the unit pointing at a path that no longer exists.
+
+**The child wrapper nudges twice.** The client re-asks its workspace-trust prompt
+when launched under the supervisor, and `SessionStart:resume` hands the turn back
+to a user who is not attached. Both strand an unattended session; both are
+handled in the wrapper rather than left for whoever notices the agent went quiet.
+
+**Continuity is the default.** The child runs `claude -c`. Starting a *new*
+session must be a deliberate act, because an unattended restart that silently
+began a fresh conversation would discard the agent's working context with nothing
+to show it had happened.
+
+## macOS
+
+**Documented, not tested.** The equivalent on macOS is a `launchd` user agent in
+`~/Library/LaunchAgents/` with `RunAtLoad` and `KeepAlive`, wrapping the same
+tmux + supervisor invocation. `systemctl --user enable --now` becomes
+`launchctl bootstrap gui/$(id -u) <plist>`, and `systemctl --user stop` becomes
+`launchctl bootout`. The `$${BASE}` escaping concern is systemd-specific and does
+not apply; the first-party flag requirement does.
+
+This path has never been exercised. Treat it as a starting point rather than a
+recipe, and do not report it as working until someone has run it.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -67,6 +67,14 @@ tmux kill-session -t <slug>    # only if you also want the running session gone
 Each of these cost a real incident. They are asserted in
 `macf/tests/test_harness_render.py` so they cannot regress silently.
 
+The six operational invariants — including the two that belong to the proxy
+rather than the harness — live in `macf/tests/test_operational_invariants.py` as
+a single registry pairing each checker with the incident that produced it. Every
+one carries a **negative control**: a mutation that must make its checker fail.
+A check never observed failing is not a check, so if someone weakens a checker
+into something that always passes, its control fails and says so. Read that
+registry rather than this list when you want the full account.
+
 **`$${BASE}` is escaped.** systemd expands `$VAR` and `${VAR}` in `Exec*` lines
 using the *unit's* environment before any shell runs. `BASE` is not a unit
 variable, so an unescaped `${BASE}` was replaced with an empty string and the

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1387,6 +1387,134 @@ def cmd_statusline(args: argparse.Namespace) -> int:
         return 1
 
 
+def _harness_params(args: argparse.Namespace):
+    from .utils.harness import default_params
+    return default_params(agent=getattr(args, "agent", None), home=getattr(args, "home", None))
+
+
+def cmd_harness_generate(args: argparse.Namespace) -> int:
+    """Render harness artifacts to stdout without touching anything.
+
+    Rendering and installing are separate verbs so the output can be reviewed,
+    diffed against a live unit, or scanned for identifiers before it lands
+    anywhere — the hand-edited predecessor drifted precisely because there was
+    nothing to diff against.
+    """
+    from .utils.harness import render_unit, render_child, render_tmux_conf
+
+    try:
+        p = _harness_params(args)
+        attach = not getattr(args, "no_proxy", False)
+        what = getattr(args, "what", "unit")
+        if what in ("unit", "all"):
+            print(render_unit(p, attach_proxy=attach), end="")
+        if what in ("child", "all"):
+            if what == "all":
+                print(f"\n# ===== {p.child_path} =====")
+            print(render_child(p), end="")
+        if what in ("tmux", "all"):
+            if what == "all":
+                print(f"\n# ===== {p.home}/.tmux-{p.agent}.conf =====")
+            print(render_tmux_conf(p), end="")
+        return 0
+    except Exception as e:
+        print(f"Error rendering harness: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_harness_install(args: argparse.Namespace) -> int:
+    """Write the rendered artifacts into place.
+
+    Refuses to clobber a unit that differs unless --force, and --check reports
+    drift without writing. A live unit that has diverged from what the generator
+    produces is the failure this command exists to make visible rather than
+    silently overwrite.
+    """
+    from pathlib import Path
+    import stat as _stat
+    from .utils.harness import render_unit, render_child, render_tmux_conf
+
+    try:
+        p = _harness_params(args)
+        attach = not getattr(args, "no_proxy", False)
+        unit_dir = Path.home() / ".config" / "systemd" / "user"
+        targets = [
+            (unit_dir / p.unit_name, render_unit(p, attach_proxy=attach), False),
+            (Path(p.child_path), render_child(p), True),
+            (p.home / f".tmux-{p.agent}.conf", render_tmux_conf(p), False),
+        ]
+
+        if getattr(args, "check", False):
+            drift = 0
+            for path, content, _ in targets:
+                if not path.exists():
+                    print(f"   ABSENT   {path}")
+                    drift += 1
+                elif path.read_text() != content:
+                    print(f"   DRIFTED  {path}")
+                    drift += 1
+                else:
+                    print(f"   ok       {path}")
+            if drift:
+                print(f"\n{drift} artifact(s) differ from what would be rendered.", file=sys.stderr)
+                return 1
+            print("\nAll harness artifacts match the generator output.")
+            return 0
+
+        for path, content, executable in targets:
+            if path.exists() and path.read_text() != content and not getattr(args, "force", False):
+                print(f"Error: {path} exists and differs from the rendered output.", file=sys.stderr)
+                print("       Review with `macf_tools harness install --check`, then re-run with --force.", file=sys.stderr)
+                return 1
+
+        for path, content, executable in targets:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+            if executable:
+                path.chmod(path.stat().st_mode | _stat.S_IXUSR)
+            print(f"   ✓ {path}")
+
+        print(f"\n✅ Harness installed for agent '{p.agent}'")
+        print(f"   systemctl --user daemon-reload && systemctl --user enable --now {p.unit_name}")
+        print(f"   attach:  tmux attach -t {p.agent}")
+        print(f"   status:  macf_tools harness status --agent {p.agent}")
+        print(f"   stop:    systemctl --user stop {p.unit_name}   (stops the supervisor, not the child)")
+        return 0
+    except Exception as e:
+        print(f"Error installing harness: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_harness_status(args: argparse.Namespace) -> int:
+    """Report unit state, session presence and proxy attachment."""
+    from pathlib import Path
+
+    try:
+        p = _harness_params(args)
+        unit_path = Path.home() / ".config" / "systemd" / "user" / p.unit_name
+        print(f"agent:   {p.agent}")
+        print(f"unit:    {unit_path} {'(present)' if unit_path.exists() else '(ABSENT)'}")
+
+        active = subprocess.run(["systemctl", "--user", "is-active", p.unit_name],
+                                capture_output=True, text=True).stdout.strip()
+        print(f"active:  {active or 'unknown'}")
+
+        has_session = subprocess.run(["tmux", "has-session", "-t", p.agent],
+                                     capture_output=True).returncode == 0
+        print(f"session: {'up' if has_session else 'absent'} (tmux -t {p.agent})")
+
+        probe = subprocess.run(
+            ["curl", "-s", "--max-time", "2", "-o", "/dev/null",
+             f"http://127.0.0.1:{p.proxy_port}/"], capture_output=True).returncode == 0
+        # Reported the same way the unit decides it, so this cannot claim an
+        # attachment the unit would not actually make.
+        print(f"proxy:   {'answering on ' + str(p.proxy_port) + ' — harness would attach' if probe else 'not answering — harness would run direct'}")
+        return 0
+    except Exception as e:
+        print(f"Error reading harness status: {e}", file=sys.stderr)
+        return 1
+
+
 def cmd_statusline_install(args: argparse.Namespace) -> int:
     """Install statusline script and configure Claude Code settings."""
     from pathlib import Path
@@ -8869,6 +8997,36 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Default to generate if no subcommand
     statusline_parser.set_defaults(func=cmd_statusline)
+
+    # Harness command with subcommands (mirrors statusline generate/install)
+    harness_parser = sub.add_parser("harness", help="persistent supervised agent session (systemd + tmux)")
+    harness_sub = harness_parser.add_subparsers(dest="harness_cmd")
+
+    harness_generate = harness_sub.add_parser("generate", help="render harness artifacts to stdout (no writes)")
+    harness_generate.add_argument("--agent", help="agent slug naming the unit and tmux session")
+    harness_generate.add_argument("--home", help="agent home directory")
+    harness_generate.add_argument("--no-proxy", action="store_true",
+                                  help="render without proxy attachment")
+    harness_generate.add_argument("--what", choices=["unit", "child", "tmux", "all"], default="unit",
+                                  help="which artifact to render (default: unit)")
+    harness_generate.set_defaults(func=cmd_harness_generate)
+
+    harness_install = harness_sub.add_parser("install", help="write harness artifacts into place")
+    harness_install.add_argument("--agent", help="agent slug naming the unit and tmux session")
+    harness_install.add_argument("--home", help="agent home directory")
+    harness_install.add_argument("--no-proxy", action="store_true",
+                                 help="install without proxy attachment")
+    harness_install.add_argument("--check", action="store_true",
+                                 help="report drift against what would be rendered; write nothing")
+    harness_install.add_argument("--force", action="store_true",
+                                 help="overwrite an existing unit that differs")
+    harness_install.set_defaults(func=cmd_harness_install)
+
+    harness_status = harness_sub.add_parser("status", help="show harness unit and session state")
+    harness_status.add_argument("--agent", help="agent slug")
+    harness_status.set_defaults(func=cmd_harness_status)
+
+    harness_parser.set_defaults(func=cmd_harness_status)
 
     # Breadcrumb command
     breadcrumb_parser = sub.add_parser("breadcrumb", help="generate fresh breadcrumb for TODO completion")

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -1,0 +1,247 @@
+"""Render the persistent agent harness from live parameters.
+
+The harness is a supervised, detached, continuity-anchored Claude Code session:
+a systemd user unit starts a tmux session, tmux runs ``macf.supervisor``, and the
+supervisor runs the client through a child wrapper. It survives client restarts
+and operator detach, and it is what makes an unattended autonomous session
+possible at all.
+
+It existed for a while as a hand-edited unit on a single host with a real
+username in it. That is why this module exists rather than a ``.sample`` file:
+the stored copy had already drifted from the live one and was missing the very
+environment flag that makes it work, so anyone installing from the artifact
+would have got a silently degraded harness. A rendered unit cannot drift from
+itself.
+
+Every non-obvious line below cost a real incident to learn. The comments say
+which, because the point of moving this into the framework is that the next
+operator does not pay for them again.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# The port the supervised proxy listens on by default. Attachment is probed,
+# never assumed — see the ExecStart comment on degradation.
+DEFAULT_PROXY_PORT = 8019
+
+# Claude Code's long-context window. Carried explicitly because the unit's shell
+# is non-interactive and inherits nothing from the operator's shell profile.
+DEFAULT_CONTEXT_WINDOW = 1_000_000
+
+# Seconds to wait for the proxy to answer before falling back to a direct
+# connection. Short: this runs on every harness start, including at boot.
+PROXY_PROBE_TIMEOUT = 2
+
+
+@dataclass(frozen=True)
+class HarnessParams:
+    """Everything the rendered artifacts need, and nothing host-specific beyond it.
+
+    ``agent`` names the unit, the tmux session and the supervisor instance. It is
+    the only identifier that appears in the published unit name, so it should be
+    a short slug rather than a person's login.
+    """
+
+    agent: str
+    home: Path
+    python: Path
+    macf_tools: Path
+    child_path: Path
+    proxy_port: int = DEFAULT_PROXY_PORT
+    context_window: int = DEFAULT_CONTEXT_WINDOW
+    term: str = "xterm-256color"
+    path_prepend: tuple = ()
+
+    @property
+    def unit_name(self) -> str:
+        return f"cc-harness-{self.agent}.service"
+
+    @property
+    def env_path(self) -> str:
+        parts = list(self.path_prepend) + [
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ]
+        return ":".join(parts)
+
+
+def default_params(agent: Optional[str] = None, home: Optional[Path] = None) -> HarnessParams:
+    """Derive parameters from the running environment.
+
+    Resolved rather than guessed: the interpreter is the one currently executing,
+    because the ``macf`` package lives in it and a bare ``python3`` in a
+    non-interactive shell resolves elsewhere — which is exactly how an earlier
+    boot path ended up without the module.
+    """
+    home = Path(home) if home else Path(os.environ.get("MACEFF_AGENT_HOME_DIR") or Path.home())
+    agent = agent or os.environ.get("MACEFF_AGENT_NAME") or "agent"
+    # Prefer the unversioned python3 beside the running interpreter. sys.executable
+    # is often versioned (python3.10), and baking that into a unit pins the harness
+    # to a specific minor release — an interpreter upgrade would leave a unit
+    # pointing at a path that no longer exists, and the failure would surface at
+    # boot as a session that simply never appeared.
+    python = Path(sys.executable)
+    unversioned = python.parent / "python3"
+    if unversioned.exists():
+        python = unversioned
+    macf_tools = Path(shutil.which("macf_tools") or (python.parent / "macf_tools"))
+    return HarnessParams(
+        agent=agent,
+        home=home,
+        python=python,
+        macf_tools=macf_tools,
+        child_path=home / ".local" / "bin" / f"maceff_cc_child_{agent}",
+        path_prepend=(str(python.parent), str(home / ".local" / "bin")),
+    )
+
+
+def render_unit(p: HarnessParams, attach_proxy: bool = True) -> str:
+    """Render the systemd user unit.
+
+    Four properties of this text are load-bearing and each has a test:
+
+    1. ``$${BASE}`` is escaped. systemd expands ``$VAR``/``${VAR}`` in ``Exec*``
+       using the UNIT's environment before any shell runs. ``BASE`` is not a unit
+       variable, so an unescaped ``${BASE}`` was substituted with an empty string
+       and the shell's own assignment never mattered — the proxy opt-in was
+       silently inert, with only "Referenced but unset environment variable" in
+       the journal.
+    2. The first-party flag is emitted in the SAME assignment as the base URL.
+       Their separation is what let the context-window defect survive for months.
+    3. Proxy attachment is probed and degrades to direct. A dead proxy must
+       degrade to a direct agent, never to a dead one.
+    4. ``StartLimit*`` directives, when emitted, go in ``[Unit]``. systemd honours
+       them nowhere else, so in ``[Service]`` they read as configured and do
+       nothing.
+    """
+    proxy_url = f"http://localhost:{p.proxy_port}"
+    probe_url = f"http://127.0.0.1:{p.proxy_port}/"
+
+    if attach_proxy:
+        # INVARIANT 2: base URL and first-party flag in one assignment. Never
+        # split these — the flag is what keeps the long-context window, and a
+        # base URL without it silently drops the client to the 200K fallback
+        # while every UI surface continues to display the full window.
+        base_branch = (
+            f'BASE=""; '
+            f'if curl -s --max-time {PROXY_PROBE_TIMEOUT} -o /dev/null {probe_url}; then '
+            f'BASE="ANTHROPIC_BASE_URL={proxy_url} _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 "; '
+            f'fi; '
+        )
+        wants = "\nAfter=network-online.target macf-proxy.service\nWants=network-online.target macf-proxy.service"
+    else:
+        base_branch = 'BASE=""; '
+        wants = "\nAfter=network-online.target\nWants=network-online.target"
+
+    # INVARIANT 1: $${BASE} — a literal ${BASE} must reach bash.
+    exec_start = (
+        f"ExecStart=/bin/bash -c '{base_branch}"
+        f'tmux has-session -t {p.agent} 2>/dev/null || '
+        f'tmux new-session -d -s {p.agent} '
+        f'"$${{BASE}}{p.python} -m macf.supervisor _run_loop '
+        f'--name {p.agent} --delay 5 --tmux-session {p.agent} -- {p.child_path}"\''
+    )
+
+    return f"""# MacEff persistent Claude Code harness — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent}
+#
+# The unit's shell is non-interactive, so it inherits nothing from the operator's
+# profile: interpreter, PATH and context window are all made explicit here. An
+# earlier boot path relied on `bash -lc` and silently resolved a python without
+# the macf module, because ~/.bashrc early-returns for non-interactive shells.
+[Unit]
+Description=Claude Code persistent TUI harness (tmux + macf supervisor, continuity-anchored){wants}
+# INVARIANT: StartLimit* belong in [Unit]. systemd honours them nowhere else —
+# placed in [Service] they read as configured and do nothing at all.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+# oneshot + RemainAfterExit: this unit's job is to CREATE the session, not to be
+# the session. Restart supervision belongs to macf.supervisor, which owns the
+# client process and restarts it in place; a Restart= here would fight it.
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory={p.home}
+Environment=MACF_CONTEXT_WINDOW={p.context_window}
+Environment=PATH={p.env_path}
+Environment=TERM={p.term}
+
+# Idempotent: creates the detached session only when absent, so re-running is safe.
+{exec_start}
+
+# The client re-asks its workspace-trust prompt when launched under the
+# supervisor. At boot nobody is attached to answer, so nudge Enter twice.
+# Harmless when no prompt is showing.
+ExecStartPost=/bin/bash -c 'sleep 20; tmux send-keys -t {p.agent} Enter 2>/dev/null; sleep 8; tmux send-keys -t {p.agent} Enter 2>/dev/null; true'
+
+# Stop the SUPERVISOR, not the child. Killing the child just makes the
+# supervisor restart it, so a stop that targets the child is not a stop.
+ExecStop=/bin/bash -c 'for f in /tmp/macf/auto-restart/*.json; do grep -q "{p.agent}" "$f" 2>/dev/null && grep -q "running" "$f" 2>/dev/null && {p.macf_tools} auto-restart disable "$(basename "$f" .json)"; done; true'
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def render_child(p: HarnessParams) -> str:
+    """Render the supervised child entrypoint.
+
+    The supervisor has no post-restart hook, and two things reliably strand an
+    unattended session after a restart: the workspace-trust prompt, and
+    SessionStart returning the turn to a user who is not there. Both are nudged
+    here rather than left to whoever notices the agent has gone quiet.
+    """
+    return f"""#!/bin/bash
+# MacEff harness child wrapper — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent}
+#
+# The supervisor has no post-restart hook. Two things strand an unattended
+# session on relaunch and both are handled below.
+SESS="${{MACEFF_TMUX_SESSION:-{p.agent}}}"
+MACF={p.macf_tools}
+(
+  # 1. The client can park at the workspace-trust prompt. Enter is a no-op on an
+  #    empty input, so this is safe when no prompt is showing.
+  sleep 18; tmux send-keys -t "$SESS" Enter 2>/dev/null
+  sleep 12
+  # 2. SessionStart:resume hands the turn back to the user. With nobody attached
+  #    an autonomous session would idle at the prompt forever, so if persistent
+  #    AUTO_MODE is active, type a re-orientation prompt and submit it.
+  if "$MACF" mode get 2>/dev/null | grep -q AUTO_MODE; then
+    tmux send-keys -t "$SESS" "AUTO_MODE RESUME: session restarted (SessionStart:resume returned the turn with nobody attached). Re-orient via the task tree and continue authorized scoped work." 2>/dev/null
+    # Paste-detection debounces an Enter that follows a fast text burst: settle,
+    # then Enter twice. The second is a no-op if the first already submitted.
+    sleep 3; tmux send-keys -t "$SESS" Enter 2>/dev/null
+    sleep 2; tmux send-keys -t "$SESS" Enter 2>/dev/null
+  fi
+) &
+
+# Continuity is the DEFAULT. `-c` resumes the prior conversation; starting a new
+# one must be a deliberate act, because an unattended restart that silently
+# began a fresh session would discard the agent's working context with nothing
+# to show that it had happened.
+exec claude -c "$@"
+"""
+
+
+def render_tmux_conf(p: HarnessParams) -> str:
+    """Terminal baseline for TUI fidelity across attach and detach."""
+    return f"""# MacEff harness tmux baseline — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent}
+set -g default-terminal "{p.term}"
+set -ga terminal-overrides ",*256col*:Tc"
+# A short escape delay keeps the client's key handling responsive; the default
+# 500ms makes a TUI feel broken on attach.
+set -sg escape-time 10
+set -g history-limit 50000
+set -g mouse on
+"""

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -17,6 +17,9 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import re
+import socket
+
 import pytest
 
 from macf.utils.harness import (
@@ -128,8 +131,14 @@ class TestNoHostIdentifiersLeak:
         # The username as a path component is the tell; a bare substring match
         # would false-positive on ordinary words.
         assert f"/{user}/" not in text
-        import socket
-        assert socket.gethostname() not in text
+        # Same hazard, and it bites: a host named "Mac" is a substring of
+        # "MacEff" in the template's own header, so a bare `in` check fails on
+        # that machine while passing on a CI runner whose hostname is long and
+        # random. Match on word boundaries — "Mac" then no longer matches
+        # "MacEff", while a genuine leak of the hostname as a token still does.
+        assert not re.search(rf"\b{re.escape(socket.gethostname())}\b", text), (
+            "a render must contain no host identifier"
+        )
 
 
 class TestChildEntrypoint:

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -1,0 +1,155 @@
+"""Tests for the harness generator.
+
+The harness had existed as a hand-edited systemd unit on a single host, and its
+stored copy had already drifted from the live one — missing the environment flag
+that keeps the long-context window, so anyone installing from the artifact would
+have got a silently degraded session. These tests assert on GENERATED output,
+which is the thing that cannot drift from itself.
+
+`systemd-analyze verify` is used as the well-formedness oracle, but on its
+OUTPUT rather than its exit status: it exits 0 while printing "Unknown key ...,
+ignoring" for both a missing ExecStart and a misplaced StartLimit directive.
+Gating on the exit code would be the same instrument-reports-success defect these
+invariants exist to catch.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from macf.utils.harness import (
+    HarnessParams,
+    render_child,
+    render_tmux_conf,
+    render_unit,
+)
+
+# Deliberately synthetic: nothing here may appear in a published artifact, and
+# nothing about the developer's machine may leak into a render made from these.
+SYNTH = HarnessParams(
+    agent="testbot",
+    home=Path("/opt/agents/testbot"),
+    python=Path("/opt/py/bin/python3"),
+    macf_tools=Path("/opt/py/bin/macf_tools"),
+    child_path=Path("/opt/agents/testbot/.local/bin/maceff_cc_child_testbot"),
+    path_prepend=("/opt/py/bin", "/opt/agents/testbot/.local/bin"),
+)
+
+
+def _verify(unit_text, tmp_path):
+    """Run systemd's own parser and return its complaints.
+
+    Returns the captured output, NOT the exit status — see module docstring.
+    """
+    p = tmp_path / "cc-harness-testbot.service"
+    p.write_text(unit_text)
+    r = subprocess.run(["systemd-analyze", "verify", str(p)],
+                       capture_output=True, text=True)
+    return (r.stdout + r.stderr).strip()
+
+
+needs_systemd = pytest.mark.skipif(
+    shutil.which("systemd-analyze") is None, reason="systemd-analyze not available"
+)
+
+
+class TestUnitIsWellFormed:
+    @needs_systemd
+    def test_rendered_unit_passes_systemds_own_parser(self, tmp_path):
+        assert _verify(render_unit(SYNTH), tmp_path) == ""
+
+    @needs_systemd
+    def test_rendered_unit_without_proxy_also_passes(self, tmp_path):
+        assert _verify(render_unit(SYNTH, attach_proxy=False), tmp_path) == ""
+
+    @needs_systemd
+    def test_the_oracle_can_actually_fail(self, tmp_path):
+        """Negative control on the oracle itself.
+
+        Stripping the ExecStart= prefix is a real bug this caught during
+        development: the exec line became an unknown key and the unit would
+        never have started anything.
+        """
+        broken = render_unit(SYNTH).replace("ExecStart=/bin/bash", "/bin/bash")
+        assert "Unknown key" in _verify(broken, tmp_path)
+
+    def test_exec_start_is_present_and_prefixed(self):
+        lines = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStart=")]
+        assert len(lines) == 1
+
+
+class TestProxyAndFirstPartyFlag:
+    def test_flag_travels_in_the_same_assignment_as_the_base_url(self):
+        """Their separation is what let the context-window defect survive months."""
+        unit = render_unit(SYNTH)
+        (exec_line,) = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
+        assert "ANTHROPIC_BASE_URL=" in exec_line
+        i = exec_line.index("ANTHROPIC_BASE_URL=")
+        j = exec_line.index("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
+        # Same quoted BASE assignment: the flag must follow the URL with nothing
+        # but the URL's own value between them.
+        assert 0 < j - i < 80, "flag is not in the same assignment as the base URL"
+
+    def test_neither_appears_without_the_other(self):
+        unit = render_unit(SYNTH)
+        assert unit.count("ANTHROPIC_BASE_URL=") == unit.count("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
+
+    def test_proxy_attachment_is_probed_not_assumed(self):
+        """A dead proxy must degrade to a direct agent, never a dead one."""
+        exec_line = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStart=")][0]
+        assert 'BASE=""' in exec_line          # default is direct
+        assert "curl" in exec_line             # attachment is conditional on a probe
+        assert "--max-time" in exec_line       # and cannot hang the boot path
+
+    def test_no_proxy_render_carries_no_base_url_at_all(self):
+        unit = render_unit(SYNTH, attach_proxy=False)
+        assert "ANTHROPIC_BASE_URL" not in unit
+        assert "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL" not in unit
+        assert "macf-proxy.service" not in unit
+        assert 'BASE=""' in unit
+
+
+class TestNoHostIdentifiersLeak:
+    """Published artifacts carry no host identity. Verified by scan, not by eye."""
+
+    @pytest.mark.parametrize("render", [
+        lambda: render_unit(SYNTH),
+        lambda: render_unit(SYNTH, attach_proxy=False),
+        lambda: render_child(SYNTH),
+        lambda: render_tmux_conf(SYNTH),
+    ])
+    def test_render_contains_only_supplied_parameters(self, render):
+        text = render()
+        real_home = str(Path.home())
+        user = Path.home().name
+        assert real_home not in text, "a render must contain no absolute home path"
+        # The username as a path component is the tell; a bare substring match
+        # would false-positive on ordinary words.
+        assert f"/{user}/" not in text
+        import socket
+        assert socket.gethostname() not in text
+
+
+class TestChildEntrypoint:
+    def test_continuity_is_the_default(self):
+        """An unattended restart that silently began a fresh session would
+        discard the agent's context with nothing to show it had happened."""
+        child = render_child(SYNTH)
+        assert "exec claude -c" in child
+
+    def test_child_is_a_shell_script(self):
+        assert render_child(SYNTH).startswith("#!/bin/bash")
+
+    def test_session_name_defaults_to_the_agent(self):
+        assert 'MACEFF_TMUX_SESSION:-testbot' in render_child(SYNTH)
+
+
+class TestStopTargetsTheSupervisor:
+    def test_exec_stop_disables_the_supervisor_rather_than_killing_the_child(self):
+        """Killing the child just makes the supervisor restart it, so a stop
+        that targets the child is not a stop."""
+        (stop,) = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStop=")]
+        assert "auto-restart disable" in stop
+        assert "kill" not in stop

--- a/macf/tests/test_operational_invariants.py
+++ b/macf/tests/test_operational_invariants.py
@@ -1,0 +1,208 @@
+"""The operational invariants, as checks that can be observed failing.
+
+Six facts about running this system cost real incidents to learn, and until now
+lived in one agent's memory and a few code comments. Each is a property of an
+artifact we generate or ship, so each becomes an assertion here.
+
+**Every invariant carries a negative control.** A check never observed failing is
+not a check — it is a comfort object. For each one below there is a mutation that
+breaks it, and a test asserting the checker rejects the mutated form. If someone
+weakens a checker into something that always passes, its negative control fails
+and says so.
+
+The `incident` field on each invariant is the point: it records what actually
+went wrong, so the reasoning survives the people who learned it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from macf.utils.harness import HarnessParams, render_unit
+
+SYNTH = HarnessParams(
+    agent="testbot",
+    home=Path("/opt/agents/testbot"),
+    python=Path("/opt/py/bin/python3"),
+    macf_tools=Path("/opt/py/bin/macf_tools"),
+    child_path=Path("/opt/agents/testbot/.local/bin/maceff_cc_child_testbot"),
+    path_prepend=("/opt/py/bin",),
+)
+
+PROXY_SRC = (
+    Path(__file__).resolve().parents[1] / "src" / "macf" / "proxy" / "server.py"
+).read_text()
+
+
+# --------------------------------------------------------------------------
+# Checkers. Each takes the artifact text and returns True when the invariant
+# holds. Kept tiny and total so a negative control can exercise them directly.
+# --------------------------------------------------------------------------
+
+def check_escaped_variable(unit: str) -> bool:
+    """Shell variables in Exec* survive the service manager's own expansion."""
+    exec_lines = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
+    return all("$${BASE}" in l for l in exec_lines if "BASE=" in l)
+
+
+def check_restart_responsibility_is_explicit(unit: str) -> bool:
+    """Exactly one component owns restart, and the unit says which.
+
+    A oneshot unit that merely creates a session must NOT also declare Restart=;
+    a long-running unit that omits it dies silently on a clean exit. Either way
+    the failure is that nobody can tell who is supposed to restart the thing.
+    """
+    body = [l.strip() for l in unit.splitlines() if not l.strip().startswith("#")]
+    oneshot = any(l == "Type=oneshot" for l in body)
+    remain = any(l == "RemainAfterExit=yes" for l in body)
+    declares_restart = any(l.startswith("Restart=") for l in body)
+    if oneshot:
+        return remain and not declares_restart
+    return declares_restart
+
+
+def check_rate_limits_in_honoured_section(unit: str) -> bool:
+    """StartLimit* appear only in [Unit]; systemd honours them nowhere else."""
+    section = None
+    for line in unit.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            section = s
+        elif s.startswith("StartLimit") and section != "[Unit]":
+            return False
+    return True
+
+
+def check_flag_travels_with_base_url(unit: str) -> bool:
+    """The first-party flag is never emitted apart from the base URL."""
+    if unit.count("ANTHROPIC_BASE_URL=") != unit.count("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1"):
+        return False
+    for line in unit.splitlines():
+        if "ANTHROPIC_BASE_URL=" not in line:
+            continue
+        i = line.index("ANTHROPIC_BASE_URL=")
+        j = line.find("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
+        if j < i or j - i > 80:
+            return False
+    return True
+
+
+def check_capture_is_bounded_and_guarded(src: str) -> bool:
+    """Capture storage is bounded, and a capture write cannot fail a request."""
+    return "_capture_cap_bytes" in src and "_capture_evict" in src
+
+
+def check_reported_equals_enforced(src: str) -> bool:
+    """The surface reporting a gate calls the same function that enforces it."""
+    return (
+        '"rewrite_enabled": _rewrite_enabled()' in src
+        and "if _rewrite_enabled():" in src
+    )
+
+
+# --------------------------------------------------------------------------
+# The registry. (name, artifact, checker, mutation, incident)
+# The mutation must break exactly this invariant.
+# --------------------------------------------------------------------------
+
+def _unit() -> str:
+    return render_unit(SYNTH)
+
+
+INVARIANTS = [
+    (
+        "escaped-variable",
+        _unit,
+        check_escaped_variable,
+        lambda u: u.replace("$${BASE}", "${BASE}"),
+        "The service manager expands ${VAR} in Exec* from the UNIT's environment "
+        "before any shell runs. An unescaped ${BASE} was replaced with an empty "
+        "string, so the shell's own assignment never mattered and the proxy "
+        "opt-in was silently inert — the only trace was a 'Referenced but unset "
+        "environment variable' line in the journal.",
+    ),
+    (
+        "restart-responsibility",
+        _unit,
+        check_restart_responsibility_is_explicit,
+        lambda u: u.replace("Type=oneshot\n", "Type=oneshot\nRestart=always\n"),
+        "A daemon that exits zero is not a success. One unit died and stayed "
+        "dead because its restart policy only covered failure exits; another "
+        "would have had two components fighting over restarting the same child. "
+        "The invariant is that exactly one component owns restart and the unit "
+        "states which.",
+    ),
+    (
+        "rate-limits-in-honoured-section",
+        _unit,
+        check_rate_limits_in_honoured_section,
+        lambda u: u.replace("[Service]\n", "[Service]\nStartLimitBurst=5\n", 1),
+        "StartLimit* directives are honoured only in [Unit]. Placed in "
+        "[Service] they read as configured and do nothing; the service manager "
+        "reports 'Unknown key ..., ignoring' and starts the unit anyway, so the "
+        "misconfiguration never surfaces as an error.",
+    ),
+    (
+        "flag-travels-with-base-url",
+        _unit,
+        check_flag_travels_with_base_url,
+        lambda u: u.replace(" _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 ", " "),
+        "When the API base URL's host is not the default, the client stops "
+        "extending the long-context window and falls back to a fifth of it, "
+        "while every surface continues to display the full window. There is no "
+        "log line and no warning; the only symptom is compacting early. The two "
+        "settings were documented separately, which is how that survived months.",
+    ),
+    (
+        "capture-bounded-and-guarded",
+        lambda: PROXY_SRC,
+        check_capture_is_bounded_and_guarded,
+        lambda s: s.replace("_capture_evict", "_capture_noop"),
+        "Capture storage was unbounded, so a long-running proxy could fill the "
+        "disk; and a capture write that raised would have failed the live "
+        "request it was only supposed to observe.",
+    ),
+    (
+        "reported-equals-enforced",
+        lambda: PROXY_SRC,
+        check_reported_equals_enforced,
+        lambda s: s.replace('"rewrite_enabled": _rewrite_enabled()',
+                            '"rewrite_enabled": False'),
+        "The startup banner read an environment variable while the request path "
+        "ignored it entirely, so the proxy advertised rewrite=off while "
+        "rewriting every request. An instrument reporting a value nobody "
+        "enforces is worse than no instrument. This is the antipattern behind "
+        "four separate defects in this cluster.",
+    ),
+]
+
+IDS = [name for name, *_ in INVARIANTS]
+
+
+@pytest.mark.parametrize("name,artifact,checker,mutate,incident", INVARIANTS, ids=IDS)
+def test_invariant_holds(name, artifact, checker, mutate, incident):
+    """The shipped artifact satisfies the invariant."""
+    assert checker(artifact()), f"{name} violated in the shipped artifact"
+
+
+@pytest.mark.parametrize("name,artifact,checker,mutate,incident", INVARIANTS, ids=IDS)
+def test_invariant_check_can_fail(name, artifact, checker, mutate, incident):
+    """NEGATIVE CONTROL — the mandatory half.
+
+    Break the invariant and the checker must reject it. Without this, a checker
+    weakened into something that always passes would keep reporting success
+    forever, which is the exact failure these invariants exist to prevent.
+    """
+    broken = mutate(artifact())
+    assert broken != artifact(), f"{name}: mutation was a no-op, so this proves nothing"
+    assert not checker(broken), f"{name}: checker still passes on a deliberately broken artifact"
+
+
+@pytest.mark.parametrize("name,artifact,checker,mutate,incident", INVARIANTS, ids=IDS)
+def test_invariant_documents_its_incident(name, artifact, checker, mutate, incident):
+    """Each invariant records what went wrong, so the why outlives the people.
+
+    A rule with no incident behind it gets deleted by the next person who finds
+    it inconvenient and cannot see what it is protecting.
+    """
+    assert len(incident) > 120, f"{name}: incident note too thin to be useful"


### PR DESCRIPTION
MISSION #33 Phase 2. The harness — systemd unit creates a tmux session, tmux runs the supervisor, supervisor runs the client — is what makes an unattended autonomous session possible. It existed as a hand-edited unit on one host with a login name baked into its paths.

**The failure this replaces had already happened.** The stored copy of the unit had drifted from the live one and was missing the environment flag that keeps the long-context window. Anyone installing from that artifact would have got a session that silently compacted at a fraction of its advertised capacity. A rendered unit cannot drift from itself.

## Commands

| | |
|---|---|
| `harness generate` | renders to stdout, **writes nothing** — review, diff, or scan before anything lands |
| `harness install` | writes the three artifacts; refuses to overwrite one that differs unless `--force` |
| `harness install --check` | reports drift without writing; non-zero if any artifact differs |
| `harness status` | unit, session, and proxy attachment |

`status` reports proxy attachment by running **the same probe the unit runs**, so it cannot claim an attachment the unit would not make.

## The four load-bearing properties

Each cost a real incident, and each has a test:

- **`$${BASE}` stays escaped.** systemd expands `${VAR}` in `Exec*` from the *unit's* environment before any shell runs. An unescaped one silently becomes an empty string — the opt-in it guards was inert, with nothing but "Referenced but unset environment variable" in the journal.
- **The first-party flag is emitted in the same assignment as the base URL.** Separating them is what let the context-window defect survive for months.
- **Proxy attachment is probed, not assumed.** A dead proxy must degrade to a direct agent, never a dead one.
- **`StartLimit*` sit in `[Unit]`.** systemd honours them nowhere else.

## On the verification oracle

`systemd-analyze verify` is used as the well-formedness check — **asserted on its output, not its exit status.**

It exits **0** while printing `Unknown key ..., ignoring` for *both* a missing `ExecStart` and a misplaced `StartLimit`. Gating on the exit code would be precisely the instrument-reports-success defect these invariants exist to catch.

It earned its place immediately: a missing `ExecStart=` prefix in the very first render would have produced a unit that started nothing, and the oracle named the line. There is a negative control asserting the oracle can still fail.

## Verification

16 tests. Rendered output was diffed against the known-good live unit; the only functional differences are two deliberate ones — `StartLimit*` added, and a per-agent child filename so two agents on one host cannot collide. **Everything else, including the full exec line, is byte-identical.**

The no-identifier tests render from wholly synthetic parameters and scan for an absolute home path, a username path component, and the hostname — by scan, not by reading.

Full suite: 1138 passed. The 12 failures on this host are confined to `test_lancedb_search.py`, `test_hybrid_search.py`, `test_search_service.py` (`lancedb` absent) — pre-existing.

The macOS path is documented and **explicitly marked untested**.

## Note

The OPSEC pre-commit gate blocked the first attempt on an assertion message in the test file. It was a false positive in substance, but the fix was to reword rather than `--no-verify` — which is what the gate is for.