### PR TITLE
feat(agents): declarative account flavor, multi-key SSH, and vanilla purity

### DIFF
--- a/docker/scripts/start.py
+++ b/docker/scripts/start.py
@@ -215,6 +215,62 @@ def create_amail_tree(public: Path, username: str) -> Path:
     return amail
 
 
+# Every path here is installed by some MacEff provisioning step. A vanilla account
+# is defined as an account where none of them exist, so this tuple IS the
+# definition — when a new provisioning step is added, its artifact belongs here or
+# the definition has silently drifted.
+MACEFF_FOOTPRINT_PATHS = (
+    'agent',                    # CA trees, amail, task_archives, subagents
+    'CLAUDE.md',                # three-layer context (system PREAMBLE + identity + project)
+    '.maceff',                  # per-agent settings, auto-mode token, agent state
+    '.claude/commands',         # framework slash commands
+    '.claude/skills',           # framework skills
+    '.claude/output-styles',    # maceff-compliance and friends
+    '.claude/agents',           # subagent definitions
+)
+
+
+def vanilla_home_violations(home: Path) -> List[str]:
+    """Return every MacEff artifact found in a home that is supposed to have none.
+
+    An empty list means the account is genuinely vanilla. This exists as a callable
+    check rather than a comment because "we skip those steps" is a claim about
+    control flow, and control flow changes. Running it against the finished home
+    tests the property that actually matters — what is on disk.
+    """
+    violations: List[str] = []
+
+    for rel in MACEFF_FOOTPRINT_PATHS:
+        if (home / rel).exists():
+            violations.append(rel)
+
+    # Hooks are installed by editing settings.json rather than by adding a file, so
+    # their absence cannot be checked by path.
+    settings = home / '.claude' / 'settings.json'
+    if settings.exists():
+        try:
+            data = json.loads(settings.read_text())
+        except (json.JSONDecodeError, OSError):
+            data = {}
+        if data.get('hooks'):
+            violations.append('.claude/settings.json:hooks')
+        style = data.get('outputStyle')
+        if style and 'maceff' in str(style).lower():
+            violations.append(f'.claude/settings.json:outputStyle={style}')
+
+    # MACEFF_* variables are "special context" even though they are not files.
+    bash_init = home / '.bash_init.sh'
+    if bash_init.exists():
+        for line in bash_init.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            if 'MACEFF_' in stripped:
+                violations.append(f'.bash_init.sh:{stripped}')
+
+    return violations
+
+
 def create_pa_user(agent_name: str, agent_spec: AgentSpec, defaults_dict: Optional[Dict] = None) -> None:
     """Create Primary Agent Linux user."""
     username = agent_spec.username
