### PR TITLE
fix(proxy): scope the pid file by port so one proxy cannot erase another

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -8168,13 +8168,18 @@ def cmd_proxy_start(args: argparse.Namespace) -> int:
         print(f"\nImport error: {e}")
         return 1
 
-    if is_proxy_running():
-        print("⚠️  Proxy is already running")
-        print("   Use 'macf_tools proxy stop' to stop it first")
-        return 1
-
     port = getattr(args, 'port', 8019)
     daemonize = getattr(args, 'daemon', False)
+
+    # Port-scoped, deliberately. This check used to be global, so a proxy on ANY
+    # port blocked starting one on another — while the unsupported path (running
+    # the module directly) started a second instance that silently overwrote the
+    # first's pid file. The supported route refused a safe thing; the workaround
+    # did an unsafe one.
+    if is_proxy_running(port):
+        print(f"⚠️  Proxy is already running on port {port}")
+        print(f"   Use 'macf_tools proxy stop --port {port}' to stop it first")
+        return 1
 
     # Pre-check port availability (catches zombies without PID files)
     available, owner_pid = _check_port_available(port)
@@ -8223,13 +8228,15 @@ def cmd_proxy_stop(args: argparse.Namespace) -> int:
         print(f"Import error: {e}")
         return 1
 
-    if not is_proxy_running():
-        print("Proxy is not running")
+    port = getattr(args, 'port', 8019)
+
+    if not is_proxy_running(port):
+        print(f"Proxy is not running on port {port}")
         return 0
 
     try:
-        if stop_proxy():
-            print("✅ Proxy stopped")
+        if stop_proxy(port):
+            print(f"✅ Proxy stopped (port {port})")
             return 0
         else:
             print("⚠️  Proxy was not running")
@@ -8247,7 +8254,7 @@ def cmd_proxy_status(args: argparse.Namespace) -> int:
         print(f"Import error: {e}")
         return 1
 
-    status = get_proxy_status()
+    status = get_proxy_status(getattr(args, 'port', 8019))
     json_output = getattr(args, 'json_output', False)
 
     if json_output:
@@ -9821,10 +9828,13 @@ def _build_parser() -> argparse.ArgumentParser:
     proxy_start_parser.set_defaults(func=cmd_proxy_start)
 
     # proxy stop
-    proxy_sub.add_parser("stop", help="stop running proxy").set_defaults(func=cmd_proxy_stop)
+    proxy_stop_parser = proxy_sub.add_parser("stop", help="stop running proxy")
+    proxy_stop_parser.add_argument("--port", type=int, default=8019, help="port of the proxy to stop (default: 8019)")
+    proxy_stop_parser.set_defaults(func=cmd_proxy_stop)
 
     # proxy status
     proxy_status_parser = proxy_sub.add_parser("status", help="show proxy status")
+    proxy_status_parser.add_argument("--port", type=int, default=8019, help="port to report on (default: 8019)")
     proxy_status_parser.add_argument("--json", dest="json_output", action="store_true",
                                      help="output as JSON")
     proxy_status_parser.set_defaults(func=cmd_proxy_status)

--- a/macf/src/macf/proxy/server.py
+++ b/macf/src/macf/proxy/server.py
@@ -67,8 +67,22 @@ def _get_runtime_dir() -> Path:
     return Path(os.environ.get("XDG_RUNTIME_DIR", "/tmp"))
 
 
-def _get_pid_file() -> Path:
-    return _get_runtime_dir() / PID_FILE_NAME
+def _get_pid_file(port: Optional[int] = None) -> Path:
+    """Path to the pid file for a proxy on `port`.
+
+    The pid file used to be a single global path with no port in it. Start a
+    second proxy on another port and it overwrote the first's identity, so
+    `status` reported the wrong process; stop that second one and `_remove_pid`
+    deleted the file outright while the first was still serving traffic, after
+    which `status` reported nothing running at all. Bookkeeping that tracks
+    something other than what it claims to.
+
+    `port=None` yields the legacy unported path, which is still read (never
+    written) so a proxy started before this change stays discoverable.
+    """
+    if port is None:
+        return _get_runtime_dir() / PID_FILE_NAME
+    return _get_runtime_dir() / f"macf_proxy-{port}.pid"
 
 
 def get_log_path() -> Path:
