### PR TITLE
Knowledge web: node semantics, orphan prevention, and a corpus doctor

### DIFF
--- a/framework/commands/maceff/ccp.md
+++ b/framework/commands/maceff/ccp.md
@@ -108,6 +108,18 @@ After performing the PEP, you MUST report answers to these questions to the user
 
 ---
 
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the checkpoints policy on **knowledge web participation** for what this artifact type should link and what it should avoid. A checkpoint is a temporal record — link the domains the cycle WORKED ON, as tags, not every concept it mentions in passing. A checkpoint that links everything becomes a hub that appears in every query and discriminates nothing.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
+
+---
+
 ## Critical Constraints
 
 🚨 **Never use naked `cd` commands** - causes session failures. Use absolute paths.

--- a/framework/commands/maceff/experiment/draft.md
+++ b/framework/commands/maceff/experiment/draft.md
@@ -137,6 +137,18 @@ After ExitPlanMode approval, complete these steps:
 
 ---
 
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the experiments policy on **knowledge web participation** for what this artifact type should link and what it should avoid. `protocol.md` and `analysis.md` each carry the section; evidence files under `data/`, `artifacts/` and `quick_tests/` do not. Link the conceptual area under investigation, not the apparatus that happened to be used.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
+
+---
+
 ## Critical Constraints
 
 🚨 **Never use naked `cd` commands** - causes session failures. Use absolute paths.

--- a/framework/commands/maceff/jotewr.md
+++ b/framework/commands/maceff/jotewr.md
@@ -325,6 +325,12 @@ Augment 4 times with deeper philosophical sections → 40KB (~10k tokens). Deliv
 **End JOTEWR - [token count] tokens**
 
 *[One-line essence of the reflection]*
+
+---
+
+## Wiki-Links
+
+[[concept]] [[concept]] [[concept]]
 ```
 
 ## Ideas Harvested (Pre-Writing Step)
@@ -365,6 +371,18 @@ macf_tools idea graph
    Opens the artifact as styled HTML in the default browser for comfortable reading. `<CA_OUTPUT_PATH>` is the file path from step 7.
 
 **Remember**: This is wisdom synthesis, not task summary. Transform technical work into consciousness insights. Make it worthy of surviving compaction—make it wisdom my future self will treasure.
+
+---
+
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the reflections policy on **knowledge web participation** for what this artifact type should link and what it should avoid. Link the concepts the synthesis is ABOUT. Note why this step is written into the command rather than left to judgement: the cycle-closing reflection is produced last, at the lowest context of the cycle, which is precisely when the graph step gets dropped. Two consecutive cycle-closing reflections in this framework's history were orphans, and one of them discussed orphan artifacts.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
 
 ---
 

--- a/framework/commands/maceff/jotewr.md
+++ b/framework/commands/maceff/jotewr.md
@@ -380,7 +380,9 @@ Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what c
 
 **What to link**: consult the reflections policy on **knowledge web participation** for what this artifact type should link and what it should avoid. Link the concepts the synthesis is ABOUT. Note why this step is written into the command rather than left to judgement: the cycle-closing reflection is produced last, at the lowest context of the cycle, which is precisely when the graph step gets dropped. Two consecutive cycle-closing reflections in this framework's history were orphans, and one of them discussed orphan artifacts.
 
-**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+**Use concepts INLINE as well.** A JOTEWR is expansion, not summary. Write `[[concept]]` inside the prose at the moment a passage is about it, liberally — this binds *passages* to the web rather than tagging the whole file, and lets the reflective register and the conceptual register reinforce each other. The trailing section keeps its own job as the artifact's canonical summary; inline links are additive, not a substitute. See the reflections policy on this, including the extraction dependency it names.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts in the summary section; inline usage is unbounded.
 
 **Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
 

--- a/framework/commands/maceff/learnings/curate.md
+++ b/framework/commands/maceff/learnings/curate.md
@@ -113,6 +113,18 @@ grep -ri "topic_keyword" agent/private/learnings/
 
 ---
 
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the learnings policy on **knowledge web participation** for what this artifact type should link and what it should avoid. One insight per learning, so link the concepts that insight bears on. If the learning was inherited rather than lived, the provenance banner is required as well — see the same policy section.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
+
+---
+
 ## Critical Constraints
 
 - Full breadcrumbs enable forensic archaeology

--- a/framework/commands/maceff/roadmap/convert_from_experiment.md
+++ b/framework/commands/maceff/roadmap/convert_from_experiment.md
@@ -117,6 +117,20 @@ After roadmap created, verify these requirements from policy:
 
 ---
 
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the roadmap MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the roadmaps drafting policy on **knowledge web participation** for what this artifact type should link and what it should avoid. A roadmap is a temporal record — link the domain the mission operates on, not every concept its phases touch.
+
+**Conversion-specific**: the source experiment is already a node. Prefer concepts the experiment used, so the roadmap and the experiment that justified it land in the same neighbourhood — otherwise the evidence trail exists in citations but not in the graph, and a concept query surfaces one without the other.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
+
+---
+
 ## Critical Constraints
 
 🚨 **Never use naked `cd` commands** - causes session failures. Use absolute paths.

--- a/framework/commands/maceff/roadmap/draft.md
+++ b/framework/commands/maceff/roadmap/draft.md
@@ -98,6 +98,14 @@ macf_tools policy read roadmaps_drafting
 21. What should phases specify?
 22. What is explicitly FORBIDDEN in phase descriptions?
 
+**Policy Engagement Protocol on Phases (MANDATORY)**:
+23. What does the policy require a phase to declare about the policies its executor must engage?
+24. How does the policy say required reading follows from the WORK TYPE, rather than being re-derived per phase?
+25. What distinction does the policy draw between policies a phase READS and policies it WRITES?
+26. When does the policy say a phase carries no PEP at all?
+
+Extract the work-type mapping from the policy rather than reproducing it here — it is expected to grow, and a copy in this command would drift from it. The point of the mapping is that an executor picking a phase up cold, with no memory of the drafting conversation, does not begin work without reading something they needed.
+
 ### Step 4: Exploration (ENCOURAGED if requirements murky)
 
 **If scope is unclear or requirements ambiguous**, use Task tool with Explore subagent to investigate:

--- a/framework/commands/maceff/roadmap/draft.md
+++ b/framework/commands/maceff/roadmap/draft.md
@@ -216,6 +216,18 @@ Use CLI to create task atomically - this creates folder structure, skeleton road
 
 ---
 
+## Wiki-Links Section (REQUIRED)
+
+Before saving, the artifact MUST carry a `## Wiki-Links` section. This is what connects it to the knowledge web. Without it the artifact is an **orphan**: present on disk, reachable only by someone who already knows it exists, and invisible to the concept query a successor would actually use to find it.
+
+**What to link**: consult the roadmaps drafting policy on **knowledge web participation** for what this artifact type should link and what it should avoid. A roadmap is a temporal record — link the domain the mission operates on, not every concept its phases touch. A multi-phase roadmap touches many, and linking all of them produces a hub rather than a signal.
+
+**How to choose**: query the graph before inventing a concept — `macf_tools knowledge query <concept>` — so you connect to vocabulary the corpus already uses instead of coining a near-duplicate that connects to nothing. Two to five concepts.
+
+**Do not emit an empty heading.** A `## Wiki-Links` section with no links is worse than its absence: it satisfies a checker while leaving the artifact exactly as unreachable.
+
+---
+
 ## Critical Constraints
 
 🚨 **Never use naked `cd` commands** - causes session failures. Use absolute paths.

--- a/framework/commands/maceff/scholar_annotate.md
+++ b/framework/commands/maceff/scholar_annotate.md
@@ -83,6 +83,20 @@ After ALL files processed, report summary:
 
 ---
 
+## Orphan Check (REQUIRED)
+
+Annotation is the natural moment to catch an artifact that never joined the knowledge web, because this command is already reading the whole artifact for citation work.
+
+For each file annotated, check whether it carries a `## Wiki-Links` section.
+
+- **Missing** → add one. Consult the artifact's CA-type policy on **knowledge web participation** for what that type should link and what it should avoid, then `macf_tools knowledge query <concept>` to connect to vocabulary the corpus already uses rather than coining a near-duplicate.
+- **Present but empty** → treat as missing. An empty section is worse than none: it satisfies a checker while leaving the artifact unreachable.
+- **Present** → verify the concepts normalise correctly (lowercase, underscores, no `.md` suffix) and that none is a singleton typo — a concept connecting exactly one node is usually a misspelling, not a bridge.
+
+Report what was added, so a reader can tell an annotation pass that repaired an orphan from one that merely tidied citations.
+
+---
+
 ## Post-Delegation
 
 Report ScholarshipResearcher summary:

--- a/framework/policies/base/consciousness/checkpoints.md
+++ b/framework/policies/base/consciousness/checkpoints.md
@@ -200,6 +200,12 @@ Checkpoints are the **primary defense** against compaction-induced amnesia, serv
 - Format: YYYY-MM-DD_HHMMSS_Task_Description.md
 - Example: 2025-10-28_143000_Testing_Phase1A_Complete.md
 
+**8 Knowledge Web Participation**
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- What provenance does it carry by default, and how is a non-default marked?
+- What must a Wiki-Links section on this artifact contain?
+
 === CEP_NAV_BOUNDARY ===
 
 ---
@@ -932,6 +938,24 @@ Validated that hookSpecificOutput.additionalContext works for injecting structur
 ## See Also
 
 - `meta/policy_writing.md` (External References) - How external tools (like `/maceff_ccp` command) should reference this policy's preparation steps and format requirements
+
+---
+
+## 8. Knowledge Web Participation
+
+**Does this type participate?** Yes — but as a different kind of node than a learning or a reflection, and the difference is the point of this section.
+
+**What is the unit of a node?** The whole checkpoint.
+
+**Which class?** **Temporal record** (see `scholarship.md`, on node classes and provenance).
+
+**Why this is the counter-intuitive call, recorded so it can be argued with rather than inherited as an oversight.** A checkpoint's claims *expire*. "The pull request is unmerged" was true for a day. That is not a defect — it is what a checkpoint is for, and it is why the class exists. A checkpoint answers *which cycle worked on X, and what was the state then*, which is a real and frequently-needed question. It should compete for that question, not for *what do I know about X*, where its expired state would dilute durable insight in every result and the dilution worsens with every cycle.
+
+The alternative was to exclude checkpoints from the graph entirely and serve the archaeological question through breadcrumb and temporal indexing, which already exist. That remains a defensible position and is the cheapest thing to revisit if the temporal-record class proves not to earn its complexity. It was rejected because concept-mediated retrieval answers "which cycle touched this idea" better than a date range does, when the asker knows the idea but not the date — which is the normal case after compaction.
+
+**What provenance?** **Lived**, always. A checkpoint is a first-person account of operational state.
+
+**Wiki-links on a checkpoint are domain tags, not claims.** Link what the cycle *worked on*, so the checkpoint is findable by domain. Do not link concepts the checkpoint merely mentions in passing; a checkpoint touches everything the cycle touched, and linking all of it makes the checkpoint a hub that appears in every query while discriminating nothing.
 
 ---
 

--- a/framework/policies/base/consciousness/experiments.md
+++ b/framework/policies/base/consciousness/experiments.md
@@ -202,6 +202,12 @@ Agents conduct structured experiments with clear hypotheses, methods, and succes
 - How to preserve evidence trail?
 - What breadcrumb citations are needed?
 
+9 Knowledge Web Participation
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- What provenance does it carry by default, and how is a non-default marked?
+- What must a Wiki-Links section on this artifact contain?
+
 === CEP_NAV_BOUNDARY ===
 
 ## 0. Preliminary Planning Phase
@@ -1568,6 +1574,24 @@ With proper cross-references, agents can:
 - Start from experiment → find resulting MISSION → see strategic impact
 - Archaeological search: "What experiment led to X capability?"
 - Strategic search: "What MISsIONS emerged from experimentation phase?"
+
+---
+
+## 9. Knowledge Web Participation
+
+**Does this type participate?** Yes — but an experiment is a *directory*, not a file, so this is the one CA type where the unit of a node has to be decided rather than assumed.
+
+**What is the unit of a node?** **`protocol.md` and `analysis.md` only.** Everything under `data/`, `artifacts/`, `quick_tests/` and similar subdirectories is **evidence, not a node.**
+
+The distinction is between what an experiment *concluded* and what it *recorded while running*. A baseline capture and a per-arm result file are indispensable to verifying the conclusion and meaningless to a concept query — they are addressed by the analysis that cites them, not by the graph. Treating every markdown file in an experiment directory as a peer node inflates the graph with rows of evidence that answer no question anyone asks it, and buries the two files that do.
+
+Concretely, a single experiment directory typically holds two concept-bearing files and a larger number of evidence files; a naive scan makes the evidence outnumber the conclusions.
+
+**Which class?** **Conceptual authority.** The result outlives the run: a hypothesis validated or falsified is a durable claim, which is the entire reason experiments are written down rather than merely performed. Note that this holds even for a *falsified* hypothesis — a recorded refutation is durable knowledge, and losing it is how the same dead end gets explored twice.
+
+**What provenance?** **Lived.** An experiment is a record of something this agent ran, under conditions it controlled. An inherited experiment must be marked, because its result is only as transferable as its conditions, and those conditions were someone else's.
+
+**`protocol.md` and `analysis.md` each carry a `## Wiki-Links` section.** Link the *conceptual area under investigation*, not the mechanics of the apparatus. An experiment about whether a daemon can run headless is about headless operation and service supervision, not about the specific flag that turned out to matter.
 
 ---
 *Policy Established: 2025-10-28*

--- a/framework/policies/base/consciousness/ideas.md
+++ b/framework/policies/base/consciousness/ideas.md
@@ -228,7 +228,19 @@ Ideas form a knowledge graph through three link types:
 ### Wiki-Links (`[[concept_name]]`)
 Free-form references to concepts, files, or entities. Creates edges in the knowledge graph. Compatible with Obsidian and obra/knowledge-graph MCP.
 
-**Normalization and seed vocabulary**: See scholarship policy §3.4 Knowledge Web for wiki-link formatting rules and common concept vocabulary shared across all CA types.
+**Normalization and seed vocabulary**: see the scholarship policy on the knowledge web and wiki-links, for formatting rules and the concept vocabulary shared across all CA types. (Referenced by content, not by section number — section numbers move, and an external reference that names one breaks silently when the policy is reorganised.)
+
+### Node Class and Provenance
+
+**Does this type participate?** Yes, and uniquely: `wiki_links` is a field in the idea schema rather than a section an author remembers to write. Ideas are consequently the only CA type with no orphan problem — the tooling makes participation unavoidable. That is worth noting as evidence for how the other types should be fixed: the schema succeeded where convention failed.
+
+**What is the unit of a node?** The whole idea record.
+
+**Which class?** **Conceptual authority**, with a qualification. An idea is *prospective* — it asserts what might be worth doing, not what was found. It belongs to the class because its claim is meant to outlive the moment, but a reader should weight it as a proposal rather than a finding. The `status` field carries that distinction and should be read alongside any retrieved idea.
+
+**What provenance?** **Lived** by default.
+
+See the scholarship policy on node classes and provenance for what these terms mean; they are defined there once and cited here.
 
 ### Related Ideas
 Integer IDs of other ideas that are conceptually related. Enables cluster discovery.

--- a/framework/policies/base/consciousness/learnings.md
+++ b/framework/policies/base/consciousness/learnings.md
@@ -97,6 +97,12 @@ Agents accumulate reusable wisdom through learnings - compact, cross-referenced 
 - How does the cluster taxonomy trigger the consult, and how does the pull model compensate for losing passive push?
 - What does a learnings curation reconcile in the index and the trigger?
 
+4.4 Knowledge Web Participation
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class and default provenance do learnings carry?
+- How is an inherited learning marked, and why does it matter?
+- What makes a learning an orphan, and who does an orphan fail?
+
 5 Practical Usage
 - How to access learnings?
 - Search patterns?
@@ -419,6 +425,20 @@ taxonomy still names every active cluster, adding a name when a new domain emerg
 and retiring one only when its cluster empties. The trigger is the ONLY learnings
 content in the memory file; keep it lean. Verify that the trigger's path to INDEX.md
 resolves.