@@ -235,15 +291,20 @@ def create_pa_user(agent_name: str, agent_spec: AgentSpec, defaults_dict: Option
     display_name = getattr(agent_spec, 'display_name', None)
     agent_uuid = provision_agent_identity(username, str(home_dir), display_name, agent_name)
 
-    # Install SSH key if present
-    install_ssh_key(username)
+    # Install every declared SSH key (falls back to /keys/{username}.pub when undeclared)
+    install_ssh_key(username, getattr(agent_spec, 'ssh_keys', None))
+
+    # Every account gets a mailbox, vanilla included — email is a capability, not
+    # a framework artifact.
+    create_maildir(username)
 
     # Create bash_init.sh (MUST come before configure_bashrc)
     # This is the single source of truth for PA environment setup
     channels = None
     if agent_spec.claude_config and agent_spec.claude_config.channels:
         channels = agent_spec.claude_config.channels
-    create_bash_init(username, agent_name, channels=channels)
+    create_bash_init(username, agent_name, channels=channels,
+                     vanilla=getattr(agent_spec, 'is_vanilla', False))
 
     # Configure .bashrc to source bash_init.sh
     configure_bashrc(username)
@@ -252,26 +313,108 @@ def create_pa_user(agent_name: str, agent_spec: AgentSpec, defaults_dict: Option
     configure_claude_settings(username, agent_name, agent_spec, defaults_dict)
 
 
-def install_ssh_key(username: str) -> None:
-    """Install SSH key for user if available."""
+KEY_LINE_PREFIXES = ('ssh-', 'ecdsa-', 'sk-ssh-', 'sk-ecdsa-')
+
+# Mounted read-only by compose. A module constant rather than a literal so tests can
+# point it at a fixture directory.
+KEYS_DIR = Path('/keys')
+
+# Root of agent home directories. Constant for the same reason as KEYS_DIR; new code
+# should prefer it over the '/home/{user}' literals that predate it.
+HOME_ROOT = Path('/home')
+
+
+def resolve_ssh_keys(username: str, ssh_keys: Optional[List[str]]) -> List[str]:
+    """Resolve declared key references into public key lines.
+
+    Each entry is either a literal public key line (recognised by its key-type
+    prefix) or a NAME resolved against /keys/{name}.pub. Returns the key lines in
+    declaration order.
+
+    When ssh_keys is None the legacy single-file lookup applies, so existing
+    deployments that never declared keys keep working unchanged.
+
+    Unresolvable named keys raise. The alternative — skipping them — produces an
+    account that looks provisioned and cannot be logged into, and the operator
+    discovers it only when authentication fails.
+    """
+    if ssh_keys is None:
+        legacy = KEYS_DIR / f'{username}.pub'
+        if not legacy.exists():
+            return []
+        return [legacy.read_text().strip()]
+
+    resolved: List[str] = []
+    missing: List[str] = []
+
+    for entry in ssh_keys:
+        entry = entry.strip()
+        if entry.startswith(KEY_LINE_PREFIXES):
+            resolved.append(entry)
+            continue
+        key_file = KEYS_DIR / f'{entry}.pub'
+        if key_file.exists():
+            resolved.append(key_file.read_text().strip())
+        else:
+            missing.append(str(key_file))
+
+    if missing:
+        raise FileNotFoundError(
+            f"agent '{username}': declared ssh_keys could not be resolved: "
+            f"{', '.join(missing)}. Add the key file(s) to the mounted key "
+            f"directory, or inline the public key in agents.yaml."
+        )
+
+    return resolved
+
+
+def install_ssh_key(username: str, ssh_keys: Optional[List[str]] = None) -> None:
+    """Install every authorized public key for a user.
+
+    Multiple keys are what allows an account to be shared with a collaborator
+    without editing provisioning code.
+    """
     if not user_exists(username):
         return
 
+    key_lines = resolve_ssh_keys(username, ssh_keys)
+    if not key_lines:
+        return
+
     ssh_dir = Path(f'/home/{username}/.ssh')
-    key_file = Path(f'/keys/{username}.pub')
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    run_command(['chown', f'{username}:{username}', str(ssh_dir)])
+    run_command(['chmod', '700', str(ssh_dir)])
 
-    if key_file.exists():
-        ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-        run_command(['chown', f'{username}:{username}', str(ssh_dir)])
-
-        authorized_keys = ssh_dir / 'authorized_keys'
-        run_command(['cp', str(key_file), str(authorized_keys)])
-        run_command(['chown', f'{username}:{username}', str(authorized_keys)])
-        run_command(['chmod', '600', str(authorized_keys)])
-        log(f"SSH key installed: {username}")
+    authorized_keys = ssh_dir / 'authorized_keys'
+    authorized_keys.write_text('\n'.join(key_lines) + '\n')
+    run_command(['chown', f'{username}:{username}', str(authorized_keys)])
+    run_command(['chmod', '600', str(authorized_keys)])
+    log(f"SSH keys installed: {username} ({len(key_lines)} key(s))")
 
 
-def create_bash_init(username: str, agent_name: str, channels: list = None) -> None:
+def create_maildir(username: str) -> Path:
+    """Create a standard Maildir in the account's home.
+
+    Deliberately NOT under agent/ — that tree is the MacEff footprint a vanilla
+    account is defined by not having, so putting mail inside it would make email a
+    framework-only capability. ~/Maildir is the universal convention and is readable
+    by any ordinary mail client with no framework knowledge.
+
+    Mode 700 throughout: mail is private to its owner. The broker delivers into it
+    as root, so group access is never needed.
+    """
+    maildir = HOME_ROOT / username / 'Maildir'
+    for sub in ('', 'cur', 'new', 'tmp'):
+        d = maildir / sub if sub else maildir
+        d.mkdir(mode=0o700, parents=True, exist_ok=True)
+    run_command(['chown', '-R', f'{username}:{username}', str(maildir)])
+    run_command(['chmod', '-R', '700', str(maildir)])
+    return maildir
+
+
+def create_bash_init(username: str, agent_name: str, channels: list = None,
+                     vanilla: bool = False) -> None:
     """Create ~/.bash_init.sh for shell initialization (interactive + non-interactive).
 
     This file is the single source of truth for PA-specific environment setup.
@@ -295,24 +438,33 @@ def create_bash_init(username: str, agent_name: str, channels: list = None) -> N
 
     # Build channels env var block if configured
     channels_block = ''
-    if channels:
+    if channels and not vanilla:
         channels_str = ' '.join(channels)
         channels_block = f'''
 # CC Channels configuration (from agents.yaml claude_config.channels)
 export MACEFF_CHANNELS="{channels_str}"
 '''
 
+    # Vanilla accounts get the toolchain environment but no MACEFF_* variables.
+    # env.d/ is deployment-provided toolchain setup (conda, Lean, TeX), not framework
+    # semantics, so it is sourced for both flavors — a vanilla agent still needs a
+    # working compiler on its PATH.
+    if vanilla:
+        identity_block = '# Vanilla account: no MacEff environment by design'
+    else:
+        identity_block = f'''# PA-specific environment (container-wide vars in /etc/environment)
+export MACEFF_AGENT_HOME_DIR="$HOME"
+export MACEFF_AGENT_NAME="{agent_name}"'''
+
     bash_init_content = f'''#!/bin/bash
-# MacEff: Shell initialization for both interactive and non-interactive shells
+# Shell initialization for both interactive and non-interactive shells
 # Created by start.py - DO NOT EDIT MANUALLY
 # Sourced by: ~/.bashrc (interactive) and BASH_ENV (non-interactive)
 
 # Self-referential BASH_ENV for nested shells
 export BASH_ENV="$HOME/.bash_init.sh"
 
-# PA-specific environment (container-wide vars in /etc/environment)
-export MACEFF_AGENT_HOME_DIR="$HOME"
-export MACEFF_AGENT_NAME="{agent_name}"
+{identity_block}
 {channels_block}
 # Source deployment-provided environment scripts (alphanumeric order)
 # Scripts: 00-core, 10-lang-managers, 20-path, 50-custom, 90-final
@@ -422,22 +574,32 @@ def configure_claude_settings(
             for field in layer.model_fields:
                 setattr(merged_prefs, field, getattr(layer, field))
 
-    # Apply layers: defaults < agent overrides
-    if defaults_dict and defaults_dict.get('claude_config'):
+    # Apply layers: defaults < agent overrides.
+    #
+    # Vanilla accounts skip the deployment defaults entirely. Those defaults are
+    # MacEff deployment defaults — they name things like outputStyle
+    # 'maceff-compliance', whose backing file is installed by a step vanilla
+    # accounts do not run. Inheriting them would point the account's config at
+    # framework assets that are not there. An explicit per-agent claude_config is
+    # still honoured, so a vanilla account can be configured deliberately.
+    is_vanilla = getattr(agent_spec, 'is_vanilla', False)
+    if defaults_dict and defaults_dict.get('claude_config') and not is_vanilla:
         merge_layer(defaults_dict['claude_config'])
     if agent_spec.claude_config:
         merge_layer(agent_spec.claude_config.model_dump())
 
     # Inject PA-specific environment variables (belt-and-suspenders with BASH_ENV)
-    # These are available to Claude Code directly without shell sourcing
-    pa_env_vars = {
-        'MACEFF_AGENT_HOME_DIR': str(home_dir),
-        'MACEFF_AGENT_NAME': agent_name,
-    }
-    # Merge PA vars into env (don't overwrite explicit config)
-    for key, value in pa_env_vars.items():
-        if key not in merged_settings.env:
-            merged_settings.env[key] = value
+    # These are available to Claude Code directly without shell sourcing.
+    # Skipped for vanilla accounts, which must carry no MACEFF_* context anywhere.
+    if not is_vanilla:
+        pa_env_vars = {
+            'MACEFF_AGENT_HOME_DIR': str(home_dir),
+            'MACEFF_AGENT_NAME': agent_name,
+        }
+        # Merge PA vars into env (don't overwrite explicit config)
+        for key, value in pa_env_vars.items():
+            if key not in merged_settings.env:
+                merged_settings.env[key] = value
 
     # Write ~/.claude/settings.json (preserve user keys like 'theme')
     settings_file = claude_dir / 'settings.json'
@@ -958,6 +1120,14 @@ def initialize_agents(agents_config: AgentsConfig) -> None:
     for agent_name, agent_spec in agents_config.agents.items():
         username = agent_spec.username
 
+        # Vanilla accounts get neither the macf agent scaffolding nor the hooks.
+        # Hooks are the loudest part of the MacEff footprint — they inject banners
+        # and policy into every turn — so installing them would contradict the
+        # flavor outright.
+        if getattr(agent_spec, 'is_vanilla', False):
+            log(f"Vanilla account, skipping macf init and hooks: {username}")
+            continue
+
         # Run macf_tools agent init
         cmd = f'su - {username} -c "macf_tools agent init"'
         result = subprocess.run(cmd, shell=True, capture_output=True)
@@ -1370,10 +1540,24 @@ def main() -> int:
 
         # Create Primary Agents
         for agent_name, agent_spec in agents_config.agents.items():
-            log(f"Setting up PA: {agent_spec.username}")
+            flavor = getattr(agent_spec, 'flavor', None)
+            flavor_label = getattr(flavor, 'value', 'maceff')
+            log(f"Setting up PA: {agent_spec.username} (flavor={flavor_label})")
 
-            # Create user
+            # Create user — both flavors get home, SSH, mailbox, shell env, settings
             create_pa_user(agent_name, agent_spec, defaults_dict)
+
+            # Everything below this line IS the MacEff footprint. A vanilla account
+            # is defined by receiving none of it: no agent/ tree, no consciousness
+            # artifacts, no personal policies, no layered CLAUDE.md, no PREAMBLEs, no
+            # framework commands/skills/output-styles, no subagents.
+            if getattr(agent_spec, 'is_vanilla', False):
+                log(f"  Vanilla account — skipping MacEff provisioning entirely")
+                violations = vanilla_home_violations(Path(f'/home/{agent_spec.username}'))
+                if violations:
+                    log(f"  WARNING: vanilla home is not clean: {', '.join(violations)}")
+                    log(f"  (a previous maceff-flavored run may have left artifacts behind)")
+                continue
 
             # Create agent tree
             create_agent_tree(agent_spec.username, agent_spec, defaults_dict)
@@ -1430,8 +1614,11 @@ def main() -> int:
         # Initialize agents with macf_tools
         initialize_agents(agents_config)
 
-        # Install SSH key for admin
-        install_ssh_key('admin')
+        # Install SSH keys for admin (declared in agents.yaml defaults, or legacy file)
+        admin_keys = None
+        if agents_config.defaults:
+            admin_keys = getattr(agents_config.defaults, 'admin_ssh_keys', None)
+        install_ssh_key('admin', admin_keys)
 
         # Setup policies
         setup_policies()

--- a/macf/src/macf/models/agent_spec.py
+++ b/macf/src/macf/models/agent_spec.py
@@ -5,8 +5,26 @@ Models correspond to the YAML structure documented in:
 docs/arch_v0.3_named_agents/05_implementation_guide.md (lines 48-125)
 """
 
+from enum import Enum
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class AgentFlavor(str, Enum):
+    """How much of the MacEff framework an account receives.
+
+    MACEFF: the full footprint — consciousness artifact trees, hooks, PREAMBLEs,
+        layered CLAUDE.md, personal policies, framework commands/skills/output-styles.
+
+    VANILLA: a plain Linux account with a home directory, SSH access, shell
+        environment, toolchain, workspace and mailbox — and none of the above.
+        Vanilla accounts exist so a deployment can host agents (or humans) that
+        should see an ordinary environment, with no framework-specific files,
+        tools, or context anywhere in their home.
+    """
+
+    MACEFF = "maceff"
+    VANILLA = "vanilla"
 
 
 class ClaudeCodePreferencesConfig(BaseModel):
@@ -137,9 +155,36 @@ class AgentSpec(BaseModel):
         description="Human-readable display name for GECOS field and statusline (e.g., 'Manny MacEff')"
     )
 
-    personality: str = Field(
-        ...,
-        description="Path to personality file (Identity layer CLAUDE.md source)"
+    flavor: AgentFlavor = Field(
+        default=AgentFlavor.MACEFF,
+        description=(
+            "How much of the MacEff framework this account receives. "
+            "'maceff' (default) installs the full footprint; 'vanilla' installs none "
+            "of it. Defaulting to 'maceff' keeps every pre-existing agents.yaml valid."
+        )
+    )
+
+    personality: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to personality file (Identity layer CLAUDE.md source). "
+            "Required for maceff-flavored agents, meaningless for vanilla ones — "
+            "enforced by the require_personality_for_maceff validator rather than by "
+            "the field itself, so vanilla accounts need not invent one."
+        )
+    )
+
+    ssh_keys: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Public keys authorized for this account, in order. Each entry is either "
+            "a key NAME resolved against the mounted key directory (e.g. 'cversek' -> "
+            "/keys/cversek.pub) or a literal public key line ('ssh-ed25519 AAAA...'). "
+            "All entries are installed, which is what lets an account be shared with a "
+            "collaborator. When omitted, provisioning falls back to the legacy "
+            "single-file lookup (/keys/{username}.pub) so existing deployments are "
+            "unaffected."
+        )
     )
 
     subagents: Optional[List[str]] = Field(
@@ -166,6 +211,54 @@ class AgentSpec(BaseModel):
         default=None,
         description="Claude Code settings override for this agent"
     )