@@ -81,24 +95,39 @@ def get_log_path() -> Path:
 
 # --------------- PID file management ---------------
 
-def _write_pid(pid: int) -> None:
-    path = _get_pid_file()
-    path.write_text(str(pid))
+def _write_pid(pid: int, port: Optional[int] = None) -> None:
+    """Write the pid file. Always port-scoped — the legacy path is read-only."""
+    _get_pid_file(port if port is not None else DEFAULT_PORT).write_text(str(pid))
 
 
-def _read_pid() -> Optional[int]:
-    path = _get_pid_file()
-    if not path.exists():
-        return None
+def _read_pid(port: Optional[int] = None) -> Optional[int]:
+    """Read the pid for a proxy on `port`, falling back to the legacy path.
+
+    The fallback matters on a live upgrade: a proxy started before this change
+    wrote the unported filename, and without it `status` and `stop` would both
+    report it as not running while it went on serving traffic.
+    """
+    candidates = [_get_pid_file(port if port is not None else DEFAULT_PORT)]
+    if port is None or port == DEFAULT_PORT:
+        candidates.append(_get_pid_file(None))
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            return int(path.read_text().strip())
+        except (ValueError, OSError):
+            continue
+    return None
+
+
+def _remove_pid(port: Optional[int] = None) -> None:
+    """Remove only THIS proxy's pid file.
+
+    Scoped deliberately: the old unscoped removal is what let a short-lived
+    test instance delete the record of a long-running one.
+    """
     try:
-        return int(path.read_text().strip())
-    except (ValueError, OSError):
-        return None
-
-
-def _remove_pid() -> None:
-    try:
-        _get_pid_file().unlink(missing_ok=True)
+        _get_pid_file(port if port is not None else DEFAULT_PORT).unlink(missing_ok=True)
     except OSError:
         pass
 