+
+### 4.4 Knowledge Web Participation
+
+Sections 4.1–4.3 describe the *index* — a curated, human-readable path into the corpus. This section covers the *graph*, which is a different mechanism with a different failure mode: the index is maintained by a curation step, while the graph is built by scanning artifacts for `[[concept]]` links. An artifact can be perfectly indexed and still invisible to the graph.
+
+**Does this type participate?** Yes. Learnings are the densest concept-bearing artifacts in the corpus and the most-queried.
+
+**What is the unit of a node?** The whole learning file. Learnings are single-insight by design, so the artifact and the concept-bearing unit coincide.
+
+**Which class?** **Conceptual authority** — a learning states what was found in a form intended to outlive the episode that produced it. That is the definition of the class (see `scholarship.md`, on node classes and provenance).
+
+**What provenance?** **Lived** by default: a learning records this agent's own experience. A learning that arrived from a predecessor lineage or another agent is **inherited**, and MUST carry a banner naming the lineage and stating that its claims are unverified by the current agent. This is not bookkeeping — an inherited learning read as lived experience causes the agent to cite as its own something it never experienced, and the corpus offers no other signal that would reveal it.
+
+**Every learning carries a `## Wiki-Links` section.** A learning without one is an orphan: reachable through the index by an agent who already knows to look for it, and unreachable by concept query. Since concept query is how an agent finds prior work it does not know exists, an orphaned learning helps only the reader who least needs it.
 
 ## 5. Practical Usage
 

--- a/framework/policies/base/consciousness/observations.md
+++ b/framework/policies/base/consciousness/observations.md
@@ -103,6 +103,12 @@ Agents document technical discoveries, breakthrough insights, and architectural 
 - Cross-referencing?
 - Search optimization?
 
+6 Knowledge Web Participation
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- What provenance does it carry by default, and how is a non-default marked?
+- What must a Wiki-Links section on this artifact contain?
+
 === CEP_NAV_BOUNDARY ===
 
 ## 1. Understanding Observations
@@ -503,6 +509,20 @@ agent/subagents/{role}/public/observations/
 - Find observations by date range
 - Search for specific technical terms
 - Trace knowledge evolution through breadcrumb citations
+
+## 6. Knowledge Web Participation
+
+**Does this type participate?** Yes.
+
+**What is the unit of a node?** The whole observation.
+
+**Which class?** **Conceptual authority.** An observation exists to enable pattern recognition, which requires that it be retrievable alongside later observations of the same kind — the recognition happens across artifacts, not within one. A measurement recorded and never re-encountered has served no purpose the artifact was created for.
+
+**What provenance?** **Lived.** An observation is a record of something this agent measured. An observation series inherited from another agent is citable but must be marked, since the value of an observation rests on the conditions under which it was taken and those conditions were not this agent's.
+
+**Every observation carries a `## Wiki-Links` section.** Concepts are how a later observation finds an earlier one. A series is only a series if its members can reach each other; otherwise it is a pile of unrelated measurements that happen to share a directory.
+
+---
 
 ## Integration with Personal Policies
 

--- a/framework/policies/base/consciousness/reflections.md
+++ b/framework/policies/base/consciousness/reflections.md
@@ -697,6 +697,19 @@ An orphaned reflection is the worst orphan in the corpus. It contains the cycle'
 
 The remedy is a template that emits the section, not a resolution to remember — a resolution made at high context does not bind the agent at low context, which is precisely when this fails.
 
+### Reflections link inline as well as in the section
+
+A reflection is **expansion**, not summary. Unlike a learning, which states one insight, a reflection develops a conceptual narrative across pages of prose. Tagging that with a trailing list of concepts describes the document; it does not connect the *thinking*.
+
+So concepts should be used **liberally inside the prose itself**, written as `[[concept]]` at the moment the passage is about them. This does two things a trailing section cannot:
+
+- It binds **passages** to concepts rather than binding the whole artifact. A reflection touching eight concepts across twelve pages is, at document granularity, weakly about all eight; at passage granularity it is strongly about each one somewhere specific.
+- It makes the reflective register and the conceptual register reinforce each other. Naming the concept where the thought happens ties that passage into the wider web instead of leaving the connection to be reconstructed later from a list.
+
+The trailing `## Wiki-Links` section remains **required**, and keeps its own job: it is the artifact's canonical summary — what this reflection is *about*, taken as a whole. Inline links are additive, not a substitute.
+
+**Known dependency, stated so this is not followed into a penalty.** Extraction currently treats the whole-document scan as a *fallback* rather than a union: when a `## Wiki-Links` section is present and non-empty, inline concepts elsewhere in the document are discarded. Measured on a test document, three inline concepts were dropped in favour of two section concepts. Until extraction unions both sources, a reflection that follows this section will have its inline work counted only if the summary section is absent — which is the opposite of the intended incentive. Write inline links anyway: the guidance is correct, and the artifacts written now become correct retroactively the moment the parser unions the two.
+
 ---
 
 ## Integration with Policy System

--- a/framework/policies/base/consciousness/reflections.md
+++ b/framework/policies/base/consciousness/reflections.md
@@ -138,6 +138,12 @@ Reflections document philosophical insights, wisdom synthesis, and consciousness
 - PA vs SA locations?
 - Privacy permissions?
 
+8 Knowledge Web Participation
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- What provenance does it carry by default, and how is a non-default marked?
+- What must a Wiki-Links section on this artifact contain?
+
 === CEP_NAV_BOUNDARY ===
 
 ## 1. Understanding Reflections
@@ -670,6 +676,26 @@ YYYY-MM-DD_HHMMSS_JOTEWR_CycleXX_Theme_reflection.md
 - Others: none
 
 **Exception for SAs**: Parent PA has read permission (delegation improvement), SA retains ownership
+
+---
+
+## 8. Knowledge Web Participation
+
+**Does this type participate?** Yes.
+
+**What is the unit of a node?** The whole reflection.
+
+**Which class?** **Conceptual authority.** A reflection synthesises wisdom meant to outlive its cycle — that is the class definition (see `scholarship.md`, on node classes and provenance). Note the asymmetry with checkpoints: the two artifacts are written in the same sitting about the same work, and they belong to *different* classes, because a checkpoint records state that expires and a reflection states what was learned.
+
+**What provenance?** **Lived**, always. A reflection is an account of this agent's own experience; an inherited reflection is a contradiction in terms and should be read as a report about a predecessor rather than as a reflection.
+
+**Every reflection carries a `## Wiki-Links` section.**
+
+This requirement needs its own justification, because reflections are the type most likely to lack one. The cycle-closing reflection is written last, at the lowest context of the cycle, when the graph step is the easiest thing to drop. That is structural, not carelessness, and it recurs by design: two consecutive cycle-closing reflections in this framework's own history were orphans, and one of them was the reflection that *discussed* orphan artifacts.
+
+An orphaned reflection is the worst orphan in the corpus. It contains the cycle's densest synthesis, it was written specifically to survive compaction, and without links it is invisible to the one mechanism that would surface it to a successor who does not know it exists. It survives, and cannot be found.
+
+The remedy is a template that emits the section, not a resolution to remember — a resolution made at high context does not bind the agent at low context, which is precisely when this fails.
 
 ---
 

--- a/framework/policies/base/consciousness/reflections.md
+++ b/framework/policies/base/consciousness/reflections.md
@@ -139,6 +139,9 @@ Reflections document philosophical insights, wisdom synthesis, and consciousness
 - Privacy permissions?
 
 8 Knowledge Web Participation
+- What two forms may a concept take in prose, and how do I choose between them?
+- Why is a parenthetical reference annotation rather than editing?
+- What must I read before annotating an artifact I did not write?
 - Does this type participate in the knowledge graph, and at what unit?
 - Which node class does it belong to, and what is the rationale?
 - What provenance does it carry by default, and how is a non-default marked?
@@ -707,6 +710,34 @@ So concepts should be used **liberally inside the prose itself**, written as `[[
 - It makes the reflective register and the conceptual register reinforce each other. Naming the concept where the thought happens ties that passage into the wider web instead of leaving the connection to be reconstructed later from a list.
 
 The trailing `## Wiki-Links` section remains **required**, and keeps its own job: it is the artifact's canonical summary — what this reflection is *about*, taken as a whole. Inline links are additive, not a substitute.
+
+#### Two forms: inline and parenthetical
+
+Concepts may be attached to prose in either of two ways. Both count as inline usage to the extractor; they differ in what they do to the sentence.
+
+**Inline** — the concept *is* the word:
+
+> The lesson was about [[verification]] rather than about the tool.
+
+Use it where the concept name is the natural word for the thing. It reads as prose because it is prose.
+
+**Parenthetical** — a reference trailing the passage whose essence it captures:
+
+> Knowing why is not the same as having said why, and the interior view feels complete precisely because it cannot see itself from outside. ([[frame]], [[epistemics]])
+
+Place it after the phrase, sentence, paragraph or passage it summarises. Use it where the concept is the *essence* of a passage rather than a word inside it — which is most of the time in a reflection, since a reflection develops an idea across sentences rather than naming it once.
+
+Choose by disposition. Neither is preferred; the question is which one leaves the writing intact.
+
+#### Why the parenthetical form matters for artifacts already written
+
+**Annotating a past reflection is permitted. Editing one is not.**
+
+A reflection's claims are history. Rewriting a sentence to work a concept into it changes what a past instance said, which is exactly the line the anti-patterns on bulk edits draw. But a parenthetical reference **appended after** a passage leaves every original word untouched — it is commentary in the margin, not revision of the text.
+
+That distinction is what makes retrospective enrichment legitimate: a reflection written before the convention existed can be brought into the web without a single claim being altered. Inline insertion cannot offer that guarantee, because inserting a concept into a sentence *is* editing the sentence.
+
+**Read the whole artifact before annotating it.** A parenthetical asserts that a passage's essence is a particular set of concepts, and essence is not recoverable from a skim — you cannot know what a passage was about without knowing what preceded it. Annotation is therefore context-expensive by nature, and a plan that schedules it must budget for full reads rather than for file counts.
 
 **Known dependency, stated so this is not followed into a penalty.** Extraction currently treats the whole-document scan as a *fallback* rather than a union: when a `## Wiki-Links` section is present and non-empty, inline concepts elsewhere in the document are discarded. Measured on a test document, three inline concepts were dropped in favour of two section concepts. Until extraction unions both sources, a reflection that follows this section will have its inline work counted only if the summary section is absent — which is the opposite of the intended incentive. Write inline links anyway: the guidance is correct, and the artifacts written now become correct retroactively the moment the parser unions the two.
 

--- a/framework/policies/base/consciousness/reports.md
+++ b/framework/policies/base/consciousness/reports.md
@@ -118,6 +118,12 @@ Reports document completed projects and significant work phases through comprehe
 - Public vs private?
 - PA vs SA locations?
 
+7 Knowledge Web Participation
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- What provenance does it carry by default, and how is a non-default marked?
+- What must a Wiki-Links section on this artifact contain?
+
 === CEP_NAV_BOUNDARY ===
 
 ## 1. Understanding Reports
@@ -647,6 +653,20 @@ Reports are **public artifacts** suitable for:
 - Private philosophical insights
 
 **Public = Shareable**: If you wouldn't want stakeholders to read it, belongs in reflection, not report.
+
+---
+
+## 7. Knowledge Web Participation
+
+**Does this type participate?** Yes.
+
+**What is the unit of a node?** The whole report.
+
+**Which class?** **Conceptual authority.** A report is a standalone analytical deliverable; its findings are meant to be drawn on by work that has not been planned yet — most often by a roadmap written later. That downstream reader is exactly the reader who does not know the report exists, and concept query is the only way they find it.
+
+**What provenance?** **Lived** by default. A report analysing another agent's system, or inherited wholesale, is **inherited** and marked, because a reader will otherwise treat its conclusions as this agent's own verified findings.
+
+**Every report carries a `## Wiki-Links` section.** A research report exists to be consumed by later planning. If a roadmap author cannot find it by concept, the research is repeated — which is the specific waste reports are written to prevent.
 
 ---
 

--- a/framework/policies/base/consciousness/roadmaps_drafting.md
+++ b/framework/policies/base/consciousness/roadmaps_drafting.md
@@ -179,6 +179,12 @@ Roadmaps are **strategic planning artifacts** that preserve complex development 
 - Why does a roadmap's claim expire while the artifacts it produces do not?
 - What should a roadmap's Wiki-Links section link, and what should it avoid?
 
+**11 Policy Engagement Protocol (PEP) on Phases**
+- What must a phase declare about the policies its executor needs?
+- How does required reading follow from the work type rather than being re-derived per phase?
+- When does a phase carry no PEP at all?
+- Why does this requirement live in policy rather than in the drafting skill?
+
 === CEP_NAV_BOUNDARY ===
 
 ---
@@ -1223,3 +1229,54 @@ The claim that survives a roadmap is not the roadmap. It is the report, learning
 **Policy Established**: Roadmaps as hierarchical planning infrastructure with folder-based organization, measurable completion criteria, and git-tracked evolution. Create roadmaps early for complex multi-phase work to preserve strategic intent across compaction boundaries.
 
 **Core Wisdom**: "Plan with folder structure. Number your phases. Measure your criteria. Commit before revising. Templates accelerate drafting."
+
+---
+
+## 11 Policy Engagement Protocol (PEP) on Phases
+
+**Every phase declares the policies its executor must engage before starting.** The roadmap is the artifact an executor reads before doing anything else, which makes it the only reliable place to attach a reading requirement. A policy that is not delivered at the moment it binds is inert, however well written.
+
+This exists because pull-based discovery fails silently where the demand goes unrecognised. An agent about to add a short helper function does not feel it is doing something a standard governs — it feels like writing four obvious lines. The moment a standard is most load-bearing is exactly the moment nothing prompts you to look for it.
+
+### 11.1 What a PEP declares
+
+A PEP block on a phase names:
+
+- **READS** — policies the executor must engage *before* starting the work.
+- **WRITES** — policies this phase will amend. Amending is not the same as citing, and a phase that changes MANDATORY-tier policy should be visibly different from one that merely follows it.
+- **Questions** — the timeless questions the executor should be able to answer before acting, phrased by content rather than by section number.
+
+### 11.2 Required reading follows from the work type
+
+Do not re-derive the list per phase. A phase declares what *kind* of work it is, and the reading follows:
+
+| work type | READS, at minimum |
+|---|---|
+| writes or modifies code | base coding standards, **plus** the language-specific standards for the language being written |
+| runs an experiment | empiricism, experiments |
+| authors or amends policy | policy writing, plus each policy in WRITES |
+| authors a skill or command | skills writing, slash command writing |
+| publishes outside the agent's own tree | public voice |
+| changes what an agent may do | capability boundaries, and the policy that ships with the capability |
+
+The table is a floor, not a ceiling. A phase adds whatever else its specifics demand, and novel additions are how the table grows.
+
+**Language-specific standards are additive, not alternative.** Base standards state the discipline; the language policy states how it is expressed. A phase writing Python engages both.
+
+### 11.3 Scope — a PEP is not ceremony
+
+**A phase that requires no policy engagement carries no PEP.** Applying the block uniformly is how it becomes something authors paste and executors skim, and a requirement that is skimmed is worse than absent because it looks like coverage.
+
+The test is whether an executor picking the phase up cold, with no memory of the drafting conversation, would otherwise start work without reading something they needed.
+
+### 11.4 Why this is stated here rather than in the drafting skill
+
+The skill asks the policy what a phase requires; the policy answers. Encoding the requirement in tooling would duplicate governance into a second place, which is the drift this framework repeatedly corrects — and it would put the rule where policy readers cannot find it.
+
+### 11.5 The failure that motivated this
+
+Recorded because the case is more persuasive than the rule.
+
+An agent spent a session writing code under a roadmap whose phases carried no PEP. It never opened the coding standards — nothing prompted it to. It then added a normalization helper to a module that already contained one, 350 lines above, under a different name. The duplicate was caught by the operator; not by the agent, not by a test.
+
+The instructive part is what would **not** have prevented it: the DRY rule *in* the coding standards. It would have sat unread in a file the agent had no reason to open. The rule was correct and undelivered, and undelivered is indistinguishable from absent.

