### PR TITLE
fix(start): defaults.consciousness_artifacts crashed provisioning as a dict

### DIFF
--- a/docker/scripts/start.py
+++ b/docker/scripts/start.py
@@ -633,6 +633,37 @@ def configure_claude_settings(
     log(f"  Claude prefs: {merged_prefs.model_dump()}")
 
 
+def resolve_ca_config(
+    agent_spec: AgentSpec,
+    defaults_config: Optional[Dict],
+) -> Optional[ConsciousnessArtifactsConfig]:
+    """Resolve the effective consciousness-artifacts config for an agent.
+
+    Per-agent spec wins; otherwise fall back to the deployment defaults.
+
+    The fallback needs coercion. `defaults_config` arrives as a plain dict —
+    main() calls model_dump() on the defaults — so the nested value is a dict too,
+    while every caller expects a model and reaches for .private / .public. This is
+    the one point where the type actually changes, so it is the one place to fix it.
+
+    That fallback went unexercised for a long time: the only deployment declared
+    consciousness_artifacts on every agent, so the documented "used if not
+    specified per-agent" path never ran and its type error never surfaced.
+    """
+    if agent_spec.consciousness_artifacts is not None:
+        return agent_spec.consciousness_artifacts
+
+    if not defaults_config:
+        return None
+
+    default_ca = defaults_config.get('consciousness_artifacts')
+    if default_ca is None:
+        return None
+    if isinstance(default_ca, dict):
+        return ConsciousnessArtifactsConfig(**default_ca)
+    return default_ca
+
+
 def create_agent_tree(username: str, agent_spec: AgentSpec, defaults_config: Optional[Dict]) -> None:
     """Create agent directory structure with consciousness artifacts."""
     home = Path(f'/home/{username}')
@@ -648,12 +679,17 @@ def create_agent_tree(username: str, agent_spec: AgentSpec, defaults_config: Opt
     public = agent / 'public'
 
     # Determine parent directory permissions based on immutable_structure flag
-    ca_config = agent_spec.consciousness_artifacts
-    if ca_config is None and defaults_config:
-        ca_config = defaults_config.get('consciousness_artifacts')
+    ca_config = resolve_ca_config(agent_spec, defaults_config)
 
-    # Check immutable_structure flag (defaults to True for governance)
-    immutable = getattr(ca_config, 'immutable_structure', True) if ca_config else True
+    # Check immutable_structure flag (defaults to True for governance).
+    #
+    # getattr with a default is deliberately NOT used here. Against a dict it
+    # returns the default silently, so a deployment setting immutable_structure:
+    # false would have been overridden to true with no error — a wrong answer on a
+    # permissions flag, which is worse than an AttributeError that at least
+    # announces itself. resolve_ca_config guarantees a model or None, so plain
+    # attribute access is correct and raises loudly if that ever stops holding.
+    immutable = ca_config.immutable_structure if ca_config else True
 
     # Private: owner-only (other PAs cannot read)
     # Public: group-readable via agents_all (other PAs can read)

--- a/macf/tests/test_defaults_ca_fallback.py
+++ b/macf/tests/test_defaults_ca_fallback.py
@@ -1,0 +1,140 @@
+"""Tests for the deployment-defaults fallback of consciousness_artifacts.
+
+`agents.yaml` documents `defaults.consciousness_artifacts` as "used if not
+specified per-agent". That fallback crashed provisioning outright: main() passes
+the defaults through `model_dump()`, so the nested value is a plain dict, while
+`create_agent_tree` reached for `.private` on it.
+
+It went unnoticed because the only deployment in existence declared
+consciousness_artifacts on every agent, so the fallback never executed. A config
+path that is documented but never exercised is untested by construction.
+
+Two defects at the same site, and the quieter one is worse:
+
+  loud   `ca_config.private` -> AttributeError, container restart-loops
+  silent `getattr(ca_config, 'immutable_structure', True)` returns the DEFAULT for
+         a dict, so `immutable_structure: false` in defaults was overridden to
+         true with no error at all — a wrong answer on a permissions flag
+
+Both are covered below, each with a negative control.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from macf.models.agent_spec import AgentSpec, ConsciousnessArtifactsConfig
+
+START_PY = Path(__file__).resolve().parents[2] / "docker" / "scripts" / "start.py"
+
+
+@pytest.fixture(scope="module")
+def start_module():
+    spec = importlib.util.spec_from_file_location("maceff_start_defaults", START_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def agent_without_ca():
+    """An agent that relies on the defaults — the shape that triggered the bug."""
+    return AgentSpec(username="pa_defaults", personality="agents/p.md")
+
+
+@pytest.fixture
+def agent_with_ca():
+    return AgentSpec(
+        username="pa_explicit",
+        personality="agents/p.md",
+        consciousness_artifacts=ConsciousnessArtifactsConfig(
+            private=["checkpoints"], public=["roadmaps"], immutable_structure=True
+        ),
+    )
+
+
+class TestDefaultsFallback:
+    def test_dict_defaults_are_coerced_to_a_model(self, start_module, agent_without_ca):
+        """The regression itself: a dict from model_dump() must come back as a
+        model, because every caller dereferences .private / .public."""
+        defaults = {
+            "consciousness_artifacts": {
+                "private": ["checkpoints", "reflections"],
+                "public": ["roadmaps"],
+                "immutable_structure": True,
+            }
+        }
+        resolved = start_module.resolve_ca_config(agent_without_ca, defaults)
+
+        assert isinstance(resolved, ConsciousnessArtifactsConfig)
+        # The attribute access that used to raise
+        assert resolved.private == ["checkpoints", "reflections"]
+        assert resolved.public == ["roadmaps"]
+
+    def test_immutable_false_in_defaults_is_honoured(self, start_module, agent_without_ca):
+        """The silent defect. `getattr(dict, 'immutable_structure', True)` returns
+        True regardless of what the deployment asked for, so a config requesting
+        writable artifact parents got read-only ones and nothing said so."""
+        defaults = {
+            "consciousness_artifacts": {
+                "private": ["checkpoints"],
+                "public": ["roadmaps"],
+                "immutable_structure": False,
+            }
+        }
+        resolved = start_module.resolve_ca_config(agent_without_ca, defaults)
+
+        assert resolved.immutable_structure is False, (
+            "immutable_structure: false in defaults was silently overridden to true"
+        )
+
+    def test_already_a_model_passes_through(self, start_module, agent_without_ca):
+        """Defaults supplied as a model (not every caller uses model_dump) must not
+        be double-wrapped."""
+        model = ConsciousnessArtifactsConfig(private=["checkpoints"], public=["roadmaps"])
+        resolved = start_module.resolve_ca_config(
+            agent_without_ca, {"consciousness_artifacts": model}
+        )
+        assert resolved is model
+
+    def test_per_agent_config_wins_over_defaults(self, start_module, agent_with_ca):
+        defaults = {
+            "consciousness_artifacts": {
+                "private": ["SHOULD_NOT_WIN"],
+                "public": ["SHOULD_NOT_WIN"],
+            }
+        }
+        resolved = start_module.resolve_ca_config(agent_with_ca, defaults)
+        assert resolved.private == ["checkpoints"]
+        assert resolved.public == ["roadmaps"]
+
+    def test_no_defaults_and_no_spec_is_none(self, start_module, agent_without_ca):
+        assert start_module.resolve_ca_config(agent_without_ca, None) is None
+        assert start_module.resolve_ca_config(agent_without_ca, {}) is None
+
+    def test_defaults_without_the_key_is_none(self, start_module, agent_without_ca):
+        """A defaults block carrying only container_env must not be mistaken for a
+        CA config."""
+        resolved = start_module.resolve_ca_config(
+            agent_without_ca, {"container_env": {"FOO": "bar"}}
+        )
+        assert resolved is None
+
+    def test_resolved_config_survives_the_immutable_read(self, start_module, agent_without_ca):
+        """End-to-end on the exact expression create_agent_tree evaluates. This is
+        the line that crashed provisioning, reproduced without needing root or a
+        filesystem."""
+        defaults = {
+            "consciousness_artifacts": {
+                "private": ["checkpoints"],
+                "public": ["roadmaps"],
+                "immutable_structure": True,
+            }
+        }
+        ca_config = start_module.resolve_ca_config(agent_without_ca, defaults)
+
+        immutable = ca_config.immutable_structure if ca_config else True
+        assert immutable is True
+        # And the dereferences that follow it in create_agent_tree
+        assert list(ca_config.private) and list(ca_config.public)


### PR DESCRIPTION
## Symptom

Bringing up a new deployment, every PA failed to provision and the container restart-looped:

```
[start.py] Setting up PA: pa_example (flavor=maceff)
[start.py] SSH keys installed: pa_example (1 key(s))
[start.py] FATAL ERROR during startup: 'dict' object has no attribute 'private'
```

## Mechanism

`main()` passes deployment defaults through `model_dump()`, so `defaults_config['consciousness_artifacts']` is a plain **dict**. `create_agent_tree` then dereferenced `.private` and `.public` on it.

## Why it survived this long

`agents.yaml` documents `defaults.consciousness_artifacts` as *"used if not specified per-agent"* — but the only deployment in existence declares `consciousness_artifacts` on **every** agent, so the fallback never executed. The documented path was effectively dead code, and it broke the first time a new deployment used the defaults block for its stated purpose.

A config path that is documented but never exercised is untested by construction.

## Two defects at the same site — the quiet one is worse

| | behaviour |
|---|---|
| **loud** | `ca_config.private` → `AttributeError`, immediate and obvious |
| **silent** | `getattr(ca_config, 'immutable_structure', True)` returns **the default** for a dict |

The second is the more serious. A deployment setting `immutable_structure: false` in defaults had it silently overridden to `true` — artifact parent directories created read-only when the config asked for writable ones, with nothing reporting the discrepancy. That is a wrong answer on a permissions-relevant flag, which is strictly worse than a crash that announces itself.

## Fix

Resolution moves into `resolve_ca_config()`, which coerces at the single point where the type actually changes and guarantees a model or `None`. The `immutable_structure` read becomes plain attribute access rather than `getattr`-with-default, so a future type regression raises loudly instead of quietly returning the default.

Extracting it also makes the logic testable without root or a filesystem — `create_agent_tree` needs both.

## Verification

7 tests covering: dict coercion, `immutable_structure: false` honoured, model pass-through without double-wrapping, per-agent precedence, absent/empty defaults, a defaults block carrying only `container_env`, and the exact expression `create_agent_tree` evaluates.

**Negative control**: restoring the uncoerced return fails exactly the three tests that target the bug — `test_dict_defaults_are_coerced_to_a_model`, `test_immutable_false_in_defaults_is_honoured`, `test_resolved_config_survives_the_immutable_read` — and no others.

Full suite: **1215 passed**. The 12 failures are a pre-existing `lancedb` environment gap, unrelated and tracked separately.

## Scope

Pre-existing; not introduced by #200. Verified by reading `b6d109b` (main before that PR), where the same lines are identical. #200 only made the path reachable by shipping a deployment that relies on defaults.