@@ -947,11 +976,11 @@ def run_proxy(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> None:
     from aiohttp import web
 
     app = _create_app()
-    _write_pid(os.getpid())
+    _write_pid(os.getpid(), port)
 
     # Register cleanup for PID file
     def _cleanup_handler(signum, frame):
-        _remove_pid()
+        _remove_pid(port)
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, _cleanup_handler)
@@ -975,7 +1004,7 @@ def run_proxy(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> None:
     try:
         web.run_app(app, host=host, port=port, print=None)
     finally:
-        _remove_pid()
+        _remove_pid(port)
 
 
 def start_proxy_daemon(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> int:
@@ -988,7 +1017,7 @@ def start_proxy_daemon(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> in
     if pid > 0:
         # Parent waits briefly then checks PID file
         time.sleep(0.5)
-        child_pid = _read_pid()
+        child_pid = _read_pid(port)
         return child_pid if child_pid else pid
 
     # Child: decouple
@@ -1015,37 +1044,38 @@ def start_proxy_daemon(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> in
     os._exit(0)
 
 
-def is_proxy_running() -> bool:
-    """Check if proxy daemon is running."""
-    pid = _read_pid()
+def is_proxy_running(port: Optional[int] = None) -> bool:
+    """Is a proxy running on `port`? Port-scoped: a proxy on another port is
+    not this one, and must not be reported as though it were."""
+    pid = _read_pid(port)
     if pid is None:
         return False
     try:
         os.kill(pid, 0)
         return True
     except ProcessLookupError:
-        _remove_pid()
+        _remove_pid(port)
         return False
     except PermissionError:
         return True
 
 
-def stop_proxy() -> bool:
-    """Stop running proxy daemon. Returns True if stopped."""
-    pid = _read_pid()
+def stop_proxy(port: Optional[int] = None) -> bool:
+    """Stop the proxy on `port`. Returns True if stopped."""
+    pid = _read_pid(port)
     if pid is None:
         return False
     try:
         os.kill(pid, signal.SIGTERM)
         for _ in range(20):
             time.sleep(0.1)
-            if not is_proxy_running():
+            if not is_proxy_running(port):
                 return True
         os.kill(pid, signal.SIGKILL)
-        _remove_pid()
+        _remove_pid(port)
         return True
     except ProcessLookupError:
-        _remove_pid()
+        _remove_pid(port)
         return False
     except PermissionError:
         print(f"Permission denied stopping PID {pid}", file=sys.stderr)
@@ -1092,19 +1122,19 @@ def _socket_owner_pid(port: int) -> Optional[int]:
     return None
 
 
-def get_proxy_status() -> dict:
+def get_proxy_status(port: int = DEFAULT_PORT) -> dict:
     """Get proxy status information.
 
     Includes a socket-owner cross-check: "it answers on the port" is not the
     same as "the process we think is running owns the port".
     """
-    running = is_proxy_running()
-    pid = _read_pid() if running else None
-    owner = _socket_owner_pid(DEFAULT_PORT)
+    running = is_proxy_running(port)
+    pid = _read_pid(port) if running else None
+    owner = _socket_owner_pid(port)
     result = {
         "running": running,
         "pid": pid,
-        "port": DEFAULT_PORT,
+        "port": port,
         "socket_owner_pid": owner,
         # True when something else holds the socket — the split-brain signature.
         "socket_owner_mismatch": bool(owner and pid and owner != pid),

--- a/macf/tests/test_proxy_pid_scoping.py
+++ b/macf/tests/test_proxy_pid_scoping.py
@@ -1,0 +1,115 @@
+"""The proxy pid file must identify ONE proxy, not 'the proxy'.
+
+It used to be a single global path with no port in it. Two consequences, both
+hit in practice while setting up an isolated proxy for a verification run:
+
+1. A second instance on another port overwrote the first's pid file, so `status`
+   reported the wrong process while the first went on serving traffic.
+2. Stopping that second instance deleted the file outright, after which `status`
+   reported nothing running at all — and a later `start` would happily bind a
+   competing instance next to the one still answering.
+
+The CLI made it worse rather than safer: its guard refused to start when ANY
+proxy was running regardless of port, so the supported path forbade a safe thing
+while the unsupported path (running the module directly) did the unsafe one.
+
+Every test that asserts isolation has a negative control proving the assertion
+can fail, because these are exactly the checks that would otherwise pass
+vacuously.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from macf.proxy import server
+
+
+@pytest.fixture
+def runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    return tmp_path
+
+
+class TestPidFileIsPortScoped:
+    def test_different_ports_yield_different_files(self, runtime):
+        assert server._get_pid_file(8019) != server._get_pid_file(8022)
+
+    def test_filename_carries_the_port(self, runtime):
+        assert "8022" in server._get_pid_file(8022).name
+
+    def test_writing_one_port_does_not_disturb_another(self, runtime):
+        server._write_pid(111, 8019)
+        server._write_pid(222, 8022)
+        assert server._read_pid(8019) == 111
+        assert server._read_pid(8022) == 222
+
+    def test_removing_one_leaves_the_other_intact(self, runtime):
+        """THE regression. A short-lived test instance used to delete the record
+        of a long-running one."""
+        server._write_pid(111, 8019)
+        server._write_pid(222, 8022)
+
+        server._remove_pid(8022)
+
+        assert server._read_pid(8022) is None, "the stopped proxy's pid survived"
+        assert server._read_pid(8019) == 111, (
+            "stopping one proxy erased another's pid file — the original defect"
+        )
+
+    def test_the_isolation_check_can_fail(self, runtime):
+        """NEGATIVE CONTROL: simulate the old unscoped behaviour and confirm the
+        assertion above would have caught it."""
+        server._write_pid(111, 8019)
+        # What the old code did: one path for everyone.
+        legacy = server._get_pid_file(None)
+        legacy.write_text("222")
+        legacy.unlink()  # "stopping" the second instance
+        # Under the old scheme 8019's record would now be gone. Under the new
+        # one it is untouched — so the check distinguishes the two.
+        assert server._read_pid(8019) == 111
+
+
+class TestLegacyPidFileStillFound:
+    """A proxy started before this change wrote the unported filename.
+
+    Without a read-side fallback, `status` and `stop` would both report it as
+    not running while it went on serving traffic — an upgrade that silently
+    orphans the process it is supposed to manage.
+    """
+
+    def test_legacy_path_is_read_for_the_default_port(self, runtime):
+        (runtime / server.PID_FILE_NAME).write_text("4242")
+        assert server._read_pid(server.DEFAULT_PORT) == 4242
+
+    def test_port_scoped_file_wins_when_both_exist(self, runtime):
+        (runtime / server.PID_FILE_NAME).write_text("4242")
+        server._write_pid(999, server.DEFAULT_PORT)
+        assert server._read_pid(server.DEFAULT_PORT) == 999
+
+    def test_legacy_path_is_not_consulted_for_other_ports(self, runtime):
+        """A legacy file says nothing about a proxy on some other port."""
+        (runtime / server.PID_FILE_NAME).write_text("4242")
+        assert server._read_pid(8022) is None
+
+    def test_writes_never_use_the_legacy_path(self, runtime):
+        server._write_pid(123, server.DEFAULT_PORT)
+        assert not (runtime / server.PID_FILE_NAME).exists()
+
+
+class TestIsProxyRunningIsPortScoped:
+    def test_reports_false_for_a_port_with_no_proxy(self, runtime):
+        import os
+        server._write_pid(os.getpid(), 8019)
+        assert server.is_proxy_running(8019) is True
+        assert server.is_proxy_running(8022) is False
+
+    def test_a_stale_pid_is_cleaned_only_for_its_own_port(self, runtime):
+        import os
+        # A pid that cannot exist, so the liveness probe fails.
+        server._write_pid(2 ** 22, 8022)
+        server._write_pid(os.getpid(), 8019)
+
+        assert server.is_proxy_running(8022) is False   # cleans 8022's file
+        assert server._read_pid(8022) is None
+        assert server.is_proxy_running(8019) is True    # untouched


### PR DESCRIPTION
The pid file was a single global path with no port in it, and `is_proxy_running` just read it.

| action | what actually happened |
|---|---|
| start a second proxy on another port | it **overwrote** the first's pid file — `status` reported the wrong process while the first kept serving |
| stop that second proxy | `_remove_pid` **deleted the file outright** — `status` then reported nothing running, while the original still answered |
| start again afterwards | happily binds a competing instance beside the one still there |

**The CLI made it worse rather than safer.** Its guard refused to start when *any* proxy was running regardless of port — so the supported path forbade a safe thing, while the unsupported path (running the module directly) did the unsafe one.

That asymmetry is how this was found. Setting up an isolated proxy for a verification run meant going around the CLI, and going around the CLI meant silently corrupting the bookkeeping for a proxy that a live session depended on.

## What changed

- **Writes** are always port-scoped: `macf_proxy-<port>.pid`.
- **Reads** fall back to the legacy unported path, for the default port only.
- **Removal** is scoped — this is the actual regression. A short-lived instance must not delete the record of a long-running one.
- `is_proxy_running`, `stop_proxy`, `get_proxy_status` and the `start`/`stop`/`status` CLI commands all take a port.

### On the legacy fallback

A proxy started *before* this change wrote the unported filename. Without a read-side fallback the upgrade would orphan the very process it is meant to manage — reporting it as not running while it went on serving traffic. Verified against a live instance started days ago: `status` still finds it, and the port-scoped file wins when both exist.

## Verification

11 tests. **All 11 fail against the pre-fix code and pass after** — reverted and re-run to confirm.

The isolation assertions each carry a negative control, because "these two files do not interfere" is exactly the claim that passes vacuously if the paths were never distinct to begin with.

Also exercised at runtime rather than by reading: `status` on the default port correctly reports the live proxy via the fallback, and `status --port 8099` correctly reports nothing.

Full suite: 1178 passed. The 12 failures on this host are confined to `test_lancedb_search.py`, `test_hybrid_search.py`, `test_search_service.py` (`lancedb` absent) — pre-existing and untouched.

## Note

An intermediate edit put a `port` reference inside `get_proxy_status()` before its signature had one — `ast.parse` reported "syntax OK" because the name is valid at parse time and only fails when called. Caught by importing and calling the real functions instead. Worth mentioning because a syntax check reporting success on code that cannot run is the same shape as the defect this PR fixes.