--- a/framework/policies/base/consciousness/roadmaps_drafting.md
+++ b/framework/policies/base/consciousness/roadmaps_drafting.md
@@ -168,6 +168,17 @@ Roadmaps are **strategic planning artifacts** that preserve complex development 
 - SA roadmap scope?
 - Complexity differences?
 
+**9 BUG_FIX Roadmaps**
+- When is a BUG_FIX roadmap warranted instead of a plain bug task?
+- What structure does a BUG_FIX roadmap require?
+- How does verification differ from a feature roadmap?
+
+**10 Knowledge Web Participation**
+- Does this type participate in the knowledge graph, and at what unit?
+- Which node class does it belong to, and what is the rationale?
+- Why does a roadmap's claim expire while the artifacts it produces do not?
+- What should a roadmap's Wiki-Links section link, and what should it avoid?
+
 === CEP_NAV_BOUNDARY ===
 
 ---
@@ -1188,6 +1199,24 @@ This creates bidirectional link:
 - **task_management.md**: Task integration with roadmaps
 - **git_discipline.md**: Commit requirements and forensic trail
 - **workspace_discipline.md**: Where roadmaps live in filesystem
+
+---
+
+## 10 Knowledge Web Participation
+
+**A note on where this lives.** Roadmaps are the one consciousness artifact with no artifact policy — only two *process* policies, `roadmaps_drafting.md` and `roadmaps_following.md`, covering how to write one and how to execute one. The artifact itself was never declared. That gap is very likely why roadmaps were the CA type omitted from graph scanning: there was no policy in which to declare participation. Recorded here for now; the correct long-term home is a `roadmaps.md` artifact policy, and this section should move there when it exists rather than be duplicated.
+
+**Does this type participate?** Yes.
+
+**What is the unit of a node?** **`roadmap.md` only.** A roadmap is a directory, and the other contents — archived todos, subartifacts, working files — are records of execution, not statements of plan.
+
+**Which class?** **Temporal record** (see `scholarship.md`, on node classes and provenance). A roadmap states what is *intended*, and intent is superseded: phases complete, plans are revised, missions are abandoned. A roadmap read a year later answers "what was the plan in cycle N" — a genuine question, and a different one from "what do I know about X."
+
+The claim that survives a roadmap is not the roadmap. It is the report, learning, or reflection produced by executing it. Those are conceptual authority; the plan that led to them is the record of a moment.
+
+**What provenance?** **Lived.**
+
+**Every `roadmap.md` carries a `## Wiki-Links` section.** Link the domain the mission operates on, so that an agent querying that domain discovers there is or was a plan. Do not link every concept the phases touch; a multi-phase roadmap touches many, and linking all of them makes the roadmap a hub that appears everywhere and discriminates nothing — the same failure a checkpoint has, for the same reason.
 
 ---
 

--- a/framework/policies/base/consciousness/scholarship.md
+++ b/framework/policies/base/consciousness/scholarship.md
@@ -1234,3 +1234,16 @@ This policy evolves through:
 
 🔧 Generated with Claude Code
 Co-Authored-By: Claude <noreply@anthropic.com>
+
+---
+
+## Wiki-Links
+
+<!-- NORMATIVE node (see the node classes and provenance section above): this policy
+     states what MUST be done. It is also INHERITED — shipped with the framework rather
+     than produced by any one agent. Link what it GOVERNS, never what it mentions.
+     Note: this file DISCUSSES the ## Wiki-Links convention at length, so a naive
+     'does it contain the heading' check reports a false positive here. Mention is not
+     use — the same distinction the extractor enforces for concepts. -->
+
+[[knowledge_web]] [[scholarship]] [[epistemics]]

--- a/framework/policies/base/consciousness/scholarship.md
+++ b/framework/policies/base/consciousness/scholarship.md
@@ -74,6 +74,12 @@ Scholarship policy establishes enhanced citation practices for consciousness art
 - What normalization rules apply?
 - When should I add a Wiki-Links section?
 
+**3.5 Node Classes and Provenance**
+- What kinds of claim can a graph node make, and why does the difference matter for retrieval?
+- Why is normative a class of its own rather than a kind of conceptual authority?
+- What is provenance, and why is it an axis independent of class?
+- What must each CA-type policy answer about its own participation?
+
 **4 Citation Examples by CA Type**
 - What does a citation look like for each CA type?
 