+
+    @property
+    def is_vanilla(self) -> bool:
+        """True when this account must receive no MacEff footprint at all."""
+        return self.flavor == AgentFlavor.VANILLA
+
+    @model_validator(mode='after')
+    def require_personality_for_maceff(self) -> 'AgentSpec':
+        """A maceff-flavored agent needs an identity layer; a vanilla one must not have one.
+
+        Rejecting a personality on a vanilla account is deliberate. Silently ignoring
+        it would let a deployment believe it had configured an identity that was never
+        installed — the config would report one thing while the home directory showed
+        another.
+        """
+        if self.flavor == AgentFlavor.MACEFF and not self.personality:
+            raise ValueError(
+                f"agent '{self.username}': personality is required for "
+                f"flavor='maceff' (omit it only on flavor='vanilla')"
+            )
+        if self.flavor == AgentFlavor.VANILLA and self.personality:
+            raise ValueError(
+                f"agent '{self.username}': personality is meaningless for "
+                f"flavor='vanilla' and would never be installed — remove it"
+            )
+        return self
+
+    @field_validator('ssh_keys')
+    @classmethod
+    def validate_ssh_keys(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        """Reject empty entries and an empty list.
+
+        An empty list is rejected rather than treated as "no keys" because the two
+        readings differ in consequence: it most likely means the operator intended to
+        list keys and the templating produced nothing, which would silently lock the
+        account out. Omit the field entirely to get the legacy single-key fallback.
+        """
+        if v is None:
+            return v
+        if not v:
+            raise ValueError(
+                "ssh_keys must not be an empty list — omit the field entirely for "
+                "the legacy /keys/{username}.pub fallback"
+            )
+        for entry in v:
+            if not entry or not entry.strip():
+                raise ValueError("ssh_keys entries must be non-empty")
+        return v
 
 
 class SubagentSpec(BaseModel):
@@ -216,6 +309,17 @@ class DefaultsConfig(BaseModel):
     claude_config: Optional[ClaudeCodeConfig] = Field(
         default=None,
         description="Default Claude Code settings for all agents"
+    )
+
+    admin_ssh_keys: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Public keys authorized for the container's admin (sudoer) account, in "
+            "the same NAME-or-literal form as AgentSpec.ssh_keys. Declared here "
+            "rather than resolved from a hardcoded /keys/admin.pub so that operator "
+            "access is configuration like every other account. When omitted, the "
+            "legacy /keys/admin.pub lookup still applies."
+        )
     )
 
     container_env: Dict[str, str] = Field(

--- a/macf/tests/test_declarative_accounts.py
+++ b/macf/tests/test_declarative_accounts.py
@@ -1,0 +1,385 @@
+"""Tests for declarative account provisioning: flavor, multi-key SSH, vanilla purity.
+
+Three capabilities are covered here, all of which used to be impossible without
+editing provisioning code:
+
+1. **flavor** — an account can opt out of the MacEff footprint entirely.
+2. **ssh_keys** — an account can authorize more than one key, which is what lets it
+   be shared with a collaborator.
+3. **vanilla purity** — the claim "a vanilla home has no MacEff artifacts" is
+   checked against the filesystem rather than asserted about control flow.
+
+Every invariant below carries a negative control: the test plants the violation and
+proves the checker notices. A check never observed failing is not a check.
+
+``docker/scripts/start.py`` is a container entrypoint, not a package module, so it
+is loaded by path here (matching test_container_amail_tree.py).
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from macf.models.agent_spec import (
+    AgentFlavor,
+    AgentsConfig,
+    AgentSpec,
+    DefaultsConfig,
+)
+
+START_PY = Path(__file__).resolve().parents[2] / "docker" / "scripts" / "start.py"
+
+# Duplicated from start.py deliberately. If the two ever disagree, either a new
+# provisioning step added an artifact without a negative control, or one was
+# removed — test_footprint_constant_is_fully_covered fails and says which.
+EXPECTED_FOOTPRINT_PATHS = [
+    "agent",
+    "CLAUDE.md",
+    ".maceff",
+    ".claude/commands",
+    ".claude/skills",
+    ".claude/output-styles",
+    ".claude/agents",
+]
+
+
+@pytest.fixture(scope="module")
+def start_module():
+    """Load start.py by path; it lives outside the importable package."""
+    spec = importlib.util.spec_from_file_location("maceff_start_accounts", START_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Schema: flavor and personality
+# ---------------------------------------------------------------------------
+
+
+class TestFlavorSchema:
+    def test_flavor_defaults_to_maceff(self):
+        """Omitting flavor must keep the pre-existing behaviour, or every
+        deployment written before this field silently changes meaning."""
+        spec = AgentSpec(username="pa_x", personality="agents/x.md")
+        assert spec.flavor == AgentFlavor.MACEFF
+        assert spec.is_vanilla is False
+
+    def test_maceff_requires_personality(self):
+        spec_kwargs = {"username": "pa_y"}
+        with pytest.raises(ValidationError, match="personality is required"):
+            AgentSpec(**spec_kwargs)
+
+    def test_maceff_with_personality_is_valid(self):
+        """Negative control for the rule above: the same call succeeds once the
+        only missing piece is supplied."""
+        spec = AgentSpec(username="pa_y", personality="agents/y.md")
+        assert spec.personality == "agents/y.md"
+
+    def test_vanilla_without_personality_is_valid(self):
+        spec = AgentSpec(username="nokirby_vanilla_01", flavor="vanilla")
+        assert spec.is_vanilla is True
+        assert spec.personality is None
+
+    def test_vanilla_rejects_personality(self):
+        """Accepting-and-ignoring would let a config claim an identity that is
+        never installed — the config reporting one thing, the home showing another."""
+        with pytest.raises(ValidationError, match="meaningless for"):
+            AgentSpec(
+                username="nokirby_vanilla_01",
+                flavor="vanilla",
+                personality="agents/n.md",
+            )
+
+    def test_unknown_flavor_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentSpec(username="pa_z", personality="p.md", flavor="semi-maceff")
+
+
+# ---------------------------------------------------------------------------
+# Schema: ssh_keys
+# ---------------------------------------------------------------------------
+
+
+class TestSshKeysSchema:
+    def test_omitted_ssh_keys_is_none(self):
+        """None is the signal for the legacy single-file fallback, and must be
+        distinguishable from an empty list."""
+        spec = AgentSpec(username="pa_x", personality="p.md")
+        assert spec.ssh_keys is None
+
+    def test_empty_list_rejected(self):
+        """An empty list almost certainly means templating produced nothing, which
+        would lock the account out silently."""
+        with pytest.raises(ValidationError, match="must not be an empty list"):
+            AgentSpec(username="pa_x", personality="p.md", ssh_keys=[])
+
+    def test_blank_entry_rejected(self):
+        with pytest.raises(ValidationError, match="non-empty"):
+            AgentSpec(username="pa_x", personality="p.md", ssh_keys=["cversek", "  "])
+
+    def test_multiple_keys_preserved_in_order(self):
+        spec = AgentSpec(
+            username="cversek_maceff_01",
+            personality="p.md",
+            ssh_keys=["cversek", "nokirby"],
+        )
+        assert spec.ssh_keys == ["cversek", "nokirby"]
+
+    def test_admin_ssh_keys_declarable_on_defaults(self):
+        """Admin access is configuration like any other account, not a hardcoded
+        username in a provisioning script."""
+        defaults = DefaultsConfig(admin_ssh_keys=["cversek"])
+        assert defaults.admin_ssh_keys == ["cversek"]
+
+
+# ---------------------------------------------------------------------------
+# Key resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def keys_dir(tmp_path, start_module, monkeypatch):
+    d = tmp_path / "keys"
+    d.mkdir()
+    (d / "cversek.pub").write_text("ssh-ed25519 AAAAcversek craig@host\n")
+    (d / "nokirby.pub").write_text("ssh-ed25519 AAAAnokirby nick@host\n")
+    (d / "pa_legacy.pub").write_text("ssh-ed25519 AAAAlegacy legacy@host\n")
+    monkeypatch.setattr(start_module, "KEYS_DIR", d)
+    return d
+
+
+class TestKeyResolution:
+    def test_named_keys_resolve_in_order(self, start_module, keys_dir):
+        keys = start_module.resolve_ssh_keys("u", ["cversek", "nokirby"])
+        assert keys == [
+            "ssh-ed25519 AAAAcversek craig@host",
+            "ssh-ed25519 AAAAnokirby nick@host",
+        ]
+
+    def test_literal_key_passes_through(self, start_module, keys_dir):
+        literal = "ssh-ed25519 AAAAinline inline@host"
+        assert start_module.resolve_ssh_keys("u", [literal]) == [literal]
+
+    def test_named_and_literal_can_mix(self, start_module, keys_dir):
+        literal = "ecdsa-sha2-nistp256 AAAAecdsa e@host"
+        keys = start_module.resolve_ssh_keys("u", ["cversek", literal])
+        assert len(keys) == 2
+        assert keys[1] == literal
+
+    def test_missing_named_key_raises(self, start_module, keys_dir):
+        """Skipping it would produce an account that looks provisioned and cannot
+        be logged into — discovered only when authentication fails."""
+        with pytest.raises(FileNotFoundError, match="could not be resolved"):
+            start_module.resolve_ssh_keys("u", ["cversek", "absent_collaborator"])
+
+    def test_none_falls_back_to_legacy_single_file(self, start_module, keys_dir):
+        """Backward compatibility: deployments that never declared ssh_keys keep
+        getting /keys/{username}.pub."""
+        keys = start_module.resolve_ssh_keys("pa_legacy", None)
+        assert keys == ["ssh-ed25519 AAAAlegacy legacy@host"]
+
+    def test_none_with_no_legacy_file_is_empty_not_error(self, start_module, keys_dir):
+        assert start_module.resolve_ssh_keys("pa_absent", None) == []
+
+
+# ---------------------------------------------------------------------------
+# Vanilla purity — the enumerated footprint check
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_home(tmp_path):
+    """A home containing only what a vanilla account is allowed to have."""
+    home = tmp_path / "nokirby_vanilla_01"
+    (home / ".ssh").mkdir(parents=True)
+    (home / ".ssh" / "authorized_keys").write_text("ssh-ed25519 AAAA n@h\n")
+    for sub in ("cur", "new", "tmp"):
+        (home / "Maildir" / sub).mkdir(parents=True)
+    (home / ".claude").mkdir()
+    (home / ".claude" / "settings.json").write_text(json.dumps({"cleanupPeriodDays": 99999}))
+    (home / ".bash_init.sh").write_text(
+        "#!/bin/bash\nexport BASH_ENV=\"$HOME/.bash_init.sh\"\n"
+        "# Vanilla account: no MacEff environment by design\n"
+    )
+    return home
+
+
+class TestVanillaPurity:
+    def test_clean_home_has_no_violations(self, start_module, clean_home):
+        assert start_module.vanilla_home_violations(clean_home) == []
+
+    def test_mailbox_and_ssh_are_allowed(self, start_module, clean_home):
+        """A mailbox is a capability, not a framework artifact — email must work
+        for vanilla accounts too."""
+        assert (clean_home / "Maildir" / "new").is_dir()
+        assert start_module.vanilla_home_violations(clean_home) == []
+
+    @pytest.mark.parametrize("artifact", EXPECTED_FOOTPRINT_PATHS)
+    def test_each_footprint_artifact_is_detected(self, start_module, clean_home, artifact):
+        """Negative control, one per enumerated artifact: plant it, prove the
+        checker notices. Without this, the checker could return [] unconditionally
+        and every purity test above would still pass."""
+        target = clean_home / artifact
+        if "." in target.name and not target.name.startswith("."):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("planted")
+        else:
+            target.mkdir(parents=True, exist_ok=True)
+
+        violations = start_module.vanilla_home_violations(clean_home)
+        assert artifact in violations, f"{artifact} was not detected as a violation"
+
+    def test_footprint_constant_is_fully_covered(self, start_module):
+        """Every artifact the checker knows about must have a negative control.
+
+        This is the test that keeps the suite honest as provisioning grows: adding
+        a footprint path to start.py without adding it here fails immediately,
+        rather than leaving an untested artifact that the checker silently misses.
+        """
+        assert set(start_module.MACEFF_FOOTPRINT_PATHS) == set(EXPECTED_FOOTPRINT_PATHS)
+
+    def test_hooks_in_settings_detected(self, start_module, clean_home):
+        """Hooks are installed by editing settings.json, not by adding a file, so
+        a path check alone cannot see them."""
+        settings = clean_home / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": {"SessionStart": [{"command": "x"}]}}))
+        violations = start_module.vanilla_home_violations(clean_home)
+        assert ".claude/settings.json:hooks" in violations
+
+    def test_empty_hooks_key_is_not_a_violation(self, start_module, clean_home):
+        """Guard against a false positive: an empty hooks dict installs nothing."""
+        settings = clean_home / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": {}}))
+        assert start_module.vanilla_home_violations(clean_home) == []
+
+    def test_maceff_output_style_detected(self, start_module, clean_home):
+        settings = clean_home / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"outputStyle": "maceff-compliance"}))
+        violations = start_module.vanilla_home_violations(clean_home)
+        assert any("outputStyle" in v for v in violations)
+
+    def test_neutral_output_style_allowed(self, start_module, clean_home):
+        """A vanilla account may still be configured deliberately — only MacEff
+        styles are the problem, because their backing files are never installed."""
+        settings = clean_home / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"outputStyle": "default"}))
+        assert start_module.vanilla_home_violations(clean_home) == []
+
+    def test_maceff_env_var_in_bash_init_detected(self, start_module, clean_home):
+        """MACEFF_* variables are 'special context' even though they are not files."""
+        (clean_home / ".bash_init.sh").write_text(
+            "#!/bin/bash\nexport MACEFF_AGENT_NAME=\"nick\"\n"
+        )
+        violations = start_module.vanilla_home_violations(clean_home)
+        assert any(".bash_init.sh" in v for v in violations)
+
+    def test_maceff_mentioned_only_in_comment_is_not_flagged(self, start_module, clean_home):
+        """False-positive guard: the vanilla bash_init legitimately contains the
+        word MacEff in a comment explaining what is deliberately absent."""
+        (clean_home / ".bash_init.sh").write_text(
+            "#!/bin/bash\n# Vanilla account: no MACEFF_ variables by design\n"
+            "export BASH_ENV=\"$HOME/.bash_init.sh\"\n"
+        )
+        assert start_module.vanilla_home_violations(clean_home) == []
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_legacy_shaped_config_still_validates(self):
+        """A config written before flavor/ssh_keys existed must validate unchanged
+        and behave identically — this is the regression that would break the
+        sibling production deployment."""
+        legacy = {
+            "agents": {
+                "manny": {
+                    "username": "pa_manny",
+                    "display_name": "Manny MacEff",
+                    "personality": "agents/manny_personality.md",
+                    "subagents": ["DevOpsEng"],
+                    "assigned_projects": ["NeuroVEP"],
+                }
+            },
+            "subagents": {
+                "DataScientist": {
+                    "role": "Data analysis",
+                    "tool_access": "Read, Bash",
+                }
+            },
+            "defaults": {"container_env": {"MACF_CONTEXT_WINDOW": "1000000"}},
+        }
+        config = AgentsConfig(**legacy)
+        manny = config.agents["manny"]
+        assert manny.flavor == AgentFlavor.MACEFF
+        assert manny.is_vanilla is False
+        assert manny.ssh_keys is None
+        assert config.defaults.admin_ssh_keys is None
+
+    def test_mixed_flavor_deployment_validates(self):
+        """The target shape for the new deployment: owner-prefixed accounts of
+        both flavors side by side."""
+        config = AgentsConfig(
+            agents={
+                "cversek_maceff": {
+                    "username": "cversek_maceff_01",
+                    "personality": "agents/researcher.md",
+                    "ssh_keys": ["cversek"],
+                },
+                "nokirby_vanilla": {
+                    "username": "nokirby_vanilla_01",
+                    "flavor": "vanilla",
+                    "ssh_keys": ["nokirby", "cversek"],
+                },
+            },
+            subagents={},
+            defaults={"admin_ssh_keys": ["cversek"]},
+        )
+        assert config.agents["cversek_maceff"].is_vanilla is False
+        assert config.agents["nokirby_vanilla"].is_vanilla is True
+        assert len(config.agents["nokirby_vanilla"].ssh_keys) == 2
+
+
+# ---------------------------------------------------------------------------
+# Maildir
+# ---------------------------------------------------------------------------
+
+
+class TestMaildir:
+    def test_maildir_is_not_a_forbidden_artifact(self, start_module):
+        """Mail must not live under agent/, or email becomes a MacEff-only
+        capability and vanilla accounts cannot have it."""
+        assert not any(
+            p.startswith("Maildir") for p in start_module.MACEFF_FOOTPRINT_PATHS
+        )
+
+    def test_maildir_created_with_standard_subdirs(self, start_module, tmp_path, monkeypatch):
+        """A Maildir without cur/new/tmp is not a Maildir — every MUA and MDA
+        expects all three. Calls the real function, not a re-implementation."""
+        monkeypatch.setattr(start_module, "HOME_ROOT", tmp_path)
+        monkeypatch.setattr(start_module, "run_command", lambda *a, **k: None)
+
+        maildir = start_module.create_maildir("someuser")
+
+        assert maildir == tmp_path / "someuser" / "Maildir"
+        for sub in ("cur", "new", "tmp"):
+            assert (maildir / sub).is_dir(), f"Maildir/{sub} missing"
+
+    def test_maildir_creation_is_idempotent(self, start_module, tmp_path, monkeypatch):
+        """Container restart re-runs provisioning against a persistent home volume;
+        a second call must not fail or discard existing mail."""
+        monkeypatch.setattr(start_module, "HOME_ROOT", tmp_path)
+        monkeypatch.setattr(start_module, "run_command", lambda *a, **k: None)
+
+        maildir = start_module.create_maildir("someuser")
+        (maildir / "new" / "msg1").write_text("existing mail")
+
+        start_module.create_maildir("someuser")
+
+        assert (maildir / "new" / "msg1").read_text() == "existing mail"


### PR DESCRIPTION
## Why

Three things were impossible without editing provisioning code:

1. **Authorizing more than one SSH key on an account.** `install_ssh_key()` copied exactly one file, `/keys/{username}.pub`. Sharing an account with a collaborator meant a code change.
2. **Declaring an account that receives no MacEff footprint.** `AgentSpec.personality` was required and provisioning installed CA trees, hooks, PREAMBLEs and framework assets unconditionally. There was no way to say "this is just a Linux user with a toolchain."
3. **Verifying that such an account actually has none.** Even with the steps skipped, "it has no MacEff artifacts" was a claim about control flow, and control flow changes.

## What

### Schema — three backward-compatible additions to `AgentSpec`

| field | behaviour |
|---|---|
| `flavor` | `maceff` (default) or `vanilla`. Defaulting to `maceff` means every `agents.yaml` written before this field keeps its exact meaning. |
| `personality` | Relaxed to `Optional`, then **required** for `maceff` and **rejected** for `vanilla` by a model validator. |
| `ssh_keys` | Ordered list of key names (resolved against the mounted key directory) or literal public key lines. All are installed. Omitting it keeps the legacy single-file lookup. |

`DefaultsConfig` gains `admin_ssh_keys`, so operator access to the sudoer account is configuration rather than a username hardcoded in a provisioning script.

Rejecting `personality` on a vanilla account is deliberate rather than ignoring it. Silent acceptance would let a config claim an identity that is never installed — the config reporting one thing while the home directory shows another.

### Provisioning

A vanilla account receives home, SSH, mailbox, shell environment and Claude settings. It skips the `agent/` tree, personal policies, layered `CLAUDE.md`, PREAMBLEs, framework commands/skills/output-styles, subagents, hooks, and `macf agent init`.

Deployment-level `claude_config` defaults are skipped too. Those defaults name assets — `outputStyle: maceff-compliance` — whose backing files are installed by a step vanilla accounts never run, so inheriting them would point the config at files that are not there. An explicit per-agent `claude_config` is still honoured.

### Mail location

Mail lands in a standard `~/Maildir`, not under `agent/`. That tree is the footprint a vanilla account is *defined by not having*, so putting mail inside it would make email a framework-only capability. `~/Maildir` is the universal convention and works with any ordinary mail client.

### Purity as a check, not a comment

`vanilla_home_violations()` inspects the finished home and returns every MacEff artifact found in it. `MACEFF_FOOTPRINT_PATHS` **is** the definition of vanilla; hooks and output styles are additionally checked inside `settings.json`, since they are installed by editing a file rather than adding one, and `MACEFF_*` shell variables are checked in `.bash_init.sh` because "special context" is not only files.

## Verification

**38 tests, every invariant negative-controlled.** Both controls were observed failing before being restored:

- Stubbing the checker to return `[]` unconditionally → **all 10 detection tests fail**, while the clean-home tests still pass. That asymmetry is exactly why the controls exist: a checker that always reports clean satisfies every positive test.
- Disabling the two schema validators → exactly the two corresponding tests fail, no others.

A guard against false positives is included both ways: an empty `hooks` dict and a non-MacEff `outputStyle` are *not* violations, and the word `MACEFF_` appearing only in a comment is not flagged.

`test_footprint_constant_is_fully_covered` asserts the constant and the parametrized control list stay in sync, so a newly added provisioning artifact cannot go unchecked.

**Backward compatibility** is proven directly: the existing sibling deployment's `agents.yaml` validates unchanged, both its agents resolve to `flavor=maceff`, `ssh_keys=None` (legacy fallback), and a legacy-shaped config is asserted in the suite.

Full suite: **1197 passed**, +38 over this branch's baseline. The 12 failures are a pre-existing `lancedb` environment gap, untouched by this change and tracked separately.