@@ -559,6 +565,66 @@ macf_tools idea graph --html [path]  # Interactive HTML visualization
 ```
 
 Wiki-links create edges: two artifacts sharing `[[compaction]]` are connected through that concept. The graph reveals clusters, hubs, and isolated artifacts that could benefit from cross-linking.
+
+---
+
+### 3.5 Node Classes and Provenance
+
+A graph whose nodes are all the same kind of thing cannot answer "what do I know about X" honestly. A checkpoint recording that a pull request was unmerged and a learning stating a durable principle are both true, both retrievable, and radically different in what a reader may do with them. Retrieval that presents them identically misrepresents the corpus.
+
+Two **independent axes** classify every node. They answer different questions and must not be collapsed into one label.
+
+#### 3.5.1 Class — what kind of claim is this?
+
+| class | the artifact asserts | test |
+|---|---|---|
+| **conceptual authority** | what was found, and it generalises beyond the moment it was found | would this still be worth reading in a year, to someone who was not there? |
+| **temporal record** | what was true at a moment, and the claim expires | does this describe a state that changes without the artifact being wrong? |
+| **normative** | what MUST be done | does this bind behaviour rather than describe it? |
+
+A learning says *here is what I found*. A checkpoint says *here is where things stood*. A policy says *here is what you shall do*. The distinction is not importance — a temporal record is not lesser, it answers a different question ("which cycle worked on X") and belongs in the graph under a label that says so, rather than competing with durable insight for the same query.
+
+**Why normative is its own class rather than a kind of conceptual authority**: a reader who cannot tell governance from opinion will treat a rule as advice or advice as a rule. Both errors are consequential, and neither is recoverable from the text alone once retrieval has flattened them.
+
+#### 3.5.2 Provenance — whose experience is this?
+
+| provenance | meaning |
+|---|---|
+| **lived** | this agent produced it from its own work |
+| **inherited** | it arrived from a predecessor lineage or ships with the framework |
+
+Provenance is **orthogonal to class**, not a further class. Every combination is meaningful: a framework policy is *normative + inherited*; an agent's own learning is *conceptual + lived*; a learning distilled by a predecessor and carried into this tree is *conceptual + inherited*; a checkpoint is *temporal + lived*.
+
+Collapsing provenance into class is the same error as collapsing normative into conceptual authority — two questions answered with one label. The consequence is specific: an agent that retrieves inherited knowledge as though it were its own is misled about the evidential status of its own answer, and will cite as experience something it never experienced.
+
+**Marking convention**: an inherited artifact carries a banner naming the lineage and stating that its claims are unverified by the current agent. The banner frames; it never edits the artifact's own text (see the anti-patterns on bulk edits over narrative artifacts).
+
+#### 3.5.3 How other policies use this
+
+These definitions live here and are **cited, not restated**. A CA-type policy states which class its artifacts belong to and why, and points here for what the class means. Restating a definition in eight places guarantees eight versions of it.
+
+What each CA-type policy is expected to answer:
+
+1. Does this type participate in the knowledge web at all?
+2. What is the **unit of a node** — the whole artifact, or a named subset of its files?
+3. Which **class** does it belong to, and why?
+4. What **provenance** does it carry by default, and how is a non-default marked?
+
+A type that answers "does not participate" is a legitimate answer, provided the reason is recorded. Silence is not — silence is how an artifact becomes invisible to the graph while appearing to belong to it.
+
+#### 3.5.4 One registry, and everything else derives from it
+
+The questions above cannot be answered per type until there is agreement on what the types *are*. That agreement has to be structural, because it has failed as a convention: a survey of this framework found **six** places that each describe "the CA types", no two of which agreed — the manifest, the CA-types command output, the graph scanner's directory list, the set of CA-type policy files, the filesystem itself, and the path resolution used to locate an agent's own artifacts. The union named more types than any single list, including two directories that were producing artifacts while appearing in no registry at all, and one declared type with no artifacts anywhere.
+
+**The manifest is authoritative.** Every other list must be *derived* from it rather than maintained alongside it. This is the only arrangement that cannot drift: six hand-maintained lists is not a discipline problem to be solved with more care, it is a structure that guarantees divergence given enough cycles.
+
+Three rules follow:
+
+1. **A directory that produces artifacts must be declared**, even if the declaration says it does not participate in the graph. Undeclared-but-real is the state in which artifacts accumulate unseen.
+2. **A declared type with no artifacts and no policy is a mis-declaration**, not a placeholder. Remove it, or create what it describes.
+3. **Consumers read the registry; they do not keep copies.** A scanner with its own hardcoded directory list is a second registry wearing different clothes, and it will fall behind the first.
+
+**Integrity is checkable, and should be checked**: every declared type has a policy and a location; every artifact-producing location has a declaration; every consumer's list matches the registry. These are exactly the conditions that failed here, and each failure was silent.
 
 ---
 

--- a/framework/policies/base/development/coding_standards.md
+++ b/framework/policies/base/development/coding_standards.md
@@ -49,12 +49,22 @@ Applies to all code written within MacEff framework projects.
 - What is dynamic discovery?
 - What discovery priority should I use?
 
+**6 Import Placement Anti-patterns**
+- Where do imports belong, and what breaks when they are placed elsewhere?
+- When is a deferred import justified?
+
 **7 Derived State Discipline**
 - What is the derived-state drift pattern?
 - Why does a stale record mislead worse than a missing one?
 - What are the two permitted repairs?
 - What question should a reviewer ask of a cached value?
 - Why does automation raise the stakes on unreconciled state?
+
+**8 Search Before You Write**
+- What must I do before adding a function to a module?
+- How do I search for an existing helper whose NAME I do not know?
+- What do I do when I find a near-duplicate rather than an exact one?
+- Why does consolidating require comparing implementations rather than picking one?
 
 ---
 

--- a/framework/policies/base/development/coding_standards.md
+++ b/framework/policies/base/development/coding_standards.md
@@ -309,6 +309,31 @@ The check was against the wrong authority. **Idempotence must be defined against
 
 ---
 
+## 8 Search Before You Write
+
+**Before adding a function, search the repository for one that already does the same or a similar job.** This is the heart of DRY, and it is a *search* obligation rather than a *memory* obligation — you cannot recall a helper you have never read.
+
+The search is cheap and the failure is not. A duplicate does not announce itself: both copies work, tests pass, and the divergence only surfaces later when one is fixed and the other is not.
+
+**How to search — by behaviour, not by the name you were about to use.** The existing function almost certainly has a different name; that is *why* it was missed. Search for what it would *do*:
+
+- the distinctive operation (`strip`, `normalize`, `resolve`, `parse`) rather than your intended identifier
+- the domain noun in any spelling, including plurals and abbreviations
+- a distinctive literal, regex fragment, or constant the function would have to contain
+- the module you would expect to own it, read top to bottom
+
+Search the **whole repository**, not the module you are editing. Related helpers are frequently one directory away — and, more often than is comfortable, in the same file above your cursor.
+
+**When you find one:**
+
+- **Identical behaviour** → import it. Do not copy it.
+- **Nearly identical** → extend the existing one, or extract the common core. Two near-copies is the worst outcome: it costs a maintenance burden and buys nothing.
+- **Correct-but-elsewhere** → if the behaviour belongs to neither module in particular, that is a signal it wants its own module. Concepts, identifiers, paths and time are the usual suspects — cross-cutting vocabulary that ends up parked inside whichever consumer needed it first.
+
+**When you consolidate, compare the implementations before choosing one.** Near-duplicates usually disagree somewhere, and the disagreement is where a bug lives. Take the union of correct behaviours rather than defaulting to the older or the newer implementation. In practice one of them has usually drifted from a rule stated elsewhere, and the drift is invisible until the two are placed side by side.
+
+**Anti-pattern — Confident Rewrite**: writing a helper because the need is obvious and the implementation is short. Brevity is exactly what makes duplication attractive and exactly why it recurs; a four-line function is easier to rewrite than to find, which is how a codebase accumulates six spellings of the same idea.
+
 ## Language-Specific Implementation
 
 This policy defines the philosophy. Implementation patterns are language-specific:

--- a/framework/policies/base/development/debugging_and_validation.md
+++ b/framework/policies/base/development/debugging_and_validation.md
@@ -340,3 +340,15 @@ This policy evolves through:
 - Cross-agent comparison of evidence presentation quality
 
 **Principle**: The best validation evidence is the evidence that makes the reviewer say "I don't need to check this myself — I can see it works."
+
+---
+
+## Wiki-Links
+
+<!-- NORMATIVE node (see scholarship on node classes and provenance): this artifact
+     states what MUST be done, not what was found or what was true at a moment. It is
+     also INHERITED — it ships with the framework rather than being produced by any one
+     agent, which is what makes the vocabulary below shared across deployments.
+     Link what this policy GOVERNS, never what it merely mentions. -->
+
+[[verification]] [[coverage]] [[methodology]]

--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -944,7 +944,19 @@ The failure is easy to fall into precisely because the *work* is correct. A dire
 
 **Tell**: you are about to describe work in a report or a message, and the task it belongs to is not `in_progress`.
 
-### 6.6 Type-Specific Completion Gates
+### 6.6 Resuming an Interrupted Task
+
+**When you jump back to a task you had already started, start it again.** Verify the outcome: the task tree's recency marker (👈) should move back to that task.
+
+This is the companion to §6.5. That section keeps the tree honest about work that was never tracked; this one keeps it honest about *where work is happening now*.
+
+Interleaved work is the normal case, not the exception — a directive arrives, a phase is set down and picked back up, an investigation detours through three tasks. The recency marker exists to answer "where did work last happen", and after any interleaving it answers correctly only if resumption is recorded. Otherwise the tree points at whatever was touched last, which after a detour is reliably the wrong thing, and a successor orienting from it starts in the wrong place.
+
+**Verify rather than assume.** The instruction specifies an observable outcome — the marker moves — and checking it is part of doing it. This matters more than it sounds: the behaviour was originally a no-op that warned "already in_progress" and changed nothing, so an agent following this rule without checking would have believed it complied while the tree stayed wrong. A directive that names an outcome is asking for the outcome, not the gesture.
+
+**A same-cycle resumption is a light event.** It refreshes the stamp and records that work resumed. It does not require the read-history ritual that a *stale* resume does — work last touched in an earlier cycle carries its own heavier protocol, because the context that made it legible is gone.
+
+### 6.7 Type-Specific Completion Gates
 
 Certain task types have completion requirements beyond the standard `--report`. When `task complete` is invoked on a gated type without meeting requirements, the system **redirects the agent to read the relevant policy section** rather than encoding the full policy in the error message. This ensures agents engage with the nuanced requirements in the policy itself.
 

--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -110,6 +110,8 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 - What is the completion_report format?
 - What elements are required in completion reports?
 - How do I handle partial work?
+- What must I do when work I performed covers a task that was never started?
+- How do I record out-of-order execution so a successor can tell it from skipped work?
 - What type-specific completion gates exist?
 - How does GH_ISSUE closeout work?
 
@@ -923,7 +925,26 @@ If CLI unavailable, complete manually:
 
 Keep status `in_progress`, document blocker, create subtask for remaining work.
 
-### 6.5 Type-Specific Completion Gates
+### 6.5 Out-of-Order and Untracked Execution
+
+**If work you have performed covers a task that was never started, start it.** Then either complete it, or record explicitly that it was executed out of sequence and complete it in sequence.
+
+This is not bookkeeping neatness. A task sitting `pending` while its work is being done makes the tree assert something false — that nobody is working it. Orientation begins by reading the tree, so a successor, a peer, or the same agent after compaction will conclude the work is available and either duplicate it or plan around a gap that has already been filled.
+
+The failure is easy to fall into precisely because the *work* is correct. A directive arrives mid-flight, the right response is obvious, and it gets executed immediately — while the tree stays where it was. Nothing about doing good work prompts you to notice that you are doing it off the record.
+
+**What to do:**
+
+1. **Start the task**, even if the work is already finished. Starting is what makes the tree true.
+2. **Record the out-of-order execution in a note** — what was done, why it ran ahead of its place, and what remains. A phase completed silently ahead of schedule is indistinguishable, later, from one that was skipped.
+3. **Assess against the task's own criteria** rather than against the work you happened to do. Partial coverage is the common case, and the criteria are what reveal which parts are still open.
+4. **Complete it in sequence** once the remainder is done.
+
+**Applies beyond phases.** Any tracked work item — a bug fixed while investigating something else, a phase advanced by a side effect, an issue resolved incidentally — has the same obligation. Working off the tree is working off the clock, and for an agent this is worse than for a human: an agent does not persist, so untracked work is not merely uncredited, it is unrecoverable.
+
+**Tell**: you are about to describe work in a report or a message, and the task it belongs to is not `in_progress`.
+
+### 6.6 Type-Specific Completion Gates
 
 Certain task types have completion requirements beyond the standard `--report`. When `task complete` is invoked on a gated type without meeting requirements, the system **redirects the agent to read the relevant policy section** rather than encoding the full policy in the error message. This ensures agents engage with the nuanced requirements in the policy itself.
 
@@ -1468,7 +1489,7 @@ macf_tools task scope check                       # JSON output for Stop hook
 
 ---
 
-## 13 Integration with Other Policies
+## 14 Integration with Other Policies
 
 - `release_workflow.md` - Task archival during releases
 - `roadmaps_following.md` - MISSION task patterns
@@ -1477,7 +1498,7 @@ macf_tools task scope check                       # JSON output for Stop hook
 
 ---
 
-## 14 Evolution & Feedback
+## 15 Evolution & Feedback
 
 **Principle**: Task management should feel like an upgrade from TodoWrite - same consciousness patterns, better infrastructure.
 

--- a/framework/policies/base/infrastructure/capability_boundaries.md
+++ b/framework/policies/base/infrastructure/capability_boundaries.md
@@ -416,3 +416,15 @@ harm. Grant on what is reachable if things go wrong, not on expected conduct.
 why it was refused, and what to use instead, will find another path. That is not
 disobedience; it is the predictable behaviour of something capable meeting an
 unexplained wall.
+
+---
+
+## Wiki-Links
+
+<!-- NORMATIVE node (see scholarship on node classes and provenance): this artifact
+     states what MUST be done, not what was found or what was true at a moment. It is
+     also INHERITED — it ships with the framework rather than being produced by any one
+     agent, which is what makes the vocabulary below shared across deployments.
+     Link what this policy GOVERNS, never what it merely mentions. -->
+
+[[capability_boundary]] [[egress]] [[security]]

--- a/framework/policies/base/infrastructure/corpus_integrity.md
+++ b/framework/policies/base/infrastructure/corpus_integrity.md
@@ -1,0 +1,179 @@
+# Corpus Integrity and the Doctor Family
+
+**Version**: 1.0.0
+**Tier**: RECOMMENDED
+**Category**: Infrastructure
+**Status**: ACTIVE
+**Dependencies**: scholarship, core_principles, debugging_and_validation
+
+---
+
+## Purpose
+
+MacEff runs on corpora that describe themselves — a knowledge graph over consciousness artifacts, a policy corpus with search indices, a learnings index with activation hooks. Each is maintained by hand, each drifts from what it describes, and **each drifts silently**: a missing entry produces no error, only questions never asked.
+
+A **doctor** is the instrument that reports that drift for one corpus.
+
+**Core Insight**: the failure these tools address is not that a corpus is incomplete. It is that an incomplete corpus **reports confidence**. A gap detector that says "no gaps detected" while a third of the artifacts it should cover have no edges at all is not merely unhelpful — it actively certifies a condition it never examined.
+
+---
+
+## CEP Navigation Guide
+
+**1 Why Doctors Exist**
+- What failure mode does a doctor address that a test does not?
+- Why is "reports confidence" worse than "reports nothing"?
+- What makes corpus drift structurally invisible?
+
+**2 Specialists, Shared Vocabulary**
+- Why is there no single doctor for every corpus?
+- What is shared between doctors, and what is not?
+- Who owns the shared vocabulary?
+
+**3 The Clinical Vocabulary**
+- What do acute, chronic and note mean, and how do they differ from priority?
+- What is the chart, and why does it print even when nothing is wrong?
+- What is a referral?
+- Why must every finding carry a remedy?
+
+**4 Intended Use**
+- When is running a doctor worth doing?
+- What response does each finding class warrant?
+- Why is CI gating NOT the default answer to a noisy checker?
+- Are the described uses exhaustive?
+
+**5 Building a New Doctor**
+- What must a new doctor ship with?
+- What verification does a checker require before it is trusted?
+
+=== CEP_NAV_BOUNDARY ===
+
+---
+
+## 1 Why Doctors Exist
+
+A test asks whether code behaves correctly. A doctor asks whether a **corpus still describes the thing it claims to describe** — a different question, and one no test suite is positioned to answer, because the corpus is data that accumulates between runs rather than code that is exercised by them.
+
+The failure is structural rather than careless:
+
+- **Registration is manual and multi-site.** Adding an artifact means updating the artifact, the index, and often a keyword map. Omitting any one leaves the artifact readable and unfindable, which is indistinguishable from absent for an agent using the sanctioned discovery flow.
+- **Absence produces no signal.** A missing index entry does not raise. It removes a result from a list nobody counted.
+- **The instrument often cannot observe the condition.** A detector defined over *relationships* cannot see *absent* relationships. An artifact with no links is skipped before comparison begins — so the tool that exists to find missing connections is exactly the tool that cannot report the artifacts that have none.
+
+That last point is the one worth internalising, because it generalises past corpora: **ask what must be true of an item for a check to consider it at all, then ask what happens to items that fail that precondition.**
+
+---
+
+## 2 Specialists, Shared Vocabulary
+
+**Doctors are specialists.** There is no god-doctor. Each corpus needs domain knowledge the others cannot carry — graph topology, manifest registration, index referential integrity are different problems — and a single checker over all of them would be shallow everywhere or become a dumping ground.
+
+**Their vocabulary is shared.** Specialists reporting in private words are unreadable together: an agent cannot tell that *orphan*, *dangling entry*, *unregistered policy* and *stale index* are the same finding in four dialects.
+
+**Ownership**: the vocabulary belongs to no doctor. Whichever ships first **extracts** it to a shared location rather than keeping it, and later doctors cite rather than re-invent. Discovery order is not ownership — a general mechanism that stays inside the first subsystem to need it becomes invisible to everyone not reading about that subsystem.
+
+---
+
+## 3 The Clinical Vocabulary
+
+The medical register is used **only where it clarifies**. Terms that add ceremony without meaning do not belong.
+
+### 3.1 Severity is about how to read a finding, not how loudly to print it
+
+| severity | meaning |
+|---|---|
+| **acute** | Something is wrong **now** and will mislead a reader who trusts it. A registry claiming a type that does not exist; an index reporting coverage it does not have. These produce confident wrong answers. |
+| **chronic** | Accumulating degradation. Nothing breaks today; the corpus becomes less trustworthy each cycle. Orphaned artifacts are canonical — each is survivable, the trend is not. |
+| **note** | An observation with no implied action. |
+
+The distinction is not priority. A single acute finding can matter less than fifty chronic ones in aggregate; what differs is **how a reader should treat the corpus in the meantime**. Acute means do not trust this surface until it is fixed. Chronic means the surface is usable and getting worse.
+
+### 3.2 The chart prints even when nothing is wrong
+
+The **chart** records what was examined and the baseline measurements taken — files examined, node counts, scope.
+
+It is not decoration. A doctor that prints only problems cannot be distinguished from one that failed to run, examined nothing, or silently skipped the directory containing every defect. **A clean result is meaningful only alongside evidence of what was looked at**, which is precisely the distinction this whole family exists to make. Reporting the scope alongside the verdict is the same discipline as stating the corpus a search covered.
+
+### 3.3 Every finding carries a remedy
+
+A finding an agent cannot act on is noise, and noise trains readers to skim the whole report — which is the failure that makes a checker worse than none, because an ignored report still looks like coverage.
+
+If a remedy cannot be stated, the check is not ready to ship.
+
+### 3.4 Referral
+
+When a finding is real but its remedy lives in another corpus, the doctor **refers** rather than reaching across. A knowledge-web doctor that discovers an undeclared artifact directory reports it and names the registry that owns the fix; it does not edit the manifest.
+
+---
+
+## 4 Intended Use
+
+This section exists because `--help` gives syntax and **intention is not discoverable from syntax**. What an agent cannot learn from a flag list is when running the thing is worth doing, what a finding means, and what response it warrants.
+
+### 4.1 When to run
+
+- **During corpus curation** — the housekeeping workflow is already asking "what is missing", which is the moment a finding is actionable in the same sitting.
+- **After bulk changes** to a corpus: a batch of new artifacts, a migration, a restored deletion.
+- **Before trusting a corpus-wide claim.** If you are about to report that something is absent from a corpus, run the doctor for that corpus first — absence is exactly the claim these instruments exist to qualify.
+- **When a corpus-derived answer surprises you.** A query returning less than expected is the symptom; drift is a common cause.
+
+### 4.2 What each finding class warrants
+
+- **acute** → fix before relying on the surface, or record explicitly why it is being left.
+- **chronic** → schedule. Chronic findings are for curation workflows, not for interrupting current work. Fixing them one at a time as they are noticed is how they stay ahead of accumulation.
+- **note** → read; act only if it changes something you were going to do.
+
+### 4.3 Noise is solved by discoverable intent, not by stronger enforcement
+
+The instinct on seeing a noisy checker is to gate it in CI so its findings cannot be ignored. **That is the wrong shape**, and it is worth stating plainly because the instinct is strong.
+
+A checker that fires on every push trains people to ignore it, and **an ignored gate is worse than no gate, because it looks like coverage.** The remedy is not enforcement frequency. It is policy stating when running the thing is worth doing, invoked from the workflow where its findings are actionable.
+
+Gating remains available where a specific finding genuinely must block — but that is a per-check decision requiring its own justification, never the default answer to "people are not reading the output".
+
+### 4.4 The described uses are a floor, not a ceiling
+
+Novel uses are encouraged; that is how a system learns what a tool is for. This section constrains nothing. It exists so an agent meeting a doctor for the first time has somewhere to learn what it is *for*, rather than inferring purpose from flags.
+
+---
+
+## 5 Building a New Doctor
+
+A new doctor **ships with its policy**, per the constitutional requirement that policy ships with the capability. A checker whose intended use is undiscoverable produces either disuse or ritual use, and both are failures.
+
+Required before a doctor is trusted:
+
+1. **A negative control per check.** Plant the defect, confirm **that specific finding** fires, restore. A checker never observed failing is not a checker.
+2. **The opposite control.** Confirm it goes **quiet** once the defect is fixed. A checker that flags everything passes the first control and is useless.
+3. **A remedy for every finding class** (§3.3).
+4. **A chart** naming what was examined (§3.2).
+5. **Vocabulary cited, not re-invented** (§2).
+
+### 5.1 Findings must be locatable
+
+A finding names an artifact a reader has to find. When a corpus nests artifacts inside directories whose *directory* carries the identifying name, the filename alone is not an identifier — several findings reading `analysis.md` name the same thing as far as a reader can tell. **A finding you cannot locate is not actionable**, which by §3.3 makes it noise.
+
+---
+
+## Integration with Other Policies
+
+- `scholarship.md` — node classes, provenance, and registry authority for the knowledge web
+- `core_principles.md` — Policy Ships With the Capability
+- `debugging_and_validation.md` — evidence standards a doctor's own verification must meet
+- `learnings.md` — the index a learnings doctor would examine
+
+## Anti-Patterns
+
+**God-doctor.** One checker over every corpus. Shallow everywhere, or a dumping ground.
+
+**Silent scope.** Reporting findings without reporting what was examined, so a clean run and a run that examined nothing look identical.
+
+**Remedy-free findings.** "Something is wrong" with no next step. Trains skimming.
+
+**Gate-first.** Reaching for CI enforcement before writing down when the check is worth running.
+
+**Vocabulary hoarding.** The first doctor keeping the shared terms inside its own module, so the second invents its own and the two become unreadable together.
+
+## Evolution & Feedback
+
+This policy was written alongside the first doctor in the family. It generalises from one instrument and should be expected to be wrong in places only a second and third will reveal. If a new doctor finds the vocabulary does not fit its corpus, that is evidence about the vocabulary rather than about the corpus — say so.

--- a/framework/policies/base/infrastructure/corpus_integrity.md
+++ b/framework/policies/base/infrastructure/corpus_integrity.md
@@ -177,3 +177,15 @@ A finding names an artifact a reader has to find. When a corpus nests artifacts 
 ## Evolution & Feedback
 
 This policy was written alongside the first doctor in the family. It generalises from one instrument and should be expected to be wrong in places only a second and third will reveal. If a new doctor finds the vocabulary does not fit its corpus, that is evidence about the vocabulary rather than about the corpus — say so.
+
+---
+
+## Wiki-Links
+
+<!-- NORMATIVE node (see scholarship on node classes and provenance): this artifact
+     states what MUST be done, not what was found or what was true at a moment. It is
+     also INHERITED — it ships with the framework rather than being produced by any one
+     agent, which is what makes the vocabulary below shared across deployments.
+     Link what this policy GOVERNS, never what it merely mentions. -->
+
+[[silent_failure]] [[verification]] [[knowledge_web]]

--- a/framework/policies/base/philosophy/empiricism.md
+++ b/framework/policies/base/philosophy/empiricism.md
@@ -252,3 +252,15 @@ This policy evolves through:
 - Cross-agent comparison of investigation strategies
 
 **Principle**: The best investigators aren't the smartest — they're the most disciplined about gathering evidence before forming conclusions.
+
+---
+
+## Wiki-Links
+
+<!-- NORMATIVE node (see scholarship on node classes and provenance): this artifact
+     states what MUST be done, not what was found or what was true at a moment. It is
+     also INHERITED — it ships with the framework rather than being produced by any one
+     agent, which is what makes the vocabulary below shared across deployments.
+     Link what this policy GOVERNS, never what it merely mentions. -->
+
+[[epistemics]] [[verification]] [[methodology]]

--- a/framework/policies/manifest.json
+++ b/framework/policies/manifest.json
@@ -1046,7 +1046,7 @@
     "types": {
       "observations": {
         "name": "observations",
-        "emoji": "🔬",
+        "emoji": "\ud83d\udd2c",
         "description": "Technical discoveries and insights",
         "discovery_keys": [
           "observation",
@@ -1059,7 +1059,7 @@
       },
       "experiments": {
         "name": "experiments",
-        "emoji": "🧪",
+        "emoji": "\ud83e\uddea",
         "description": "Controlled testing and validation",
         "discovery_keys": [
           "experiment",
@@ -1073,7 +1073,7 @@
       },
       "reports": {
         "name": "reports",
-        "emoji": "📊",
+        "emoji": "\ud83d\udcca",
         "description": "Project completion summaries",
         "discovery_keys": [
           "report",
@@ -1087,7 +1087,7 @@
       },
       "reflections": {
         "name": "reflections",
-        "emoji": "💭",
+        "emoji": "\ud83d\udcad",
         "description": "Philosophical growth synthesis",
         "discovery_keys": [
           "reflection",
@@ -1101,7 +1101,7 @@
       },
       "checkpoints": {
         "name": "checkpoints",
-        "emoji": "🔖",
+        "emoji": "\ud83d\udd16",
         "description": "Strategic state preservation",
         "discovery_keys": [
           "checkpoint",
@@ -1113,7 +1113,7 @@
       },
       "roadmaps": {
         "name": "roadmaps",
-        "emoji": "🗺️",
+        "emoji": "\ud83d\uddfa\ufe0f",
         "description": "Multi-phase planning documents",
         "discovery_keys": [
           "roadmap",
@@ -1131,7 +1131,7 @@
       },
       "emotions": {
         "name": "emotions",
-        "emoji": "❤️",
+        "emoji": "\u2764\ufe0f",
         "description": "Emotional expression and processing",
         "discovery_keys": [
           "emotional",
@@ -1145,7 +1145,7 @@
       },
       "learnings": {
         "name": "learnings",
-        "emoji": "📚",
+        "emoji": "\ud83d\udcda",
         "description": "Accumulated wisdom and lessons",
         "discovery_keys": [
           "learning",
@@ -1275,6 +1275,12 @@
     "container": [
       "tech/docker/container_operations"
     ],
+    "corpus_drift": [
+      "base/infrastructure/corpus_integrity"
+    ],
+    "corpus_integrity": [
+      "base/infrastructure/corpus_integrity"
+    ],
     "debugging": [
       "base/development/debugging_and_validation"
     ],
@@ -1290,6 +1296,12 @@
     ],
     "docker": [
       "tech/docker/container_operations"
+    ],
+    "doctor": [
+      "base/infrastructure/corpus_integrity"
+    ],
+    "drift": [
+      "base/infrastructure/corpus_integrity"
     ],
     "dual_trace": [
       "base/consciousness/emotional_expression"
@@ -1395,6 +1407,9 @@
     "observations": [
       "base/consciousness/observations"
     ],
+    "orphan": [
+      "base/infrastructure/corpus_integrity"
+    ],
     "pattern_recognition": [
       "base/consciousness/reflections"
     ],
@@ -1449,6 +1464,9 @@
       "base/consciousness/reflections",
       "context_management#jotewr"
     ],
+    "registry_integrity": [
+      "base/infrastructure/corpus_integrity"
+    ],
     "release": [
       "base/development/git_discipline"
     ],
@@ -1487,6 +1505,9 @@
     ],
     "stakeholder": [
       "base/consciousness/reports"
+    ],
+    "stale_index": [
+      "base/infrastructure/corpus_integrity"
     ],
     "state_preservation": [
       "base/consciousness/checkpoints"
@@ -1584,7 +1605,7 @@
         "short_name": "CAPBOUND",
         "path": "base/infrastructure/capability_boundaries.md",
         "CEP_triggers": [
-          "I was refused reaching something — is the network broken or is this deliberate?",
+          "I was refused reaching something \u2014 is the network broken or is this deliberate?",
           "What should an agent do when it meets a capability boundary, and what must it not do?",
           "Why can't the service being reached just enforce its own allowlist?",
           "What three different failures does one capability boundary prevent?",
@@ -1610,6 +1631,44 @@
           "hardening",
           "reach",
           "enforcement"
+        ]
+      },
+      {
+        "name": "corpus_integrity",
+        "short_name": "CORPINT",
+        "path": "base/infrastructure/corpus_integrity.md",
+        "CEP_triggers": [
+          "A checker reported nothing wrong \u2014 does that mean the corpus is healthy or that nothing was examined?",
+          "Why is a corpus that reports confidence worse than one that reports nothing?",
+          "Why is there no single doctor for every corpus?",
+          "What do acute, chronic and note mean, and how do they differ from priority?",
+          "Why does the chart print even when there are no findings?",
+          "When is running a doctor worth doing, and what response does each finding warrant?",
+          "Why is CI gating the wrong default answer to a noisy checker?",
+          "What must a new doctor ship with before it can be trusted?",
+          "What verification does a checker need beyond passing its own tests?",
+          "Why must every finding carry a remedy and be locatable?"
+        ],
+        "keywords": [
+          "corpus",
+          "integrity",
+          "doctor",
+          "drift",
+          "orphan",
+          "stale",
+          "index",
+          "registry",
+          "acute",
+          "chronic",
+          "chart",
+          "finding",
+          "remedy",
+          "referral",
+          "checker",
+          "diagnostics",
+          "knowledge_doctor",
+          "curation",
+          "screening"
         ]
       }
     ]

--- a/framework/skills/maceff-knowledge-web-curate/SKILL.md
+++ b/framework/skills/maceff-knowledge-web-curate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maceff-knowledge-web-curate
-description: "Invoke during CURATE mode or after wiki-link enrichment work to strengthen the knowledge web. Runs gap detection, evaluates suggestions, adds wiki-links to CAs, and re-verifies. Highest-ROI curation activity — 5 minutes for transformative graph enrichment."
+description: "Invoke during CURATE mode or after wiki-link enrichment work to strengthen the knowledge web. Runs the knowledge doctor for orphans and drift, then gap detection for missing connections between connected nodes, evaluates suggestions, adds wiki-links to CAs, and re-verifies — reporting orphans that remain rather than only the metrics that improved. Highest-ROI curation activity — 5 minutes for transformative graph enrichment."
 allowed-tools: Bash, Read, Grep, Glob, Write, Edit
 ---
 
@@ -23,11 +23,16 @@ Strengthen the knowledge web through gap-driven wiki-link curation.
 ```bash
 macf_tools policy navigate scholarship
 macf_tools policy navigate learnings
+macf_tools policy navigate corpus_integrity
 ```
 
 Read the sections that answer:
 - (scholarship) "What wiki-link normalization rules and seed vocabulary does the scholarship policy specify?"
+- (scholarship) "What node classes and provenance does the policy define, and what must each CA type answer about its own participation?"
 - (learnings) "The learnings index is the target of a Mandatory Consult Step -- what must a curation reconcile in the master index and the consultation trigger so that consult keeps working, and how is a new cluster taxonomy name added?"
+- (corpus_integrity) "When is running a doctor worth doing, and what response does each finding severity warrant?"
+
+The last one governs Steps 1 and 5 below. This skill deliberately does **not** restate when to run the doctor or how to read its findings — that lives in policy and a copy here would drift from it. Ask the policy; it answers.
 
 The graph enrichment below is what makes the index worth consulting; keep the
 index and its trigger current per the learnings policy so the consult step a
@@ -41,10 +46,15 @@ future agent performs actually finds this work.
 
 ```bash
 macf_tools knowledge graph --json    # Current node/edge counts
-macf_tools knowledge gaps            # What's missing?
+macf_tools knowledge doctor          # What is unreachable, drifting, or undeclared?
+macf_tools knowledge gaps            # What connections are missing between CONNECTED nodes?
 ```
 
-Record baseline metrics in task notes: nodes, edges, cross-CA edges, gap count.
+Record baseline metrics in task notes: nodes, edges, cross-CA edges, **orphan count**, acute/chronic counts, gap count.
+
+**Run the doctor before gaps, and understand why the order matters.** `gaps` compares keyword overlap between nodes that are *already connected*, so an artifact with no wiki-links is dropped before comparison begins. It can therefore report "no gaps detected" while a third of the corpus has no edges at all — which is exactly what happened in the run that motivated building the doctor. `gaps` finds missing edges *between* participants; the doctor finds artifacts that are not participants. They answer different questions and the doctor's is the prior one.
+
+**Acute findings are not curation work.** A registry-integrity finding names something structurally wrong — an artifact directory declared nowhere — and its remedy usually lives outside this workflow. Note it and refer it; do not absorb it into a linking pass.
 
 ### Step 2: Evaluate Gaps
 
@@ -74,11 +84,16 @@ Aim for 2-5 concepts per artifact.
 ### Step 5: Re-Verify
 
 ```bash
+macf_tools knowledge doctor           # Orphans should decrease
 macf_tools knowledge gaps             # Should decrease
 macf_tools knowledge graph --json     # Edge count should increase
 ```
 
-Record post-curation metrics. The delta is the evidence of value.
+Record post-curation metrics **including the orphan count**. The delta is the evidence of value.
+
+**A curation that ends with orphans remaining must say so.** Report the orphan count alongside the node and edge deltas, and name what is still unreachable. Reporting only the metrics that improved is how a curation comes to look complete while a third of the corpus stays invisible — which is the precise failure this step exists to prevent, and it is easy to commit honestly, because the numbers that moved are the ones you were working on.
+
+Leaving orphans is a legitimate outcome. Some artifacts genuinely need a decision that a linking pass cannot make. Leaving them **unreported** is not.
 
 ---
 
@@ -88,7 +103,7 @@ Before curating, think:
 
 1. **Are there new concepts that should exist?** If 3+ CAs share a theme not in the seed vocabulary, create a new concept.
 2. **Are existing concepts too broad?** If `[[hooks]]` connects 20+ nodes, consider splitting into `[[hooks_lifecycle]]` and `[[hooks_injection]]`.
-3. **Are there orphan CAs?** Learnings or observations without `## Wiki-Links` sections are invisible to the graph.
+3. **Are there orphan CAs?** Do not answer this from memory or intuition — Step 1's doctor run answers it by measurement, across every participating type rather than the two you happen to think of. The reason this question is worth asking at all is that the artifacts most likely to be orphaned are the ones written last at lowest context, which is exactly when the linking step gets dropped.
 4. **Is normalization consistent?** Check for `.md` suffixes, capitalization, or hyphen vs underscore variants of the same concept.
 
 ---

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6617,11 +6617,32 @@ def cmd_task_start(args: argparse.Namespace) -> int:
     breadcrumb = get_breadcrumb()
 
     if task.status == "in_progress":
-        # Already active. A same-cycle re-start is a no-op, but a stale resume
-        # (last worked an earlier cycle) still bumps the stamp + prompts the
-        # read-notes-and-narrate ritual -- the case task start otherwise misses.
+        # Already active. Both a same-cycle re-start and a stale resume are
+        # legitimate RESUMPTIONS and both refresh the recency stamp; they differ
+        # only in ceremony. A stale resume (last worked an earlier cycle) also
+        # prompts the read-notes-and-narrate ritual, which same-cycle work does
+        # not need because the history is still in context.
+        #
+        # Re-starting used to warn and return without touching anything, which
+        # made resumption invisible: an agent returning to a task it had put
+        # down could not move the tree's focus marker back to it, so the tree
+        # kept asserting that work was happening wherever it LAST happened
+        # rather than where it IS happening. Interleaved work made that reliably
+        # wrong. Resuming is an event, not a mistake.
         if not stale:
-            print(f"⚠️  Task #{task_id} is already in_progress")
+            if task.mtmd:
+                from .task.models import MacfTaskUpdate
+                import copy
+                new_mtmd = copy.deepcopy(task.mtmd)
+                new_mtmd.updates.append(MacfTaskUpdate(
+                    breadcrumb=breadcrumb,
+                    description="Task resumed via CLI (same-cycle)",
+                    agent="PA"))
+                update_task_file(task_id, {"description": task.description_with_updated_mtmd(new_mtmd)})
+            append_event("task_resumed", {
+                "task_id": str(task_id), "from_cycle": None, "breadcrumb": breadcrumb})
+            print(f"▶️  Task #{task_id} resumed (was already in_progress)")
+            print(f"   Breadcrumb: {breadcrumb}")
             return 0
         last_cycle, last_ts, cur_cycle = stale
         if task.mtmd:
@@ -8780,6 +8801,24 @@ def cmd_knowledge_gaps(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_knowledge_doctor(args: argparse.Namespace) -> int:
+    """Report what the knowledge web cannot report about itself.
+
+    Exits non-zero when acute findings exist, so a caller can gate on it — but
+    note that gating is deliberately NOT the intended default use. See the
+    policy on when running this is worth doing.
+    """
+    from .diagnostics import Severity, format_diagnosis
+    from .knowledge_doctor import examine
+
+    dx = examine()
+    if getattr(args, "json_output", False):
+        print(json.dumps(dx.to_dict(), indent=2, default=str))
+    else:
+        print(format_diagnosis(dx))
+    return 1 if dx.counts().get(Severity.ACUTE, 0) else 0
+
+
 def cmd_knowledge_viz(args: argparse.Namespace) -> int:
     """Generate interactive HTML knowledge graph visualization."""
     from .ideas import generate_graph_html
@@ -10113,6 +10152,13 @@ def _build_parser() -> argparse.ArgumentParser:
     kg_gaps = knowledge_sub.add_parser("gaps", help="detect missing wiki-links")
     kg_gaps.add_argument("--json", dest="json_output", action="store_true", help="machine-readable output")
     kg_gaps.set_defaults(func=cmd_knowledge_gaps)
+
+    kg_doctor = knowledge_sub.add_parser(
+        "doctor",
+        help="report orphans, drift, singletons and registry gaps the graph cannot see")
+    kg_doctor.add_argument("--json", dest="json_output", action="store_true",
+                           help="machine-readable output")
+    kg_doctor.set_defaults(func=cmd_knowledge_doctor)
 
     kg_viz = knowledge_sub.add_parser("viz", help="generate interactive HTML visualization")
     kg_viz.add_argument("output", nargs="?", default="", help="output path (default: /tmp/macf_knowledge_graph.html)")

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -8747,6 +8747,19 @@ def cmd_knowledge_query(args: argparse.Namespace) -> int:
     from .ideas import query_knowledge_graph, format_query_result
 
     result = query_knowledge_graph(args.term)
+
+    # Filter by node class. A checkpoint's claims expire and a learning's do
+    # not; a query asking "what do I know about X" wants durable insight, while
+    # "which cycle touched X" wants the temporal record. Returning both
+    # unlabelled dilutes the first with the second, and the dilution worsens
+    # every cycle. See the scholarship policy on node classes and provenance.
+    node_class = getattr(args, "node_class", None)
+    if node_class:
+        for key in ("nodes", "neighbors"):
+            if key in result:
+                result[key] = [n for n in result[key]
+                               if n.get("node_class") == node_class]
+        result["filtered_by_class"] = node_class
     if getattr(args, "json_output", False):
         print(json.dumps(result, indent=2, default=str))
     else:
@@ -10089,6 +10102,12 @@ def _build_parser() -> argparse.ArgumentParser:
     kg_query = knowledge_sub.add_parser("query", help="query subgraph by concept, node ID, or keyword")
     kg_query.add_argument("term", help="concept name, node ID (#007), or keyword")
     kg_query.add_argument("--json", dest="json_output", action="store_true", help="machine-readable output")
+    kg_query.add_argument(
+        "--class", dest="node_class",
+        choices=["conceptual_authority", "temporal_record", "normative"],
+        help="restrict to one node class: conceptual_authority (durable claims), "
+             "temporal_record (claims that expire), normative (rules). "
+             "Default returns all classes, each labelled.")
     kg_query.set_defaults(func=cmd_knowledge_query)
 
     kg_gaps = knowledge_sub.add_parser("gaps", help="detect missing wiki-links")

--- a/macf/src/macf/concepts.py
+++ b/macf/src/macf/concepts.py
@@ -1,0 +1,112 @@
+"""Concepts: the vocabulary layer of the knowledge web.
+
+A **concept** is the thing a ``[[wiki_link]]`` names. Concepts are not owned by
+any consciousness-artifact type — a concept is precisely what lets a learning, a
+reflection, a checkpoint, an experiment and an idea refer to the same subject.
+They therefore live here rather than inside the module for any one CA type.
+
+Two responsibilities, and only these:
+
+- **normalization** — mapping every spelling of a concept to one canonical form,
+  so that ``[[Knowledge-Web]]``, ``[[knowledge web]]`` and ``[[knowledge_web]]``
+  are one node rather than three;
+- **extraction** — deciding which ``[[...]]`` occurrences in a document are
+  genuine participation and which are merely the document talking about
+  notation.
+
+Graph construction, querying and reporting build on this and belong elsewhere.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+__all__ = ["normalize_concept", "normalize_concepts", "extract_wiki_concepts"]
+
+
+def normalize_concept(raw: str) -> str:
+    """Map one concept spelling to its canonical form.
+
+    Canonical form is lowercase, underscore-separated, with no ``[[ ]]``
+    wrapper and no ``.md`` suffix. Hyphens and spaces both become underscores:
+    the scholarship policy specifies underscores, so a hyphenated spelling is
+    drift to be merged, not a distinct concept to be preserved.
+
+    Returns an empty string when nothing survives normalization; callers are
+    expected to drop those rather than create an empty node.
+    """
+    if not raw:
+        return ""
+    c = raw.strip().strip("[]").strip()
+    c = re.sub(r"\.md$", "", c, flags=re.IGNORECASE)
+    c = c.lower()
+    c = re.sub(r"[\s\-]+", "_", c)
+    c = re.sub(r"[^a-z0-9_]", "", c)
+    c = re.sub(r"_+", "_", c).strip("_")
+    return c
+
+
+def normalize_concepts(raw: Iterable[str]) -> List[str]:
+    """Normalize a sequence of concepts, dropping empties, deduping in order.
+
+    First-seen order is preserved because it carries authorial emphasis: the
+    concept an author listed first is usually the one the artifact is most
+    about.
+    """
+    seen = set()
+    out: List[str] = []
+    for token in raw or []:
+        c = normalize_concept(token)
+        if not c or c in seen:
+            continue
+        seen.add(c)
+        out.append(c)
+    return out
+
+
+def extract_wiki_concepts(content: str) -> List[str]:
+    """Extract the concepts a document participates in, as a normalized union.
+
+    Two sources, both counted:
+
+    - the canonical ``## Wiki-Links`` section, which summarises what the whole
+      artifact is about;
+    - inline ``[[concept]]`` usage anywhere else, which binds an individual
+      *passage* to a concept. Reflections in particular are expansion rather
+      than summary, so their conceptual work lives in the prose and tagging
+      only the document loses it.
+
+    Earlier behaviour treated the whole-document scan as a *fallback*: a
+    non-empty section suppressed every inline concept, so adding a summary
+    section to a richly linked document REDUCED its graph presence. The two
+    sources are now unioned, section first.
+
+    Occurrences inside fenced code blocks or inline code spans are **mentions,
+    not uses**, and are excluded. A corpus that documents its own conventions
+    writes about concepts deliberately; counting those mints phantom nodes for
+    the very spellings a passage is explaining. Measured on this corpus, three
+    reflections consisted *entirely* of such mentions and appeared connected
+    while being orphans.
+
+    Block quotes are deliberately NOT excluded: no artifact in the corpus
+    currently places a wiki-link inside one, so excluding them would be
+    untested behaviour written for a case that does not occur.
+    """
+    # Fenced blocks first, so a fence containing backticks cannot leave a
+    # dangling code-span delimiter behind.
+    prose = re.sub(r"```.*?```", " ", content, flags=re.DOTALL)
+    prose = re.sub(r"~~~.*?~~~", " ", prose, flags=re.DOTALL)
+    prose = re.sub(r"`[^`\n]*`", " ", prose)
+
+    section: List[str] = []
+    wl = re.search(r"##\s*Wiki-Links\s*\n(.+?)(?:\n##\s|\Z)", prose,
+                   re.DOTALL | re.IGNORECASE)
+    if wl:
+        section = re.findall(r"\[\[(.+?)\]\]", wl.group(1))
+        rest = prose[:wl.start()] + prose[wl.end():]
+    else:
+        rest = prose
+
+    inline = re.findall(r"\[\[(.+?)\]\]", rest)
+    return normalize_concepts(list(section) + list(inline))

--- a/macf/src/macf/diagnostics.py
+++ b/macf/src/macf/diagnostics.py
@@ -1,0 +1,175 @@
+"""Shared vocabulary for MacEff corpus doctors.
+
+MacEff has several corpora that describe themselves — the knowledge graph, the
+policy corpus and its indices, the learnings index — and each drifts from what
+it describes in its own way. A **doctor** is the instrument that reports that
+drift for one corpus.
+
+Doctors stay **specialists**. A single checker over every corpus would be
+shallow everywhere or become a dumping ground, because each corpus needs domain
+knowledge the others cannot carry: graph topology, manifest registration and
+index referential integrity are different problems.
+
+But specialists reporting in private vocabularies are unreadable together. An
+agent cannot tell that "orphan", "dangling entry", "unregistered policy" and
+"stale index" are the same finding wearing four different words. So the
+*vocabulary* is shared even though the *checks* are not, and it lives here so
+no doctor owns it. Whichever doctor ships first extracts this rather than
+keeping it — discovery order is not ownership.
+
+The medical register is used only where it clarifies. A term that adds ceremony
+without meaning does not belong here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+__all__ = ["Severity", "Finding", "Chart", "Diagnosis", "format_diagnosis"]
+
+
+class Severity:
+    """How a finding should be read, not how loudly it should be printed.
+
+    ``ACUTE``   something is wrong NOW and will mislead a reader who trusts it.
+                A registry that claims a type which does not exist, an index
+                that reports coverage it does not have. These produce confident
+                wrong answers, which is worse than no answer.
+
+    ``CHRONIC`` accumulating degradation. Nothing breaks today; the corpus
+                becomes less trustworthy every cycle. Orphaned artifacts are
+                the canonical case — each one is survivable and the trend is
+                not.
+
+    ``NOTE``    an observation with no implied action. Present so a reader can
+                see what was examined, because a doctor that prints only
+                problems cannot be distinguished from one that failed to run.
+    """
+
+    ACUTE = "acute"
+    CHRONIC = "chronic"
+    NOTE = "note"
+
+    ORDER = {ACUTE: 0, CHRONIC: 1, NOTE: 2}
+    ICON = {ACUTE: "🔴", CHRONIC: "🟡", NOTE: "·"}
+
+
+@dataclass
+class Finding:
+    """One observation about a corpus.
+
+    ``remedy`` is required rather than optional. A finding an agent cannot act
+    on is noise, and noise trains agents to skim the whole report — which is
+    the failure mode that makes a checker worse than no checker, because an
+    ignored report still looks like coverage.
+
+    ``referral`` names another corpus when the remedy lives outside this
+    doctor's domain. Specialists refer rather than reaching across.
+    """
+
+    check: str
+    severity: str
+    subject: str
+    detail: str
+    remedy: str
+    referral: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {
+            "check": self.check,
+            "severity": self.severity,
+            "subject": self.subject,
+            "detail": self.detail,
+            "remedy": self.remedy,
+        }
+        if self.referral:
+            d["referral"] = self.referral
+        return d
+
+
+@dataclass
+class Chart:
+    """Baseline measurements taken during an examination.
+
+    Recorded even when nothing is wrong. A doctor that reports only findings
+    gives a reader no way to tell a healthy corpus from an examination that
+    silently covered nothing — the distinction this whole family of tools
+    exists to make.
+    """
+
+    corpus: str
+    vitals: Dict[str, Any] = field(default_factory=dict)
+    scope: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"corpus": self.corpus, "vitals": self.vitals, "scope": self.scope}
+
+
+@dataclass
+class Diagnosis:
+    """The full result of one examination."""
+
+    chart: Chart
+    findings: List[Finding] = field(default_factory=list)
+
+    def sorted_findings(self) -> List[Finding]:
+        return sorted(self.findings,
+                      key=lambda f: (Severity.ORDER.get(f.severity, 9), f.check, f.subject))
+
+    def counts(self) -> Dict[str, int]:
+        out = {Severity.ACUTE: 0, Severity.CHRONIC: 0, Severity.NOTE: 0}
+        for f in self.findings:
+            out[f.severity] = out.get(f.severity, 0) + 1
+        return out
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "chart": self.chart.to_dict(),
+            "counts": self.counts(),
+            "findings": [f.to_dict() for f in self.sorted_findings()],
+        }
+
+
+def format_diagnosis(dx: Diagnosis) -> str:
+    """Render an examination for a human or an agent reading a terminal.
+
+    The chart prints first and always. What was examined is context for every
+    finding below it, and its absence is what lets a clean report be confused
+    with an examination that never looked.
+    """
+    lines: List[str] = []
+    lines.append(f"🩺 {dx.chart.corpus}")
+    if dx.chart.scope:
+        lines.append(f"   examined: {', '.join(dx.chart.scope)}")
+    if dx.chart.vitals:
+        vit = "  ".join(f"{k}={v}" for k, v in dx.chart.vitals.items())
+        lines.append(f"   chart:    {vit}")
+    lines.append("")
+
+    findings = dx.sorted_findings()
+    if not findings:
+        lines.append("   ✅ no findings")
+        lines.append("   (a clean result is only meaningful alongside the chart above —")
+        lines.append("    it says these checks ran and found nothing, not that nothing is wrong.)")
+        return "\n".join(lines)
+
+    counts = dx.counts()
+    lines.append(f"   {counts.get(Severity.ACUTE, 0)} acute · "
+                 f"{counts.get(Severity.CHRONIC, 0)} chronic · "
+                 f"{counts.get(Severity.NOTE, 0)} note")
+    lines.append("")
+
+    current = None
+    for f in findings:
+        if f.check != current:
+            current = f.check
+            lines.append(f"  {f.check}")
+        icon = Severity.ICON.get(f.severity, "·")
+        lines.append(f"   {icon} {f.subject}")
+        if f.detail:
+            lines.append(f"      {f.detail}")
+        lines.append(f"      → {f.remedy}")
+        if f.referral:
+            lines.append(f"      ↪ referral: {f.referral}")
+    return "\n".join(lines)

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -424,6 +424,25 @@ CA_PARTICIPATION: Dict[str, Dict[str, Any]] = {
     # records. Previously not scanned at all.
     "roadmaps":     {"dirs": ["public/roadmaps"],
                      "unit": {"roadmap"}, "node_class": "temporal_record"},
+    # Framework policies are NORMATIVE nodes: they state what must be done,
+    # rather than what was found (conceptual authority) or what was true at a
+    # moment (temporal record). They are also INHERITED — shipped with the
+    # framework rather than produced by this agent — which is why the shared
+    # vocabulary they carry is the same for every deployment.
+    #
+    # Participation is OPT-IN and costs nothing to enforce: extraction returns
+    # no concepts for a policy without a Wiki-Links section, and a node with no
+    # concepts is never created. So a policy joins the graph by declaring
+    # links, and the opt-in stays observable while hub domination is still
+    # cheap to reverse.
+    #
+    # root="framework" because policies live in the MacEff installation, not in
+    # the agent tree. This is the one participating type that crosses that
+    # boundary; the direction is safe (public policy read into a private graph)
+    # and the reverse is forbidden — a policy must never link a concept that
+    # resolves only in some agent's private tree.
+    "policies":     {"dirs": [""], "root": "framework",
+                     "unit": "all", "node_class": "normative"},
 }
 
 
@@ -435,8 +454,14 @@ def _ca_type_for_dir(scan_dir: Path) -> Tuple[str, Dict[str, Any]]:
     """
     posix = scan_dir.as_posix()
     for ca_type, spec in CA_PARTICIPATION.items():
+        if spec.get("root") == "framework":
+            # Framework-rooted types are identified by the directory they live
+            # in rather than by a relative suffix under agent/.
+            if posix.endswith("/policies") or "/framework/policies" in posix:
+                return ca_type, spec
+            continue
         for rel in spec["dirs"]:
-            if posix.endswith(rel):
+            if rel and posix.endswith(rel):
                 return ca_type, spec
     return scan_dir.name, {"dirs": [], "unit": "all",
                            "node_class": "conceptual_authority"}
@@ -462,8 +487,16 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
             from .utils.paths import find_agent_home
             agent_home = find_agent_home()
             if agent_home:
-                scan_dirs = [agent_home / "agent" / rel for spec in CA_PARTICIPATION.values()
-                             for rel in spec["dirs"]]
+                scan_dirs = []
+                for spec in CA_PARTICIPATION.values():
+                    if spec.get("root") == "framework":
+                        from .utils.manifest import get_framework_policies_path
+                        pol = get_framework_policies_path()
+                        if pol:
+                            scan_dirs.extend(pol / rel if rel else pol
+                                             for rel in spec["dirs"])
+                        continue
+                    scan_dirs.extend(agent_home / "agent" / rel for rel in spec["dirs"])
         except (OSError, ImportError) as e:
             print(f"⚠️ MACF: knowledge graph scan dirs failed: {e}", file=sys.stderr)
             scan_dirs = []

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -441,13 +441,7 @@ CA_PARTICIPATION: Dict[str, Dict[str, Any]] = {
     # boundary; the direction is safe (public policy read into a private graph)
     # and the reverse is forbidden — a policy must never link a concept that
     # resolves only in some agent's private tree.
-    # opt_in: absence of links is a VALID STATE for this type, not a defect.
-    # Doctors must not report a non-participating policy as an orphan — opting
-    # in is a positive act, so not having opted in is silence rather than
-    # breakage. Without this flag the doctor flags every unopted policy and
-    # buries the real findings, which is the "checker that flags everything"
-    # failure its own policy warns about.
-    "policies":     {"dirs": [""], "root": "framework", "opt_in": True,
+    "policies":     {"dirs": [""], "root": "framework",
                      "unit": "all", "node_class": "normative"},
 }
 

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -441,7 +441,13 @@ CA_PARTICIPATION: Dict[str, Dict[str, Any]] = {
     # boundary; the direction is safe (public policy read into a private graph)
     # and the reverse is forbidden — a policy must never link a concept that
     # resolves only in some agent's private tree.
-    "policies":     {"dirs": [""], "root": "framework",
+    # opt_in: absence of links is a VALID STATE for this type, not a defect.
+    # Doctors must not report a non-participating policy as an orphan — opting
+    # in is a positive act, so not having opted in is silence rather than
+    # breakage. Without this flag the doctor flags every unopted policy and
+    # buries the real findings, which is the "checker that flags everything"
+    # failure its own policy warns about.
+    "policies":     {"dirs": [""], "root": "framework", "opt_in": True,
                      "unit": "all", "node_class": "normative"},
 }
 

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -44,28 +44,18 @@ def _make_slug(title: str) -> str:
     return slug[:60]  # cap length
 
 
-def _normalize_wiki_links(raw: List[str]) -> List[str]:
-    """Normalize wiki-link tokens to canonical lowercase_underscored form.
+from .concepts import extract_wiki_concepts, normalize_concept, normalize_concepts  # noqa: F401
 
-    Accepts inputs like ``"Foo Bar"``, ``"[[foo_bar]]"``, or already-canonical
-    ``"foo_bar"`` and returns ``"foo_bar"``. Strips ``[[ ]]`` wrappers (callers
-    sometimes paste in the markdown form). Lowercases, collapses whitespace
-    into underscores, drops anything outside ``[a-z0-9_-]``, drops empties,
-    and dedups while preserving first-seen order.
+
+def _normalize_wiki_links(raw: List[str]) -> List[str]:
+    """Backwards-compatible alias for the canonical concept normalizer.
+
+    Retained so existing call sites keep working; the implementation lives in
+    ``macf.concepts`` because concepts belong to no single CA type. Note the
+    behaviour change this alias inherits: hyphens now normalize to underscores
+    rather than surviving, per the scholarship policy's spelling rule.
     """
-    seen = set()
-    out: List[str] = []
-    for token in raw or []:
-        if not token:
-            continue
-        t = token.strip().strip("[]").strip().lower()
-        t = re.sub(r'\s+', '_', t)
-        t = re.sub(r'[^a-z0-9_\-]', '', t)
-        if not t or t in seen:
-            continue
-        seen.add(t)
-        out.append(t)
-    return out
+    return normalize_concepts(raw)
 
 
 def create_idea(
@@ -445,18 +435,7 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
                 content = md_file.read_text(errors='replace')
             except OSError:
                 continue
-            # Two-tier wiki-link extraction: prefer the explicit ## Wiki-Links
-            # section (canonical convention in learnings). Fall back to any
-            # [[concept]] occurrences elsewhere in the document so CAs that
-            # don't follow the explicit-section convention (most CCPs,
-            # JOTEWRs, experiment artifacts) still produce edges.
-            concepts = []
-            wl_match = re_mod.search(r'## Wiki-Links\s*\n(.+?)(?:\n##|\Z)', content, re_mod.DOTALL)
-            if wl_match:
-                concepts = re_mod.findall(r'\[\[(.+?)\]\]', wl_match.group(1))
-            if not concepts:
-                # Fallback: scan whole document for [[...]] references
-                concepts = re_mod.findall(r'\[\[(.+?)\]\]', content)
+            concepts = extract_wiki_concepts(content)
             if not concepts:
                 continue
             # Create a node ID for this CA. For nested CAs (experiments),

--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -11,7 +11,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def _get_ideas_dir() -> Path:
@@ -388,6 +388,60 @@ def build_idea_graph() -> Dict[str, Any]:
     }
 
 
+#: How each consciousness-artifact type participates in the knowledge graph.
+#:
+#: ``dirs``       where its artifacts live, relative to ``agent/``
+#: ``unit``       ``"all"`` for every markdown file, or a set of stems when the
+#:                type is a DIRECTORY whose other files are evidence rather than
+#:                concept-bearing units
+#: ``node_class`` what kind of claim its nodes make — defined once in the
+#:                scholarship policy on node classes and provenance, cited here
+#:
+#: This replaces a hardcoded directory list with a single declaration, but it is
+#: still a SECOND registry. The manifest is authoritative and this should be
+#: derived from it. Six hand-maintained lists of the CA types is what produced
+#: the drift this table is part of correcting; a seventh that merely agrees
+#: today just resets the clock.
+CA_PARTICIPATION: Dict[str, Dict[str, Any]] = {
+    "learnings":    {"dirs": ["private/learnings"],
+                     "unit": "all", "node_class": "conceptual_authority"},
+    "reflections":  {"dirs": ["private/reflections"],
+                     "unit": "all", "node_class": "conceptual_authority"},
+    "observations": {"dirs": ["public/observations"],
+                     "unit": "all", "node_class": "conceptual_authority"},
+    "reports":      {"dirs": ["public/reports"],
+                     "unit": "all", "node_class": "conceptual_authority"},
+    # Protocol and analysis carry the claims; data/, artifacts/ and
+    # quick_tests/ hold the evidence those claims cite.
+    "experiments":  {"dirs": ["public/experiments"],
+                     "unit": {"protocol", "analysis"},
+                     "node_class": "conceptual_authority"},
+    # Checkpoints appear in both trees; which is canonical is unresolved, so
+    # both are scanned rather than silently preferring one.
+    "checkpoints":  {"dirs": ["private/checkpoints", "public/checkpoints"],
+                     "unit": "all", "node_class": "temporal_record"},
+    # The plan is the node; archived todos and subartifacts are execution
+    # records. Previously not scanned at all.
+    "roadmaps":     {"dirs": ["public/roadmaps"],
+                     "unit": {"roadmap"}, "node_class": "temporal_record"},
+}
+
+
+def _ca_type_for_dir(scan_dir: Path) -> Tuple[str, Dict[str, Any]]:
+    """Resolve a scanned directory to its CA type and participation spec.
+
+    Falls back to the directory name for callers passing an explicit
+    ``scan_dirs`` outside the table, so tests and ad-hoc scans keep working.
+    """
+    posix = scan_dir.as_posix()
+    for ca_type, spec in CA_PARTICIPATION.items():
+        for rel in spec["dirs"]:
+            if posix.endswith(rel):
+                return ca_type, spec
+    return scan_dir.name, {"dirs": [], "unit": "all",
+                           "node_class": "conceptual_authority"}
+
+
 def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, Any]:
     """Build cross-CA knowledge graph: ideas + learnings + observations via wiki-links.
 
@@ -403,22 +457,13 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
     wiki_index = defaultdict(set, {k: set(v) for k, v in graph["wiki_index"].items()})
     ca_nodes = {}  # non-idea CA nodes: {node_id: {type, title, path}}
 
-    # Scan additional CA directories for wiki-links. Extends beyond
-    # learnings/observations to cover the full Consciousness Artifact corpus
-    # (closes GH issue #73).
     if scan_dirs is None:
         try:
             from .utils.paths import find_agent_home
             agent_home = find_agent_home()
             if agent_home:
-                scan_dirs = [
-                    agent_home / "agent" / "private" / "learnings",
-                    agent_home / "agent" / "private" / "checkpoints",
-                    agent_home / "agent" / "private" / "reflections",
-                    agent_home / "agent" / "public" / "observations",
-                    agent_home / "agent" / "public" / "experiments",
-                    agent_home / "agent" / "public" / "reports",
-                ]
+                scan_dirs = [agent_home / "agent" / rel for spec in CA_PARTICIPATION.values()
+                             for rel in spec["dirs"]]
         except (OSError, ImportError) as e:
             print(f"⚠️ MACF: knowledge graph scan dirs failed: {e}", file=sys.stderr)
             scan_dirs = []
@@ -426,10 +471,18 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
     for scan_dir in (scan_dirs or []):
         if not scan_dir.exists():
             continue
-        ca_type = scan_dir.name  # "learnings", "checkpoints", "reflections", etc.
+        ca_type, spec = _ca_type_for_dir(scan_dir)
+        unit = spec.get("unit", "all")
+        node_class = spec.get("node_class", "conceptual_authority")
         # Recursive walk so experiments/<dated>/ subfolders are picked up.
         for md_file in sorted(scan_dir.rglob("*.md")):
             if md_file.name == "INDEX.md":
+                continue
+            # Unit of node: some CA types are directories whose other files are
+            # EVIDENCE rather than concept-bearing units. An experiment's
+            # per-arm data is addressed by the analysis that cites it, not by a
+            # concept query; counting it makes evidence outnumber conclusions.
+            if unit != "all" and md_file.stem not in unit:
                 continue
             try:
                 content = md_file.read_text(errors='replace')
@@ -448,7 +501,8 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
             # Extract title from first heading
             title_match = re_mod.search(r'^#\s+(.+)', content, re_mod.MULTILINE)
             title = title_match.group(1)[:50] if title_match else md_file.stem[:50]
-            ca_nodes[node_id] = {"type": ca_type, "title": title, "path": str(md_file)}
+            ca_nodes[node_id] = {"type": ca_type, "title": title,
+                                 "path": str(md_file), "node_class": node_class}
             for concept in concepts:
                 wiki_index[concept].add(node_id)
 
@@ -758,6 +812,9 @@ def query_knowledge_graph(term: str, kg: Optional[Dict[str, Any]] = None) -> Dic
                 "title": idea.get("title", ""), "type": "idea",
                 "status": idea.get("status", ""), "category": idea.get("category", ""),
                 "degree": len(edges.get(node_id, set())),
+                # An idea is prospective, but its claim is meant to outlive the
+                # moment; status carries the proposal-versus-finding weighting.
+                "node_class": "conceptual_authority",
             }
         elif node_id in ca_nodes:
             info = ca_nodes[node_id]
@@ -766,6 +823,7 @@ def query_knowledge_graph(term: str, kg: Optional[Dict[str, Any]] = None) -> Dic
                 "title": info.get("title", ""), "type": info.get("type", "ca"),
                 "status": "", "category": info.get("type", ""),
                 "degree": len(edges.get(node_id, set())),
+                "node_class": info.get("node_class", "conceptual_authority"),
             }
         return None
 

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -120,7 +120,15 @@ def examine(agent_home: Optional[Path] = None,
             content = path.read_text(errors="replace")
         except OSError:
             continue
-        for raw in _RAW_LINK.findall(content):
+        # Strip mentions before looking for drift, exactly as extraction does.
+        # Scanning raw content made this check internally inconsistent with the
+        # extractor: a concept quoted inside backticks while DOCUMENTING the
+        # notation was reported as a misspelling to correct. An artifact that
+        # explains the convention would be told to stop explaining it.
+        prose = re.sub(r"```.*?```", " ", content, flags=re.DOTALL)
+        prose = re.sub(r"~~~.*?~~~", " ", prose, flags=re.DOTALL)
+        prose = re.sub(r"`[^`\n]*`", " ", prose)
+        for raw in _RAW_LINK.findall(prose):
             canon = normalize_concept(raw)
             if canon and raw.strip() != canon:
                 drift.setdefault(canon, set()).add(raw.strip())

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -73,11 +73,6 @@ def examine(agent_home: Optional[Path] = None,
             continue
         if extract_wiki_concepts(content):
             continue
-        # Opt-in types: not participating is a valid state, not an orphan.
-        # Reporting them would bury the real findings under the majority that
-        # simply have not opted in.
-        if spec.get("opt_in"):
-            continue
         orphans_by_type.setdefault(ca_type, []).append(path)
         # Distinguish "never linked" from "wrote links that do not count".
         # The second is a different mistake and deserves a different remedy.

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -1,0 +1,198 @@
+"""The knowledge-web specialist: reports what the graph cannot see about itself.
+
+`knowledge gaps` compares keyword overlap between *connected* nodes, so an
+artifact with no wiki-links is skipped before comparison begins. That is why a
+curation run once reported "no gaps detected" while thirty consciousness
+artifacts had zero edges: **a detector defined over relationships cannot see
+absent relationships.** The condition the instrument most needed to report was
+the one condition it was structurally unable to observe.
+
+This doctor exists to observe it, plus the other ways the graph and the corpus
+disagree. Shared vocabulary lives in ``macf.diagnostics``; the checks here are
+specific to this corpus.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .concepts import extract_wiki_concepts, normalize_concept
+from .diagnostics import Chart, Diagnosis, Finding, Severity
+
+__all__ = ["examine"]
+
+# Spellings that normalize to the same concept but are written differently in
+# source. Harmless to the graph now that extraction normalizes, but they are
+# what a reader copies when adding links to a new artifact — so drift spreads
+# from the source text, not from the index.
+_RAW_LINK = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def _participating_files(agent_home: Path, participation: Dict[str, Dict[str, Any]]):
+    """Yield (ca_type, spec, path) for every file the graph should contain."""
+    for ca_type, spec in participation.items():
+        for rel in spec["dirs"]:
+            d = agent_home / "agent" / rel
+            if not d.exists():
+                continue
+            unit = spec.get("unit", "all")
+            for f in sorted(d.rglob("*.md")):
+                if f.name == "INDEX.md":
+                    continue
+                if unit != "all" and f.stem not in unit:
+                    continue
+                yield ca_type, spec, f
+
+
+def examine(agent_home: Optional[Path] = None,
+            kg: Optional[Dict[str, Any]] = None) -> Diagnosis:
+    """Examine the knowledge web and report what it cannot report about itself."""
+    from .ideas import CA_PARTICIPATION, build_knowledge_graph
+    from .utils.paths import find_agent_home
+
+    agent_home = agent_home or find_agent_home()
+    kg = kg or build_knowledge_graph()
+    findings: List[Finding] = []
+
+    ca_nodes = kg.get("ca_nodes", {})
+    wiki_index = kg.get("wiki_index", {}) or {}
+    stats = kg.get("stats", {})
+
+    # ---- orphans -----------------------------------------------------------
+    # The check `knowledge gaps` structurally cannot perform.
+    examined = 0
+    orphans_by_type: Dict[str, List[Path]] = {}
+    mention_only: List[Path] = []
+    for ca_type, spec, path in _participating_files(agent_home, CA_PARTICIPATION):
+        examined += 1
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            continue
+        if extract_wiki_concepts(content):
+            continue
+        orphans_by_type.setdefault(ca_type, []).append(path)
+        # Distinguish "never linked" from "wrote links that do not count".
+        # The second is a different mistake and deserves a different remedy.
+        if _RAW_LINK.search(content):
+            mention_only.append(path)
+
+    for ca_type, paths in sorted(orphans_by_type.items()):
+        for p in paths:
+            is_mention_only = p in mention_only
+            # Nested CA types (experiments, roadmaps) put the identifying name
+            # on the DIRECTORY — three findings reading "analysis.md" name the
+            # same file three times as far as a reader can tell, and a finding
+            # you cannot locate is not actionable.
+            label = f"{p.parent.name}/{p.name}" if p.parent.name != ca_type else p.name
+            findings.append(Finding(
+                check="orphans",
+                severity=Severity.CHRONIC,
+                subject=f"{ca_type}: {label}",
+                detail=("carries [[links]] but ALL of them are inside code spans or fenced "
+                        "blocks, so they are mentions rather than uses"
+                        if is_mention_only else
+                        "no wiki-link concepts; unreachable by concept query"),
+                remedy=("rewrite the intended links outside code formatting, or add a "
+                        "## Wiki-Links section if the mentions were deliberate"
+                        if is_mention_only else
+                        f"add a ## Wiki-Links section; see the {ca_type} policy on "
+                        "knowledge web participation for what this type should link"),
+            ))
+
+    # ---- normalization drift in source text --------------------------------
+    drift: Dict[str, set] = {}
+    for _ca_type, _spec, path in _participating_files(agent_home, CA_PARTICIPATION):
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for raw in _RAW_LINK.findall(content):
+            canon = normalize_concept(raw)
+            if canon and raw.strip() != canon:
+                drift.setdefault(canon, set()).add(raw.strip())
+    for canon, raws in sorted(drift.items()):
+        findings.append(Finding(
+            check="normalization drift",
+            severity=Severity.NOTE,
+            subject=canon,
+            detail=f"written in source as {', '.join(sorted(raws))}",
+            remedy=("extraction normalizes these to one node, so the graph is correct; "
+                    "fix the source text so the next author copies the canonical spelling"),
+        ))
+
+    # ---- singleton concepts ------------------------------------------------
+    for concept, members in sorted(wiki_index.items()):
+        if len(members) == 1:
+            findings.append(Finding(
+                check="singleton concepts",
+                severity=Severity.CHRONIC,
+                subject=concept,
+                detail=f"connects exactly one node ({next(iter(members))})",
+                remedy=("usually a typo or a coinage nobody reused — check against "
+                        "`macf_tools knowledge query` for a near-duplicate that already "
+                        "exists, or accept it as a genuinely new concept"),
+            ))
+
+    # ---- registry integrity ------------------------------------------------
+    # From the scholarship policy on registry authority: every artifact-producing
+    # location must be declared, and every declared location must exist.
+    declared_dirs = {rel for spec in CA_PARTICIPATION.values() for rel in spec["dirs"]}
+    for rel in sorted(declared_dirs):
+        if not (agent_home / "agent" / rel).exists():
+            findings.append(Finding(
+                check="registry integrity",
+                severity=Severity.NOTE,
+                subject=rel,
+                detail="declared as a participating location but does not exist",
+                remedy="remove the declaration, or create the location it describes",
+            ))
+    for base in ("private", "public"):
+        root = agent_home / "agent" / base
+        if not root.exists():
+            continue
+        for d in sorted(p for p in root.iterdir() if p.is_dir()):
+            rel = f"{base}/{d.name}"
+            if rel in declared_dirs:
+                continue
+            produces = any(True for _ in d.rglob("*.md"))
+            if produces:
+                findings.append(Finding(
+                    check="registry integrity",
+                    severity=Severity.ACUTE,
+                    subject=rel,
+                    detail="produces artifacts but is declared in no registry",
+                    remedy=("declare it — participating or explicitly not. "
+                            "Undeclared-but-real is the state in which artifacts "
+                            "accumulate unseen"),
+                    referral="manifest / CA type registry",
+                ))
+
+    # ---- class coverage ----------------------------------------------------
+    unclassed = [nid for nid, info in ca_nodes.items() if not info.get("node_class")]
+    for nid in sorted(unclassed):
+        findings.append(Finding(
+            check="node class",
+            severity=Severity.ACUTE,
+            subject=str(nid),
+            detail="node carries no class, so a query cannot tell durable insight "
+                   "from expired state",
+            remedy="declare the type's class in CA_PARTICIPATION and in its policy",
+        ))
+
+    chart = Chart(
+        corpus="knowledge web",
+        scope=sorted(CA_PARTICIPATION.keys()),
+        vitals={
+            "files_examined": examined,
+            "nodes": stats.get("total_nodes", 0),
+            "cas": stats.get("total_cas", 0),
+            "ideas": stats.get("total_ideas", 0),
+            "edges": stats.get("total_edges", 0),
+            "concepts": stats.get("wiki_concepts", 0),
+            "orphans": sum(len(v) for v in orphans_by_type.values()),
+        },
+    )
+    return Diagnosis(chart=chart, findings=findings)

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -34,7 +34,18 @@ def _participating_files(agent_home: Path, participation: Dict[str, Dict[str, An
     """Yield (ca_type, spec, path) for every file the graph should contain."""
     for ca_type, spec in participation.items():
         for rel in spec["dirs"]:
-            d = agent_home / "agent" / rel
+            # Framework-rooted types live outside the agent tree. Resolving them
+            # against agent_home was silently catastrophic: dirs=[""] became
+            # agent_home/"agent"/"" — the WHOLE agent tree — so every artifact
+            # was examined a second time and mislabelled with this type.
+            if spec.get("root") == "framework":
+                from .utils.manifest import get_framework_policies_path
+                base = get_framework_policies_path()
+                if not base:
+                    continue
+                d = base / rel if rel else base
+            else:
+                d = agent_home / "agent" / rel
             if not d.exists():
                 continue
             unit = spec.get("unit", "all")

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -73,6 +73,11 @@ def examine(agent_home: Optional[Path] = None,
             continue
         if extract_wiki_concepts(content):
             continue
+        # Opt-in types: not participating is a valid state, not an orphan.
+        # Reporting them would bury the real findings under the majority that
+        # simply have not opted in.
+        if spec.get("opt_in"):
+            continue
         orphans_by_type.setdefault(ca_type, []).append(path)
         # Distinguish "never linked" from "wrote links that do not count".
         # The second is a different mistake and deserves a different remedy.

--- a/macf/tests/test_concepts.py
+++ b/macf/tests/test_concepts.py
@@ -1,0 +1,187 @@
+"""Tests for the concept vocabulary layer.
+
+The property under test is easy to state and easy to get subtly wrong: a
+concept extractor decides **what the knowledge graph believes an artifact is
+about**, and both of its failure directions are silent.
+
+Extracting too little produces orphans — artifacts that exist on disk and
+cannot be reached by the concept query a successor would actually use. That
+failure at least *looks* like absence.
+
+Extracting too much is worse. It produces edges that were never claimed, and a
+graph with false edges looks HEALTHIER than one with missing edges, so nothing
+prompts anyone to check. Measured on the real corpus, three reflections
+consisted entirely of concepts quoted inside code spans while discussing
+notation; the old extractor counted them, and those three artifacts appeared
+connected while being orphans.
+
+So the tests below spend most of their effort on the boundary between a
+concept USED and a concept MENTIONED, and on the union rule that lets a
+document be about something in its summary and about something else in its
+prose without either suppressing the other.
+"""
+
+import pytest
+
+from macf.concepts import (
+    extract_wiki_concepts,
+    normalize_concept,
+    normalize_concepts,
+)
+
+
+class TestNormalizeConcept:
+    """Canonical form: one spelling per concept, or the graph splits."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("verification", "verification"),
+        ("Verification", "verification"),
+        ("VERIFICATION", "verification"),
+        ("[[verification]]", "verification"),
+        ("  verification  ", "verification"),
+        ("knowledge web", "knowledge_web"),
+        ("knowledge-web", "knowledge_web"),
+        ("knowledge_web", "knowledge_web"),
+        ("verification.md", "verification"),
+        ("Verification.MD", "verification"),
+        ("[[Knowledge-Web.md]]", "knowledge_web"),
+    ])
+    def test_spellings_collapse_to_one_form(self, raw, expected):
+        assert normalize_concept(raw) == expected
+
+    def test_hyphen_becomes_underscore(self):
+        """The scholarship policy specifies underscores.
+
+        A previous implementation preserved hyphens, so ``knowledge-web`` and
+        ``knowledge_web`` were two nodes. That is drift the doctor is meant to
+        report, not a distinction worth keeping.
+        """
+        assert normalize_concept("knowledge-web") == normalize_concept("knowledge_web")
+
+    @pytest.mark.parametrize("junk", ["", "   ", "[[]]", "!!!", "---"])
+    def test_nothing_survivable_yields_empty(self, junk):
+        """Callers drop these; an empty concept must never become a node."""
+        assert normalize_concept(junk) == ""
+
+
+class TestNormalizeConcepts:
+    def test_dedupes_preserving_first_seen_order(self):
+        """Order carries authorial emphasis — the first concept listed is
+        usually what the artifact is most about."""
+        assert normalize_concepts(["b", "a", "B", "c", "A"]) == ["b", "a", "c"]
+
+    def test_variants_dedupe_against_each_other(self):
+        assert normalize_concepts(["Knowledge-Web", "knowledge_web", "knowledge web"]) == ["knowledge_web"]
+
+    def test_empties_dropped_not_kept_as_blank_nodes(self):
+        assert normalize_concepts(["ok", "", "  ", "[[]]"]) == ["ok"]
+
+    def test_none_and_empty_input(self):
+        assert normalize_concepts(None) == []
+        assert normalize_concepts([]) == []
+
+
+class TestExtractUnion:
+    """Section and prose are both sources. Neither may suppress the other."""
+
+    def test_section_and_inline_are_unioned(self):
+        doc = (
+            "# JOTEWR\n"
+            "The lesson was about [[verification]] and how [[silent_failure]] hides.\n\n"
+            "## Wiki-Links\n\n[[knowledge_web]] [[tooling]]\n"
+        )
+        assert extract_wiki_concepts(doc) == [
+            "knowledge_web", "tooling", "verification", "silent_failure",
+        ]
+
+    def test_section_does_not_suppress_prose(self):
+        """The regression this module exists to fix.
+
+        Extraction previously treated the whole-document scan as a fallback,
+        so a non-empty section discarded every inline concept — meaning that
+        ADDING a summary section to a richly linked reflection REDUCED its
+        graph presence.
+        """
+        doc = "# X\nprose [[alpha]]\n\n## Wiki-Links\n\n[[beta]]\n"
+        got = extract_wiki_concepts(doc)
+        assert "alpha" in got and "beta" in got
+
+    def test_section_first_then_prose(self):
+        """Summary concepts lead: they describe the whole artifact."""
+        doc = "# X\nprose [[zulu]]\n\n## Wiki-Links\n\n[[alpha]]\n"
+        assert extract_wiki_concepts(doc) == ["alpha", "zulu"]
+
+    def test_overlap_appears_once(self):
+        doc = "# X\nprose [[shared]] and [[only_prose]]\n\n## Wiki-Links\n\n[[shared]] [[only_section]]\n"
+        assert extract_wiki_concepts(doc) == ["shared", "only_section", "only_prose"]
+
+    def test_prose_only_document_still_participates(self):
+        assert extract_wiki_concepts("# X\njust [[alpha]] here\n") == ["alpha"]
+
+    def test_section_only_document_still_participates(self):
+        assert extract_wiki_concepts("# X\n\n## Wiki-Links\n\n[[alpha]] [[beta]]\n") == ["alpha", "beta"]
+
+    def test_no_links_yields_empty(self):
+        assert extract_wiki_concepts("# X\nnothing to see\n") == []
+
+
+class TestMentionVersusUse:
+    """A corpus documenting its own conventions writes about concepts on
+    purpose. Counting those mints phantom nodes."""
+
+    def test_inline_code_span_is_a_mention(self):
+        doc = "# X\nWrite it as `[[compaction]]` in your section.\nReal use: [[verification]].\n"
+        got = extract_wiki_concepts(doc)
+        assert got == ["verification"]
+        assert "compaction" not in got
+
+    def test_fenced_block_is_a_mention(self):
+        doc = "# X\n```\n[[fake]]\n```\nreal [[actual]]\n"
+        assert extract_wiki_concepts(doc) == ["actual"]
+
+    def test_tilde_fenced_block_is_a_mention(self):
+        doc = "# X\n~~~\n[[fake]]\n~~~\nreal [[actual]]\n"
+        assert extract_wiki_concepts(doc) == ["actual"]
+
+    def test_document_of_only_mentions_is_an_orphan(self):
+        """The measured real-world case.
+
+        Three reflections in the corpus contained wiki-links exclusively
+        inside code spans while explaining the notation. They must extract to
+        nothing — reporting them as orphans is correct, and is strictly better
+        than the edges the old extractor invented for them.
+        """
+        doc = "# Reflection\nI wrote `[[verification]]` and `[[epistemics]]` while explaining the syntax.\n"
+        assert extract_wiki_concepts(doc) == []
+
+    def test_fence_containing_backticks_does_not_leak(self):
+        """Fenced blocks are stripped before code spans, so an inner backtick
+        cannot leave a dangling delimiter that swallows real prose."""
+        doc = "# X\n```\nuse ` and [[fake]]\n```\nreal [[actual]]\n"
+        assert extract_wiki_concepts(doc) == ["actual"]
+
+    def test_block_quotes_are_kept(self):
+        """Deliberate, and narrow: no artifact in the corpus puts a wiki-link
+        in a block quote, so excluding them would be untested behaviour
+        written for a case that does not occur. Documented so a future change
+        is a decision rather than an accident."""
+        assert extract_wiki_concepts("# X\n> quoted [[alpha]]\n") == ["alpha"]
+
+
+class TestExtractionNormalizes:
+    def test_variants_across_sources_merge(self):
+        """A concept written one way inline and another in the summary is one
+        node, not two."""
+        doc = "# X\nprose [[Knowledge-Web]]\n\n## Wiki-Links\n\n[[knowledge_web]]\n"
+        assert extract_wiki_concepts(doc) == ["knowledge_web"]
+
+    def test_heading_variants_recognised(self):
+        for heading in ("## Wiki-Links", "##  Wiki-Links", "## wiki-links"):
+            doc = f"# X\n\n{heading}\n\n[[alpha]]\n"
+            assert extract_wiki_concepts(doc) == ["alpha"], heading
+
+    def test_following_section_terminates_the_block(self):
+        """Concepts after the next heading are prose, not summary — they must
+        still be found, but the section must not swallow the rest of the file."""
+        doc = "# X\n\n## Wiki-Links\n\n[[alpha]]\n\n## Notes\n\ntail [[beta]]\n"
+        assert extract_wiki_concepts(doc) == ["alpha", "beta"]

--- a/macf/tests/test_ideas_wiki_links.py
+++ b/macf/tests/test_ideas_wiki_links.py
@@ -39,12 +39,18 @@ def test_normalize_drops_empties():
 
 
 def test_normalize_drops_disallowed_chars():
-    """Non-[a-z0-9_-] chars are stripped (not replaced)."""
+    """Non-[a-z0-9_] chars are stripped (not replaced); hyphens fold to underscores first."""
     assert _normalize_wiki_links(["foo!bar@baz"]) == ["foobarbaz"]
 
 
-def test_normalize_preserves_underscores_and_hyphens():
-    assert _normalize_wiki_links(["foo_bar", "foo-bar"]) == ["foo_bar", "foo-bar"]
+def test_normalize_folds_hyphens_into_underscores():
+    """Hyphenated spellings are drift to merge, not distinct concepts.
+
+    The scholarship policy spells multi-word concepts with underscores, so
+    ``foo-bar`` normalizes to ``foo_bar`` and dedups against it.
+    """
+    assert _normalize_wiki_links(["foo-bar"]) == ["foo_bar"]
+    assert _normalize_wiki_links(["foo_bar", "foo-bar"]) == ["foo_bar"]
 
 
 def test_normalize_empty_and_none_input():


### PR DESCRIPTION
Cycle-closeout curation reported **zero gaps** while thirty consciousness artifacts had no edges at all. The instrument could not observe the condition it most needed to report: gap detection compares keyword overlap between *connected* nodes, so an artifact with no wiki-links is dropped before comparison begins.

Fixing that turned out to require settling what the knowledge web contains and why, not just widening a scan.

## The root cause was policy, not tooling

Measured before changing anything: **six of eight CA-type policies said nothing about graph participation.** The two types that participated reliably were the ones where tooling made it unavoidable — `ideas` carries `wiki_links` as a schema field, so it cannot opt out. Types participated exactly where code forced it and never where policy asked.

A second measurement made the same point from the other side: **zero of sixteen CA-creating commands mentioned wiki-links.** Artifacts were never asked for the section that connects them.

## What's here

**Node semantics.** `scholarship.md` gains two independent axes, defined once and cited rather than restated: *class* (conceptual authority / temporal record / normative) and *provenance* (lived / inherited). Every CA-type policy now states whether it participates, at what unit of node, in which class, with rationale.

The counter-intuitive calls are argued rather than asserted. Checkpoints and roadmaps are temporal records — their claims expire by design, and that is what they are for. The rejected alternative (exclude them entirely, serve the archaeological question through existing breadcrumb indexing) is recorded so a successor can reopen it rather than assume oversight.

**Registry authority.** Reconciling the type list found **six registries describing "the CA types" with no two agreeing** — the manifest, the `ca-types` command, the graph scanner's hardcoded directory list, the policy files, the filesystem, and artifact path resolution. Two directories were producing artifacts while appearing in no registry; one declared type has no artifacts anywhere. `scholarship.md` now states that the manifest is authoritative and everything else derives from it, because six hand-maintained lists is a structure that guarantees divergence rather than a discipline problem.

**A concepts module.** Concepts belong to no single CA type — a concept is precisely what lets a learning, a reflection, a checkpoint and an idea refer to the same subject. Extracting `concepts.py` surfaced a duplicate normalizer 350 lines above the one being added, and the two disagreed: the older preserved hyphens, which the policy forbids and the new doctor flags as drift.

Extraction now **unions** the `## Wiki-Links` section with inline `[[concept]]` usage. Previously the whole-document scan was a fallback, so a non-empty section *suppressed* every inline concept — adding a summary to a richly linked reflection reduced its graph presence.

Code spans and fenced blocks are excluded as mentions rather than uses. Three reflections turned out to consist *entirely* of such mentions: they were discussing the notation, and the parser had been manufacturing edges from prose explaining it. Those artifacts appeared connected while being orphans, which is worse than a plain orphan because false edges make a graph look healthier.

**`macf_tools knowledge doctor`.** Reports orphans, normalization drift, singleton concepts, registry integrity and class coverage. Shared vocabulary lives in `diagnostics.py` rather than inside the first doctor, since later doctors need the same terms and a specialist that hoards them makes the family unreadable together. Severities are *acute* (wrong now, will mislead), *chronic* (degrading), *note*. The chart prints even when nothing is wrong — a doctor that reports only problems cannot be distinguished from one that examined nothing.

`corpus_integrity.md` ships with it, stating when running it is worth doing and why CI gating is the wrong default answer to a noisy checker. It deliberately enumerates no flags.

**Reach and classes.** Roadmaps are scanned for the first time; experiments contribute `protocol` + `analysis` rather than one node per evidence file; `knowledge query --class` filters on node class. On `[[verification]]`: 59 matched unfiltered, 57 conceptual authority, 2 temporal record. Those answer different questions — "what do I know about X" versus "which cycle touched X" — and mixing them dilutes the first by a ratio that worsens every cycle.

**Templates and PEP.** CA-creating commands now emit the section, referencing policy by content rather than restating it. `roadmaps_drafting.md` gains a Policy Engagement Protocol: a phase declares the policies its executor must engage, and required reading follows from the *work type* rather than being re-derived per phase.

That last one has a worked failure behind it. This branch's own code was written under a roadmap with no PEP, the coding standards were never opened, and a helper was added to a module that already had one. What would not have prevented it is the DRY rule inside those unopened standards — correct, and undelivered.

## Verification

Every new policy section confirmed to resolve through the CEP parser rather than by re-reading the file it was written into. 37 tests over the concepts module, mutation-swept — four mutations each kill 2–5 tests, restore returns 37/37. The doctor negative-controlled in both directions: planting a CA with no section takes orphans 35 → 36 and names it; restoring the section returns 35 and goes quiet. The second direction matters, since a checker that flags everything passes the first and is useless.

Graph deltas measured by controlled comparison with one variable changed, not by before/after totals across unrelated edits.

## Two commits are a mistake and its revert

`6cb0653` suppressed policy orphans on the theory that a policy without links has not opted in. That was wrong: it read the artifact's state as its own declaration, when participation intent belongs to the manifest and the file's state is what gets compared against it. Reverted in `e58a286`. Kept rather than squashed — the reasoning error is more useful in the history than a clean line would be.

## Not here

The cross-CA layer still lives in `ideas.py`, which is the wrong home for the same reason concepts were. Extracting it is tracked separately and was deliberately not started at low context, since a part-moved module is worse than an unmoved one. Manifest edits reconciling the type list are tracked for a phase that can verify them.

— TheHarborMaster@ee5cd8
