### PR TITLE
Harness: one launch implementation, identity-derived session names, and failures you can actually read

### DIFF
--- a/framework/policies/base/infrastructure/agent_harness.md
+++ b/framework/policies/base/infrastructure/agent_harness.md
@@ -1,0 +1,265 @@
+# Agent Harness — The Supervised Session, and the Name It Answers To
+
+**Breadcrumb**: s_1afd4d78/c_12/p_04343b94/t_1786152911
+**Type**: Infrastructure (opt-in)
+**Scope**: All agents that run supervised, and the deployments that provision them
+**Status**: ACTIVE
+**Version**: 1.0
+
+---
+
+## Purpose
+
+The **harness** is what makes an agent session outlive the terminal that started
+it: a systemd user unit creates a tmux session, tmux runs `macf.supervisor`, and
+the supervisor runs the client through a child wrapper that restarts it in place.
+Detach, reboot, client crash, and deliberate restart all survive it. Unattended
+autonomous operation is not possible without one.
+
+This policy exists because the harness fails in a particular way. **It does not
+crash. It reports success and does nothing** — or it comes up degraded in a
+configuration no surface displays. Every rule below was written after a failure
+that produced no error message, and the rules are stated with what they cost so
+the next deployment does not pay again.
+
+**Core Insight**: the harness is *identity infrastructure*, not just process
+supervision. What names the session determines who can find it, whether a status
+check can resolve its own subject, and whether "is it running" has an answer.
+
+---
+
+## CEP Navigation Guide
+
+**1 What the Harness Is**
+- What are the four layers and which one supervises which?
+- Why is the systemd unit `oneshot` when it manages a long-lived session?
+- What does `stop` have to stop, and why is the obvious answer wrong?
+
+**2 Identity and Naming**
+- What names the tmux session and the systemd unit?
+- How do I get from a Calling Card to a session name, and back?
+- Which characters are substituted, and which of those are actual constraints?
+- What happens when two agents map to the same identifier?
+- Why is what I *type* a different identifier from what the machine *names*?
+
+**3 Establishing That the Harness Is Up**
+- Why isn't `tmux has-session` an answer?
+- Why isn't `pgrep` for the supervisor an answer either?
+- What is the authoritative signal?
+- Why must every tmux target be written `=name`?
+
+**4 Invariants That Cost Incidents**
+- Why must the base URL and the first-party flag never be separated?
+- Why does the launch decision live in exactly one script?
+- What must a command started under tmux state explicitly?
+
+**5 For a Deployment**
+- What must I install, and in what order?
+- What must I not hand-edit?
+- How do I verify the harness rather than assume it?
+
+**6 Scope**
+- One session per identity — why, and what is deferred?
+
+---
+
+## 1 What the Harness Is
+
+Four layers, each supervising the next:
+
+| layer | responsibility |
+|---|---|
+| systemd user unit | create the session at boot, once |
+| tmux | own the session so a detached client survives |
+| `macf.supervisor` | own the client process and restart it in place |
+| child wrapper | resume with `-c`, restore channels, answer the trust prompt |
+
+The unit is `Type=oneshot` with `RemainAfterExit=yes` because **its job is to
+create the session, not to be the session.** A `Restart=` here would fight the
+supervisor, which is the component that actually owns the client.
+
+For the same reason, **stopping the harness means stopping the SUPERVISOR.**
+Killing the child is not a stop — the supervisor simply restarts it. A stop that
+targets the child is a restart with extra steps.
+
+---
+
+## 2 Identity and Naming
+
+### 2.1 The session identifier derives from the Calling Card
+
+The tmux session, the systemd unit and the supervisor instance are all named by
+one **session identifier**, and it is a pure function of the agent's Calling
+Card:
+
+```
+TheHarborMaster@ee5cd8   ->   TheHarborMaster_ee5cd8
+```
+
+`macf.utils.identity.session_identifier()` computes it;
+`calling_card_from_identifier()` reverses it.
+
+Before this, the harness used a nickname that appeared nowhere else in the
+framework. That made session management **a second, unregistered namespace**: an
+operator holding the Calling Card could not derive the session name, a tool
+holding the session name could not recover the agent, and `harness status` had no
+default it could resolve — so it guessed, printed `ABSENT`, and read as *there is
+no harness here* while a healthy harness ran under another name.
+
+**A default reported as a resolution is a lie the reader cannot detect.** Any
+surface that falls back to a default must say that it did.
+
+### 2.2 Which characters are substituted, and why each
+
+Measured, not assumed (tmux 3.6 / systemd 257, 2026-08-07):
+
+| char | tmux | systemd | verdict |
+|---|---|---|---|
+| `.` | **silently rewritten to `_`** at session creation | fine | **constraint** |
+| `:` | **silently rewritten to `_`** | rejected: "Couldn't process aliases" | **constraint** |
+| `/`, space, tab | unsafe | unsafe | **constraint** |
+| `@` | kept verbatim, addresses correctly | enables, symlinks, starts, reports active | **convention** |
+| `-`, `_` | fine | fine | kept |
+
+The `.` and `:` cases are the reason substitution exists at all, and they show the
+harness's signature failure shape: `tmux new-session` **succeeds**, reports no
+error, and stores a different name — so every later `-t` lookup silently misses.
+
+`@` is different and the difference is recorded deliberately. It is **not** a
+constraint: a concrete unit named `cc-harness-Name@abc123.service` enables,
+symlinks into `default.target.wants`, starts and reports `is-active`. It is
+substituted by **convention**, because `@` is how systemd spells a template
+instance and a concrete unit wearing that shape misleads both people and tooling.
+
+> An earlier write-up of this work asserted that `@` had to be substituted *for
+> systemd's sake*. Measurement refuted it. The distinction is kept in the policy
+> because a convention can be revisited and a constraint cannot, and a reader who
+> cannot tell them apart will treat both as immovable.
+
+### 2.3 Collisions
+
+Two Calling Cards differing only in a substituted character map to one
+identifier. This is **not resolved by the substitution** — it is made harmless
+downstream: a resolver that finds several candidate harnesses **lists them and
+refuses to choose**. The six-hex suffix comes from a UUID, so a real collision
+needs two monikers differing only by punctuation *and* a shared UUID prefix.
+
+### 2.4 Two identifiers, on purpose
+
+What the machine **names** and what an operator **types** are separate:
+
+- `agent` — the session identifier. Traceable to an identity. Long.
+- `shell_prefix` — the handle in the generated shell functions
+  (`maceff_<prefix>_harness_launch`). Short. Defaults to the moniker.
+
+Forcing one identifier to serve both is what produced the untraceable nickname in
+the first place. **Traceability is a property the tools need; brevity is a
+property the hand needs.** Do not collapse them.
+
+---
+
+## 3 Establishing That the Harness Is Up
+
+Three checks, two of which are wrong, and both wrong ones look right.
+
+**`tmux has-session -t <name>` — wrong.** It proves a session *by that name*
+exists, not that it is yours. An unrelated ssh login once owned the name; the
+guard matched, launch attached to a shell, and the harness stayed down for nine
+days with nothing logged, because a session really did exist.
+
+**`pgrep -f 'macf.supervisor ... --name <agent>'` — also wrong**, and worse
+because it looks like a real check. When tmux starts a server it keeps the
+command it was asked to run **in its own argv**. So this matches the tmux server
+and reports a live supervisor for as long as the server lives — nine days after
+the supervisor exited, when measured.
+
+**Authoritative**: the supervisor's own registry, which is keyed by the
+supervisor's pid, then confirmed against the process table:
+
+1. a registry entry for this agent with `status: running`, and
+2. `kill -0 <pid>` — entries outlive their processes, and
+3. `ps -o args= -p <pid>` still shows a supervisor — pids get recycled.
+
+### 3.1 Every tmux target must be written `=name`
+
+**tmux resolves `-t` targets by PREFIX.** `-t thm` matches a session called
+`thm-stale-ssh`. This is not academic: renaming the imposter out of the way is
+exactly the remedy an operator reaches for, and it **does not free the name** —
+the harness kept reporting its session "up" for nine days after the only session
+by that prefix had been renamed and handed to an ssh login.
+
+Write `-t =name` everywhere: `has-session`, `attach`, `send-keys`, and in any
+advice printed for a human to type. Loose advice teaches the loose form.
+
+Short identifiers make this worse — a three-character slug is a prefix of almost
+anything — which is a second, independent reason to derive names from the Calling
+Card.
+
+---
+
+## 4 Invariants That Cost Incidents
+
+**The base URL and the first-party flag are one assignment.** Whenever
+`ANTHROPIC_BASE_URL` points at a host that is not `api.anthropic.com`, the client
+stops extending the long-context window and falls back to 200K — silently, while
+every UI surface keeps displaying the full window. `_CLAUDE_CODE_ASSUME_FIRST_
+PARTY_BASE_URL=1` is what prevents it. Emitting them in separate places is how a
+months-long "compacts early" mystery survived, and later how a terminal-launched
+harness ran at a fifth of its reported capacity for a week.
+
+**The launch decision lives in exactly one script.** systemd and the operator's
+shell both call it. When they each carried a copy, the copies drifted, and the
+drift was the missing flag above. One implementation cannot disagree with itself.
+
+**A command started under tmux inherits nothing you can rely on.** It runs under
+the tmux *server*, which may have been created days earlier by an unrelated
+login. Interpreter path, `PATH`, and context window must be stated in the command
+string. Verified: an exported variable in the launching shell did not arrive.
+
+**Channels are part of continuity.** Losing `--channels` costs no error and no
+log line — the session comes up, the terminal looks right, and the agent is
+unreachable from outside. Never defaulted, never inferred: declared.
+
+---
+
+## 5 For a Deployment
+
+```bash
+macf_tools harness generate              # review first; writes nothing
+macf_tools harness install --check       # report drift against the generator
+macf_tools harness install --channel <plugin> [--shell-prefix <short>]
+systemctl --user daemon-reload && systemctl --user enable --now cc-harness-<id>.service
+macf_tools harness status                # resolves the agent, or says it defaulted
+```
+
+**Do not hand-edit the rendered artifacts.** Every one carries a
+`generated, do not hand-edit` banner and a regeneration command. The generator
+exists because a hand-edited unit and its stored copy drifted, and the stored copy
+was missing the flag that makes the harness work — so anyone installing from the
+artifact got a silently degraded session.
+
+**Verify, do not assume.** `install --check` reports drift. `harness status`
+reports whether the session is *owned* by this harness, not merely present.
+A harness that has never been observed through a second path has not been
+verified.
+
+---
+
+## 6 Scope
+
+**In scope: one active session per Calling Card.** This is Agentic Continuity —
+one agent identity persisting across restarts, which is what the harness exists
+to provide.
+
+**Out of scope: multiple parallel sessions sharing one Calling Card.** That needs
+fork → join semantics to reconcile divergent sessions into a single identity, and
+it is a substantially harder problem: two sessions writing one task store is a
+solved class of problem, but **which fork's experience is the agent's experience**
+is not. It is named here so the naming scheme does not foreclose it — an
+identifier with room for an optional discriminator costs nothing today.
+
+---
+
+## Wiki-Links
+
+[[tooling]] [[silent_failure]] [[verification]] [[autonomy]] [[capability_boundary]]

--- a/framework/policies/manifest.json
+++ b/framework/policies/manifest.json
@@ -1046,7 +1046,7 @@
     "types": {
       "observations": {
         "name": "observations",
-        "emoji": "🔬",
+        "emoji": "\ud83d\udd2c",
         "description": "Technical discoveries and insights",
         "discovery_keys": [
           "observation",
@@ -1059,7 +1059,7 @@
       },
       "experiments": {
         "name": "experiments",
-        "emoji": "🧪",
+        "emoji": "\ud83e\uddea",
         "description": "Controlled testing and validation",
         "discovery_keys": [
           "experiment",
@@ -1073,7 +1073,7 @@
       },
       "reports": {
         "name": "reports",
-        "emoji": "📊",
+        "emoji": "\ud83d\udcca",
         "description": "Project completion summaries",
         "discovery_keys": [
           "report",
@@ -1087,7 +1087,7 @@
       },
       "reflections": {
         "name": "reflections",
-        "emoji": "💭",
+        "emoji": "\ud83d\udcad",
         "description": "Philosophical growth synthesis",
         "discovery_keys": [
           "reflection",
@@ -1101,7 +1101,7 @@
       },
       "checkpoints": {
         "name": "checkpoints",
-        "emoji": "🔖",
+        "emoji": "\ud83d\udd16",
         "description": "Strategic state preservation",
         "discovery_keys": [
           "checkpoint",
@@ -1113,7 +1113,7 @@
       },
       "roadmaps": {
         "name": "roadmaps",
-        "emoji": "🗺️",
+        "emoji": "\ud83d\uddfa\ufe0f",
         "description": "Multi-phase planning documents",
         "discovery_keys": [
           "roadmap",
@@ -1131,7 +1131,7 @@
       },
       "emotions": {
         "name": "emotions",
-        "emoji": "❤️",
+        "emoji": "\u2764\ufe0f",
         "description": "Emotional expression and processing",
         "discovery_keys": [
           "emotional",
@@ -1145,7 +1145,7 @@
       },
       "learnings": {
         "name": "learnings",
-        "emoji": "📚",
+        "emoji": "\ud83d\udcda",
         "description": "Accumulated wisdom and lessons",
         "discovery_keys": [
           "learning",
@@ -1584,7 +1584,7 @@
         "short_name": "CAPBOUND",
         "path": "base/infrastructure/capability_boundaries.md",
         "CEP_triggers": [
-          "I was refused reaching something — is the network broken or is this deliberate?",
+          "I was refused reaching something \u2014 is the network broken or is this deliberate?",
           "What should an agent do when it meets a capability boundary, and what must it not do?",
           "Why can't the service being reached just enforce its own allowlist?",
           "What three different failures does one capability boundary prevent?",
@@ -1610,6 +1610,36 @@
           "hardening",
           "reach",
           "enforcement"
+        ]
+      },
+      {
+        "name": "agent_harness",
+        "short_name": "HARNESS",
+        "path": "base/infrastructure/agent_harness.md",
+        "CEP_triggers": [
+          "How do I tell whether the harness is actually running, and why isn't `tmux has-session` an answer?",
+          "What names the tmux session and the systemd unit, and how do I get back to the agent from it?",
+          "Which characters can a session identifier not contain, and which of those are real constraints?",
+          "Why did `harness status` report ABSENT while the harness was running?",
+          "Why must every tmux `-t` target be written `=name`?",
+          "Why must ANTHROPIC_BASE_URL and the first-party flag never be emitted separately?",
+          "Why does a command started under tmux not inherit my shell's environment?",
+          "What does stopping the harness have to stop, and why is killing the client wrong?",
+          "What must a deployment install, verify, and never hand-edit?",
+          "Why is one session per Calling Card the supported case, and what is deferred?"
+        ],
+        "keywords": [
+          "harness",
+          "tmux",
+          "systemd",
+          "supervisor",
+          "session",
+          "unit",
+          "calling card",
+          "identifier",
+          "restart",
+          "continuity",
+          "auto-restart"
         ]
       }
     ]

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1435,8 +1435,13 @@ def _harness_params(args: argparse.Namespace):
     channels = tuple(getattr(args, "channel", None) or ())
     prefix = getattr(args, "shell_prefix", None)
     if channels or prefix:
-        p = replace(p, channels=channels or p.channels, shell_prefix=prefix or p.shell_prefix)
-    return p
+        p = replace(p, channels=channels, shell_prefix=prefix)
+    # Fill anything not given from what the last install recorded. Without this
+    # a flagless `install --check` renders different artifacts and reports drift
+    # that is not there — and acting on that report with --force would strip the
+    # channel silently.
+    from .utils.harness import load_settings
+    return load_settings(p)
 
 
 def cmd_harness_generate(args: argparse.Namespace) -> int:
@@ -1499,6 +1504,7 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
         render_start,
         render_tmux_conf,
         render_unit,
+        save_settings,
     )
 
     try:
@@ -1543,6 +1549,8 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
                 path.chmod(path.stat().st_mode | _stat.S_IXUSR)
             print(f"   ✓ {path}")
 
+        save_settings(p)
+        print(f"   ✓ {p.settings_path}")
         print(f"\n✅ Harness installed for agent '{p.agent}'")
         print(f"   systemctl --user daemon-reload && systemctl --user enable --now {p.unit_name}")
         # "=" is not decoration: tmux matches targets by PREFIX, so advice

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1427,8 +1427,16 @@ def cmd_statusline(args: argparse.Namespace) -> int:
 
 
 def _harness_params(args: argparse.Namespace):
+    from dataclasses import replace
     from .utils.harness import default_params
-    return default_params(agent=getattr(args, "agent", None), home=getattr(args, "home", None))
+    p = default_params(agent=getattr(args, "agent", None), home=getattr(args, "home", None))
+    # Channels are declared, never inferred. They are the agent's inbound link
+    # when nobody is attached, and a default would be a guess about reachability.
+    channels = tuple(getattr(args, "channel", None) or ())
+    prefix = getattr(args, "shell_prefix", None)
+    if channels or prefix:
+        p = replace(p, channels=channels or p.channels, shell_prefix=prefix or p.shell_prefix)
+    return p
 
 
 def cmd_harness_generate(args: argparse.Namespace) -> int:
@@ -1439,7 +1447,13 @@ def cmd_harness_generate(args: argparse.Namespace) -> int:
     anywhere — the hand-edited predecessor drifted precisely because there was
     nothing to diff against.
     """
-    from .utils.harness import render_unit, render_child, render_tmux_conf
+    from .utils.harness import (
+        render_child,
+        render_launch_functions,
+        render_start,
+        render_tmux_conf,
+        render_unit,
+    )
 
     try:
         p = _harness_params(args)
@@ -1447,10 +1461,18 @@ def cmd_harness_generate(args: argparse.Namespace) -> int:
         what = getattr(args, "what", "unit")
         if what in ("unit", "all"):
             print(render_unit(p, attach_proxy=attach), end="")
+        if what in ("start", "all"):
+            if what == "all":
+                print(f"\n# ===== {p.start} =====")
+            print(render_start(p, attach_proxy=attach), end="")
         if what in ("child", "all"):
             if what == "all":
                 print(f"\n# ===== {p.child_path} =====")
             print(render_child(p), end="")
+        if what in ("functions", "all"):
+            if what == "all":
+                print(f"\n# ===== {p.functions} =====")
+            print(render_launch_functions(p), end="")
         if what in ("tmux", "all"):
             if what == "all":
                 print(f"\n# ===== {p.home}/.tmux-{p.agent}.conf =====")
@@ -1471,7 +1493,13 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
     """
     from pathlib import Path
     import stat as _stat
-    from .utils.harness import render_unit, render_child, render_tmux_conf
+    from .utils.harness import (
+        render_child,
+        render_launch_functions,
+        render_start,
+        render_tmux_conf,
+        render_unit,
+    )
 
     try:
         p = _harness_params(args)
@@ -1479,7 +1507,9 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
         unit_dir = Path.home() / ".config" / "systemd" / "user"
         targets = [
             (unit_dir / p.unit_name, render_unit(p, attach_proxy=attach), False),
+            (Path(p.start), render_start(p, attach_proxy=attach), True),
             (Path(p.child_path), render_child(p), True),
+            (Path(p.functions), render_launch_functions(p), False),
             (p.home / f".tmux-{p.agent}.conf", render_tmux_conf(p), False),
         ]
 
@@ -1515,7 +1545,9 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
 
         print(f"\n✅ Harness installed for agent '{p.agent}'")
         print(f"   systemctl --user daemon-reload && systemctl --user enable --now {p.unit_name}")
-        print(f"   attach:  tmux attach -t {p.agent}")
+        # "=" is not decoration: tmux matches targets by PREFIX, so advice
+        # without it teaches the loose form that caused GH #209.
+        print(f"   attach:  tmux attach -t ={p.agent}   (or: maceff_{p.prefix}_harness_launch)")
         print(f"   status:  macf_tools harness status --agent {p.agent}")
         print(f"   stop:    systemctl --user stop {p.unit_name}   (stops the supervisor, not the child)")
         return 0
@@ -1525,22 +1557,69 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
 
 
 def cmd_harness_status(args: argparse.Namespace) -> int:
-    """Report unit state, session presence and proxy attachment."""
+    """Report unit state, session presence and proxy attachment.
+
+    Every negative line names the agent it checked, and a defaulted name says
+    so. This command once printed a confident ABSENT for a harness that was
+    running under a different name, and came within one step of telling the
+    operator his harness did not exist — an instrument answering about
+    something it never looked at.
+    """
     from pathlib import Path
+    from .utils.harness import resolve_agent
+    from .utils.identity import calling_card_from_identifier
 
     try:
+        agent, source = resolve_agent(getattr(args, "agent", None))
+        if source == "ambiguous":
+            print("agent:   AMBIGUOUS — several harnesses are installed here:")
+            for a in agent:
+                print(f"           {a}  ({calling_card_from_identifier(a)})")
+            print("\nPick one with --agent; this command will not choose for you.",
+                  file=sys.stderr)
+            return 1
+
         p = _harness_params(args)
         unit_path = Path.home() / ".config" / "systemd" / "user" / p.unit_name
-        print(f"agent:   {p.agent}")
-        print(f"unit:    {unit_path} {'(present)' if unit_path.exists() else '(ABSENT)'}")
+        card = calling_card_from_identifier(p.agent)
+        if source == "default":
+            # The line that was missing. A default reported as a resolution is
+            # how "no harness for the name I guessed" reads as "no harness".
+            print(f"agent:   {p.agent}  (DEFAULT — not resolved from the "
+                  f"environment, config or any installed unit)")
+        else:
+            print(f"agent:   {p.agent}  ({card}, via {source})")
+        print(f"unit:    {unit_path} "
+              f"{'(present)' if unit_path.exists() else f'(ABSENT for agent {p.agent})'}")
 
         active = subprocess.run(["systemctl", "--user", "is-active", p.unit_name],
                                 capture_output=True, text=True).stdout.strip()
         print(f"active:  {active or 'unknown'}")
 
-        has_session = subprocess.run(["tmux", "has-session", "-t", p.agent],
+        # "=" forces an EXACT session match. Without it tmux resolves a target
+        # by prefix, so `-t thm` happily matches a session called
+        # "thm-stale-ssh" -- which is precisely the name someone gives the
+        # imposter while moving it out of the way, so the workaround for the
+        # name collision silently did not resolve the collision.
+        has_session = subprocess.run(["tmux", "has-session", "-t", f"={p.agent}"],
                                      capture_output=True).returncode == 0
-        print(f"session: {'up' if has_session else 'absent'} (tmux -t {p.agent})")
+        print(f"session: {'up' if has_session else f'absent for {p.agent}'} "
+              f"(tmux -t ={p.agent})")
+
+        # Presence is not ownership. A session under this name may be anyone's
+        # — that is how the harness stayed down for days while every surface
+        # said "session: up".
+        if has_session:
+            sup = subprocess.run(
+                ["bash", "-c",
+                 f'for f in {p.registry}/*.json; do [ -e "$f" ] || continue; '
+                 f'grep -q \'"name": "{p.agent}"\' "$f" || continue; '
+                 f'grep -q \'"status": "running"\' "$f" || continue; '
+                 f'pid=${{f##*/}}; pid=${{pid%.json}}; kill -0 "$pid" 2>/dev/null || continue; '
+                 f'ps -o args= -p "$pid" | grep -q "macf\\.supervisor" || continue; '
+                 f'echo "$pid"; break; done'],
+                capture_output=True, text=True).stdout.strip()
+            print(f"owner:   {'macf supervisor pid ' + sup if sup else 'NOT this harness — the name is held by something else'}")
 
         probe = subprocess.run(
             ["curl", "-s", "--max-time", "2", "-o", "/dev/null",
@@ -9053,8 +9132,13 @@ def _build_parser() -> argparse.ArgumentParser:
     harness_generate.add_argument("--home", help="agent home directory")
     harness_generate.add_argument("--no-proxy", action="store_true",
                                   help="render without proxy attachment")
-    harness_generate.add_argument("--what", choices=["unit", "child", "tmux", "all"], default="unit",
-                                  help="which artifact to render (default: unit)")
+    harness_generate.add_argument("--channel", action="append", metavar="PLUGIN",
+                                 help="channel plugin the client must load; repeatable")
+    harness_generate.add_argument("--shell-prefix", metavar="NAME",
+                                 help="short handle for the generated shell functions (default: the moniker half of the Calling Card)")
+    harness_generate.add_argument(
+        "--what", choices=["unit", "start", "child", "functions", "tmux", "all"], default="unit",
+        help="which artifact to render (default: unit)")
     harness_generate.set_defaults(func=cmd_harness_generate)
 
     harness_install = harness_sub.add_parser("install", help="write harness artifacts into place")
@@ -9062,6 +9146,10 @@ def _build_parser() -> argparse.ArgumentParser:
     harness_install.add_argument("--home", help="agent home directory")
     harness_install.add_argument("--no-proxy", action="store_true",
                                  help="install without proxy attachment")
+    harness_install.add_argument("--channel", action="append", metavar="PLUGIN",
+                                 help="channel plugin the client must load; repeatable")
+    harness_install.add_argument("--shell-prefix", metavar="NAME",
+                                 help="short handle for the generated shell functions (default: the moniker half of the Calling Card)")
     harness_install.add_argument("--check", action="store_true",
                                  help="report drift against what would be rendered; write nothing")
     harness_install.add_argument("--force", action="store_true",

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1631,9 +1631,16 @@ def cmd_harness_attach(args: argparse.Namespace) -> int:
                   file=sys.stderr)
             return 1
 
+        # -CC hands the session to iTerm2 as native windows. It matters more
+        # than it looks: the client owns the alternate screen, so under a plain
+        # attach there is no tmux-level scrollback at all -- control mode is
+        # what restores native scrollback, selection and find on macOS.
+        cmd = ["tmux"]
+        if getattr(args, "control", False):
+            cmd.append("-CC")
+        cmd += ["attach", "-t", target]
         # -d evicts other clients: two clients of different geometries is the
         # cause of the fragmented redraws. Read-only observers skip it.
-        cmd = ["tmux", "attach", "-t", target]
         cmd.append("-r" if getattr(args, "read_only", False) else "-d")
         os.execvp("tmux", cmd)
     except Exception as e:
@@ -9247,6 +9254,8 @@ def _build_parser() -> argparse.ArgumentParser:
     harness_attach = harness_sub.add_parser(
         "attach", help="attach this terminal to the agent's supervised session")
     harness_attach.add_argument("--agent", help="agent slug (default: resolved from identity)")
+    harness_attach.add_argument("--control", action="store_true",
+                                help="attach in tmux control mode (-CC), for iTerm2 on macOS")
     harness_attach.add_argument("--read-only", action="store_true",
                                 help="observe without evicting other clients or taking the keyboard")
     harness_attach.set_defaults(func=cmd_harness_attach)

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -391,6 +391,17 @@ def cmd_env(args: argparse.Namespace) -> int:
         }
     }
 
+    # Supervision diagnostics. Every fact below was derivable before this
+    # existed, and every one of them was derived by hand -- repeatedly, in one
+    # evening, by the person who had just written the harness -- from $TMUX, ps
+    # ancestry walks and greps of the supervisor registry. Two came out wrong.
+    try:
+        from macf.utils.supervision import diagnose
+        data["supervision"] = diagnose()
+    except Exception as e:
+        # Never let a diagnostic break the command it is reporting on.
+        data["supervision"] = {"error": f"{type(e).__name__}: {e}"}
+
     # Output format
     if getattr(args, 'json', False):
         # Convert tuple to dict for JSON serialization
@@ -404,6 +415,15 @@ def cmd_env(args: argparse.Namespace) -> int:
 
         print("Agent ID")
         print(f"  {data['identity']['agent_id']}")
+        print()
+
+        print("Supervision")
+        sup = data.get("supervision") or {}
+        if "error" in sup:
+            print(f"  (unavailable: {sup['error']})")
+        else:
+            from macf.utils.supervision import format_diagnosis
+            print(format_diagnosis(sup))
         print()
 
         print("Versions")
@@ -1458,12 +1478,20 @@ def cmd_harness_generate(args: argparse.Namespace) -> int:
         render_start,
         render_tmux_conf,
         render_unit,
+        render_watchdog,
     )
 
     try:
         p = _harness_params(args)
         attach = not getattr(args, "no_proxy", False)
         what = getattr(args, "what", "unit")
+        if what == "watchdog":
+            svc, tmr = render_watchdog(p)
+            print(f"# ===== cc-harness-{p.agent}-watch.service =====")
+            print(svc, end="")
+            print(f"\n# ===== cc-harness-{p.agent}-watch.timer =====")
+            print(tmr, end="")
+            return 0
         if what in ("unit", "all"):
             print(render_unit(p, attach_proxy=attach), end="")
         if what in ("start", "all"):
@@ -1518,6 +1546,12 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
             (Path(p.functions), render_launch_functions(p), False),
             (p.home / f".tmux-{p.agent}.conf", render_tmux_conf(p), False),
         ]
+        if getattr(args, "watchdog", False):
+            svc, tmr = render_watchdog(p)
+            targets += [
+                (unit_dir / f"cc-harness-{p.agent}-watch.service", svc, False),
+                (unit_dir / f"cc-harness-{p.agent}-watch.timer", tmr, False),
+            ]
 
         if getattr(args, "check", False):
             drift = 0
@@ -1561,6 +1595,49 @@ def cmd_harness_install(args: argparse.Namespace) -> int:
         return 0
     except Exception as e:
         print(f"Error installing harness: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_harness_attach(args: argparse.Namespace) -> int:
+    """Attach this terminal to the agent's supervised session.
+
+    Exists so that no remote shell has to hardcode a session name. A helper on
+    another machine held the OLD name after the session was renamed, and broke
+    with "no sessions" -- a fourth hand-maintained copy of harness knowledge, on
+    a host the generator cannot reach. `ssh host -t macf_tools harness attach`
+    resolves the name where the name is defined, so a rename cannot strand it.
+    """
+    from .utils.harness import resolve_agent
+    from .utils.identity import calling_card_from_identifier
+
+    try:
+        agent, source = resolve_agent(getattr(args, "agent", None))
+        if source == "ambiguous":
+            print("Several harnesses are installed here; name one with --agent:",
+                  file=sys.stderr)
+            for a in agent:
+                print(f"   {a}  ({calling_card_from_identifier(a)})", file=sys.stderr)
+            return 1
+
+        # "=" forces an exact match; tmux resolves targets by prefix, so a bare
+        # name would happily attach to "<agent>-stale-ssh".
+        target = f"={agent}"
+        if subprocess.run(["tmux", "has-session", "-t", target],
+                          capture_output=True).returncode != 0:
+            print(f"No tmux session '{agent}' on this host.", file=sys.stderr)
+            print(f"   start it:  {'maceff_' + agent.rpartition('_')[0].lower() + '_harness_launch'}",
+                  file=sys.stderr)
+            print(f"   or:        systemctl --user start cc-harness-{agent}.service",
+                  file=sys.stderr)
+            return 1
+
+        # -d evicts other clients: two clients of different geometries is the
+        # cause of the fragmented redraws. Read-only observers skip it.
+        cmd = ["tmux", "attach", "-t", target]
+        cmd.append("-r" if getattr(args, "read_only", False) else "-d")
+        os.execvp("tmux", cmd)
+    except Exception as e:
+        print(f"Error attaching to harness: {e}", file=sys.stderr)
         return 1
 
 
@@ -9145,7 +9222,7 @@ def _build_parser() -> argparse.ArgumentParser:
     harness_generate.add_argument("--shell-prefix", metavar="NAME",
                                  help="short handle for the generated shell functions (default: the moniker half of the Calling Card)")
     harness_generate.add_argument(
-        "--what", choices=["unit", "start", "child", "functions", "tmux", "all"], default="unit",
+        "--what", choices=["unit", "start", "child", "functions", "tmux", "watchdog", "all"], default="unit",
         help="which artifact to render (default: unit)")
     harness_generate.set_defaults(func=cmd_harness_generate)
 
@@ -9158,11 +9235,21 @@ def _build_parser() -> argparse.ArgumentParser:
                                  help="channel plugin the client must load; repeatable")
     harness_install.add_argument("--shell-prefix", metavar="NAME",
                                  help="short handle for the generated shell functions (default: the moniker half of the Calling Card)")
+    harness_install.add_argument("--watchdog", action="store_true",
+                                 help="also install a timer that restarts the session if the "
+                                      "tmux server dies (the supervisor dies with it)")
     harness_install.add_argument("--check", action="store_true",
                                  help="report drift against what would be rendered; write nothing")
     harness_install.add_argument("--force", action="store_true",
                                  help="overwrite an existing unit that differs")
     harness_install.set_defaults(func=cmd_harness_install)
+
+    harness_attach = harness_sub.add_parser(
+        "attach", help="attach this terminal to the agent's supervised session")
+    harness_attach.add_argument("--agent", help="agent slug (default: resolved from identity)")
+    harness_attach.add_argument("--read-only", action="store_true",
+                                help="observe without evicting other clients or taking the keyboard")
+    harness_attach.set_defaults(func=cmd_harness_attach)
 
     harness_status = harness_sub.add_parser("status", help="show harness unit and session state")
     harness_status.add_argument("--agent", help="agent slug")

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -275,6 +275,48 @@ def _tmux_wrap(tmux_session: str, cmd: list) -> list:
             _shell_command_string(cmd)]
 
 
+def _is_supervisor_process(pid: int) -> bool:
+    """Is this pid still a supervisor, or something that inherited the number?
+
+    Separate and module-level for the same reason ``_is_alive`` is: the process
+    table is not a thing a test should have to own. Both are the seam where
+    "what the registry says" meets "what is actually true".
+    """
+    try:
+        args = subprocess.run(["ps", "-o", "args=", "-p", str(pid)],
+                              capture_output=True, text=True, timeout=5).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "macf.supervisor" in args
+
+
+def is_live_supervisor(data: dict) -> bool:
+    """Does this registry entry describe a supervisor that is actually running?
+
+    Three conditions, and each excludes a state that has been observed on a
+    live host:
+
+    * ``status == "running"`` — entries persist after the process ends, so the
+      file existing proves nothing. Seven stale entries sat in one registry,
+      one of them still claiming a supervisor that had exited nine days earlier.
+    * the pid is alive — an entry can outlive its process by any amount.
+    * the pid is still a supervisor — pids are recycled, and an entry pointing
+      at whatever inherited the number is worse than no entry at all.
+
+    Deliberately NOT ``pgrep -f 'macf.supervisor --name X'``: when tmux starts a
+    server it keeps the command it was asked to run in its own argv, so that
+    matches the tmux server and reports a live supervisor for as long as the
+    server lives. The registry is keyed by the supervisor's own pid, which is
+    what makes the process check meaningful.
+    """
+    if data.get("status") != "running":
+        return False
+    pid = data.get("supervisor_pid", 0)
+    if not pid or not _is_alive(pid):
+        return False
+    return _is_supervisor_process(pid)
+
+
 def _find_supervisor(target: str) -> dict | None:
     """Find a RUNNING supervisor registry entry by supervisor PID or by name.
     On multiple name matches, returns the most recently created."""
@@ -288,9 +330,9 @@ def _find_supervisor(target: str) -> dict | None:
             data = json.loads(entry.read_text())
         except (json.JSONDecodeError, OSError):
             continue
-        sup_pid = data.get("supervisor_pid", 0)
-        if not _is_alive(sup_pid):
+        if not is_live_supervisor(data):
             continue
+        sup_pid = data.get("supervisor_pid", 0)
         if target == str(sup_pid) or target == data.get("name"):
             matches.append(data)
     if not matches:

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -500,6 +500,39 @@ def launch_in_terminal(cmd_args: list, name: str = "",
     return 0
 
 
+# Shell exit codes that mean the command was never launched. POSIX shells use
+# 127 for "not found" and 126 for "found but not executable". Neither describes
+# a process that ran and failed, so neither is a reason to try again.
+_NEVER_LAUNCHED_EXITS = (126, 127)
+
+# A child that exits this fast did not do any work. Pairing the exit code with
+# the lifetime matters: a long-running child is entitled to exit 127 as its own
+# considered result, and killing supervision for that would be wrong.
+_NEVER_LAUNCHED_WINDOW_SECONDS = 3
+
+
+def _unlaunchable_reason(cmd_args: list) -> "str | None":
+    """Why this command can never run, or None if it might.
+
+    Only a path is checked, and only when it is one: a bare word may be an
+    alias or a shell function, and the child is deliberately run through an
+    interactive shell so that those resolve. Refusing them here would break the
+    very indirection that invocation exists to support. An absolute or relative
+    PATH-bearing target, by contrast, is a claim about the filesystem that can
+    be checked cheaply and answered definitively.
+    """
+    if not cmd_args:
+        return "no command was given"
+    target = cmd_args[0]
+    if os.sep not in target:
+        return None
+    if not os.path.exists(target):
+        return f"{target} does not exist"
+    if not os.access(target, os.X_OK):
+        return f"{target} exists but is not executable"
+    return None
+
+
 def _send_post_start_keys(tmux_session: str, keys: str, delay: int) -> None:
     """Send `keys` to the child's tmux pane `delay` seconds after it spawns.
 
@@ -535,6 +568,24 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
     pid = os.getpid()
     created = time.time()
 
+    # Refuse to supervise a command that cannot ever run. Restarting is a
+    # response to a process that FAILED; a command that does not exist has not
+    # failed, it was never launchable, and no number of retries changes that.
+    #
+    # Measured before this existed: with the child binary removed, the loop
+    # reached three restarts in eight seconds, kept its registry entry marked
+    # "running", and surfaced nothing — the shell's "command not found" went to
+    # a pane that had already gone. An agent's harness silently spinning is
+    # indistinguishable, from every status surface, from one that is simply up.
+    problem = _unlaunchable_reason(cmd_args)
+    if problem:
+        print(f"[auto-restart] REFUSING TO START: {problem}", file=sys.stderr)
+        print("[auto-restart] This is not a transient failure and restarting "
+              "cannot fix it, so no supervisor is registered.", file=sys.stderr)
+        _notify_telegram(f"Name: {name}\n{problem}",
+                         prefix="\U0001f6d1 Supervisor Refused")
+        return 1
+
     # Export the pinned session id so the child (run via $SHELL -ic, which
     # inherits this environment) can pass it to `claude --session-id`.
     if session_id:
@@ -557,6 +608,8 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
     child = None
     restart_count = 0
     stop_requested = False  # Flag for Ctrl-C during countdown
+    # Mutable so the `finally` block can set it without a nonlocal dance.
+    _exit_status = [0]
 
     def handle_restart(signum, frame):
         nonlocal child
@@ -634,7 +687,9 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
                     daemon=True,
                 ).start()
 
+            spawned_at = time.time()
             exit_code = child.wait()
+            lifetime = time.time() - spawned_at
             child = None
             restart_count += 1
 
@@ -648,6 +703,27 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
             reg = _read_registry(pid)
             if reg.get("status") == "disabled":
                 print(f"[auto-restart] Disabled. Not restarting.")
+                break
+
+            # The pre-flight check cannot see through an alias, a shell
+            # function or a PATH lookup, so the same "never launched" case can
+            # still arrive here — as a shell exit code instead of a missing
+            # file. Stop, rather than spin: the shell has already decided this
+            # command does not resolve, and it will decide the same thing every
+            # five seconds forever.
+            if exit_code in _NEVER_LAUNCHED_EXITS and lifetime < _NEVER_LAUNCHED_WINDOW_SECONDS:
+                reason = ("not found" if exit_code == 127 else "not executable")
+                print(f"\n[auto-restart] FATAL: the shell reports the command is "
+                      f"{reason} (exit {exit_code}, after {lifetime:.1f}s).",
+                      file=sys.stderr)
+                print("[auto-restart] Not restarting — retrying cannot resolve a "
+                      "command that does not resolve.", file=sys.stderr)
+                _update_registry(pid, status="failed", last_exit_code=exit_code,
+                                 failure_reason=f"command {reason}")
+                _notify_telegram(
+                    f"Process: {name}\nCommand {reason} (exit {exit_code})\n"
+                    f"Supervision stopped after {restart_count} attempt(s).",
+                    prefix="\U0001f6d1 Supervisor Failed")
                 break
 
             # Install countdown SIGINT handler (interactive shell corrupts default handler)
@@ -685,13 +761,26 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
             child.send_signal(signal.SIGINT)
             child.wait()
     finally:
-        _update_registry(pid, status="stopped",
+        # "stopped" means someone asked it to stop. "failed" means it gave up.
+        # Overwriting the second with the first erases the only signal that
+        # distinguishes a clean shutdown from a supervisor that could not run
+        # what it was given — and that distinction is the entire point of
+        # recording a failure.
+        final_status = "stopped"
+        if _read_registry(pid).get("status") == "failed":
+            final_status = "failed"
+        _update_registry(pid, status=final_status,
                          stopped=time.time(),
                          total_restarts=restart_count)
+        # Carried out of `finally` so the caller — and therefore the service
+        # manager — sees a failure as a failure. A supervisor that gave up and
+        # exited 0 leaves the unit reporting active with nothing supervised.
+        _exit_status[0] = 1 if final_status == "failed" else 0
         _notify_telegram(
             f"Process: {name}\nRestarts: {restart_count}\nUptime: {_format_duration(time.time() - created)}",
             prefix="\U0001f6d1 Supervisor Stopped"
         )
+    return _exit_status[0]
 
 
 def list_processes(show_all: bool = False):
@@ -878,10 +967,14 @@ if __name__ == "__main__":
         args = parser.parse_args(supervisor_argv)
 
         if args.action == "_run_loop":
-            run_loop(cmd, name=args.name, restart_delay=args.delay,
-                     tmux_session=args.tmux_session, session_id=args.session_id,
-                     post_start_keys=args.post_start_keys,
-                     post_start_delay=args.post_start_delay)
+            # Propagate the return code. A supervisor that refuses to start and
+            # then exits 0 tells the service manager it succeeded, which is the
+            # same silent-success failure the refusal exists to end: systemd
+            # would mark the unit active with nothing supervising anything.
+            sys.exit(run_loop(cmd, name=args.name, restart_delay=args.delay,
+                              tmux_session=args.tmux_session, session_id=args.session_id,
+                              post_start_keys=args.post_start_keys,
+                              post_start_delay=args.post_start_delay) or 0)
 
     except Exception as e:
         # Top-level supervisor crash handler — bare Exception is intentional:

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -93,6 +93,19 @@ class HarnessParams:
         return self.functions_path or (self.home / ".maceff" / f"harness_functions_{self.agent}.bash")
 
     @property
+    def settings_path(self) -> Path:
+        """Where the install-time choices are remembered.
+
+        Channels and the shell prefix cannot be re-derived from the environment,
+        so without this a later ``install --check`` renders DIFFERENT artifacts
+        and reports drift that does not exist — and a ``--force`` reinstall run
+        on that false report would silently strip the channel, taking the agent
+        off the air with nothing to see. The generator can only be authoritative
+        about what it can reproduce.
+        """
+        return self.home / ".maceff" / f"harness_{self.agent}.json"
+
+    @property
     def prefix(self) -> str:
         """Short handle for the generated shell functions.
 
@@ -178,6 +191,34 @@ def resolve_agent(explicit: Optional[str] = None,
     if len(units) > 1:
         return units, "ambiguous"
     return "agent", "default"
+
+
+def load_settings(p: HarnessParams) -> HarnessParams:
+    """Re-apply the choices recorded at install time.
+
+    Explicit flags win; this only fills what was not given, so a check run with
+    no flags reproduces the installed artifacts instead of inventing new ones.
+    """
+    import json
+    from dataclasses import replace
+    try:
+        data = json.loads(p.settings_path.read_text())
+    except (OSError, ValueError):
+        return p
+    return replace(
+        p,
+        channels=p.channels or tuple(data.get("channels") or ()),
+        shell_prefix=p.shell_prefix or data.get("shell_prefix"),
+    )
+
+
+def save_settings(p: HarnessParams) -> None:
+    """Record what cannot be re-derived, so the generator stays authoritative."""
+    import json
+    p.settings_path.parent.mkdir(parents=True, exist_ok=True)
+    p.settings_path.write_text(json.dumps(
+        {"agent": p.agent, "channels": list(p.channels), "shell_prefix": p.shell_prefix},
+        indent=2) + "\n")
 
 
 def default_params(agent: Optional[str] = None, home: Optional[Path] = None) -> HarnessParams:

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -536,6 +536,12 @@ exec > >(tee -a "$LOG") 2>&1
 # succeed. Measured A/B on one conversation, same minute: without a prompt, exit
 # 1 every time; with one, the client came up.
 #
+# ARGUMENT ORDER IS LOAD-BEARING. `--channels` is VARIADIC: it keeps consuming
+# following words, so a prompt placed after it is parsed as another channel and
+# the client dies with "--channels entries must be tagged: <your prompt>". The
+# prompt therefore goes first and the variadic flag goes LAST, where the only
+# thing it can consume is its own values. Reproduced both ways before choosing.
+#
 # It also replaces a timing hack. The re-orientation used to be typed in by
 # send-keys ~30s after launch, which meant guessing when the client was ready
 # and defeating paste-detection with a double Enter. Passing it as the initial
@@ -547,7 +553,7 @@ else
   PROMPT="Session resumed by the harness. Summarize where things stand and await instructions."
 fi
 
-exec claude -c{channels} "$@" "$PROMPT"
+exec claude -c "$PROMPT" "$@"{channels}
 """
 
 

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -500,15 +500,19 @@ def render_child(p: HarnessParams) -> str:
 # session on relaunch and both are handled below.
 SESS="${{MACEFF_TMUX_SESSION:-{p.agent}}}"
 MACF={p.macf_tools}
-(
-  # 1. The client can park at the workspace-trust prompt. Enter is a no-op on an
-  #    empty input, so this is safe when no prompt is showing.
-  sleep 18; tmux send-keys -t "=$SESS" Enter 2>/dev/null
-  # The re-orientation prompt is no longer typed in here. It is passed to the
-  # client as its initial prompt below, which is both earlier and unconditional
-  # -- send-keys had to guess when the client was ready, and a resume that never
-  # started could not be rescued by typing into it.
-) &
+# NO BLIND KEYSTROKES ON LAUNCH. A timed `sleep 18; send-keys Enter` used to
+# live here to clear the workspace-trust prompt, justified as "Enter is a no-op
+# on an empty input". That justification only holds if the thing on screen is
+# the prompt we expect. The client's startup dialogs are not stable across
+# versions, and an unattended Enter does not accept a known prompt -- it accepts
+# WHATEVER is focused, including a resume dialog whose default is to summarize
+# rather than continue as-is. Silently discarding the session's own context is
+# not a recoverable mistake, and nothing would record that a choice was made.
+#
+# Operator directive: a menu that a human has not seen is a menu a machine must
+# not answer. First launch is the operator's to select. If a trust prompt blocks
+# an unattended restart, the fix is to grant trust beforehand -- state that
+# survives restarts -- not to guess at the keyboard.
 
 # Continuity is the DEFAULT. `-c` resumes the prior conversation; starting a new
 # one must be a deliberate act, because an unattended restart that silently
@@ -519,15 +523,31 @@ MACF={p.macf_tools}
 # line -- the session comes up, the terminal looks right, and the agent is
 # simply unreachable from outside. It has happened here: a resume that dropped
 # --channels took the inbound link down with nothing to see.
-# Tee, not redirect: the pane stays live for whoever is attached AND the output
-# survives the pane for whoever is not. `exec` keeps this process replaced by
-# the client, so the supervisor still waits on the client itself and not on a
-# wrapper -- a pipeline here would make the supervisor watch `tee` instead, and
-# a client that died would look alive.
+# LOG THE PANE FROM OUTSIDE THE CHILD. `tmux pipe-pane` copies what the pane
+# renders to a file without touching any of the client's descriptors, so the
+# client keeps the terminal tmux gave it.
+#
+# The previous form, `exec > >(tee -a "$LOG") 2>&1`, was a redirection, and it
+# replaced the client's stdout with a PIPE. That matters more than it looks:
+# a terminal is not a cosmetic property, it is what an interactive client
+# inspects to decide whether to BE interactive. Deprived of one it can render
+# a single turn and exit 0 -- whereupon the supervisor, behaving exactly as
+# designed, restarts it. The result is a restart loop in which no layer is
+# misbehaving and no error is logged anywhere, which is why it survived a
+# night of reading logs that all said things were fine.
+#
+# The diagnostic caused the fault it was added to diagnose. Measured, not
+# reasoned: in a tmux pane `[ -t 1 ]` is true, and after that exec it is false
+# (tests/test_harness_runtime.py).
+#
+# pipe-pane is also strictly better as logging: it captures what the pane
+# actually showed, including anything written straight to the terminal, which
+# a stdout redirect never sees. `-o` toggles off any prior pipe first so a
+# restart does not stack writers onto one file.
 LOG="{p.log_path}"
 mkdir -p "$(dirname "$LOG")"
 {{ echo; echo "=== $(date -Is) starting: claude -c{channels} ==="; }} >> "$LOG"
-exec > >(tee -a "$LOG") 2>&1
+tmux pipe-pane -o -t "=$SESS" "cat >> '$LOG'" 2>/dev/null || true
 
 # A RESUME MUST CARRY A PROMPT. `claude -c` with no prompt can refuse to resume
 # outright -- "No deferred tool marker found in the resumed session ... Provide a

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -547,7 +547,22 @@ MACF={p.macf_tools}
 LOG="{p.log_path}"
 mkdir -p "$(dirname "$LOG")"
 {{ echo; echo "=== $(date -Is) starting: claude -c{channels} ==="; }} >> "$LOG"
-tmux pipe-pane -o -t "=$SESS" "cat >> '$LOG'" 2>/dev/null || true
+# NO -t: pipe-pane takes a PANE target, and `=name` is exact-match syntax for a
+# SESSION. `pipe-pane -t "=$SESS"` therefore fails with "can't find pane" every
+# single time -- which the first version of this line hid behind
+# `2>/dev/null || true`, producing a log containing start markers and nothing
+# else. Run from inside the pane, pipe-pane defaults to $TMUX_PANE, which is
+# both correct and unambiguous: no name resolution, so no prefix-match hazard.
+#
+# The failure is reported INTO the log rather than swallowed. A diagnostic that
+# can fail silently is the thing being diagnosed here; if the pipe does not
+# attach, whoever reads this file later must learn that from the file.
+if [ -n "$TMUX_PANE" ]; then
+  tmux pipe-pane -o "cat >> '$LOG'" \
+    || echo "=== pipe-pane FAILED: pane output is NOT captured below ===" >> "$LOG"
+else
+  echo "=== not running inside tmux: pane output is NOT captured below ===" >> "$LOG"
+fi
 
 # A RESUME MUST CARRY A PROMPT. `claude -c` with no prompt can refuse to resume
 # outright -- "No deferred tool marker found in the resumed session ... Provide a

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -54,6 +54,22 @@ class HarnessParams:
     python: Path
     macf_tools: Path
     child_path: Path
+    start_path: Optional[Path] = None
+    functions_path: Optional[Path] = None
+    registry_dir: Optional[Path] = None
+    # Channel plugins the supervised client must load. Empty by default and
+    # never guessed: this is the agent's inbound link when nobody is at the
+    # terminal, and a render that silently dropped it would take the agent
+    # off the air in exactly the unattended case the harness exists to serve.
+    channels: tuple = ()
+    # What the operator TYPES. Deliberately separate from `agent`: the session
+    # and unit derive from the Calling Card so they are traceable to an
+    # identity, but nobody is going to type
+    # `maceff_TheHarborMaster_ee5cd8_harness_launch`. Traceability is a property
+    # the machine needs; brevity is a property the hand needs, and forcing one
+    # identifier to serve both is what produced the untraceable nickname this
+    # replaces.
+    shell_prefix: Optional[str] = None
     proxy_port: int = DEFAULT_PROXY_PORT
     context_window: int = DEFAULT_CONTEXT_WINDOW
     term: str = "xterm-256color"
@@ -62,6 +78,46 @@ class HarnessParams:
     @property
     def unit_name(self) -> str:
         return f"cc-harness-{self.agent}.service"
+
+    @property
+    def start(self) -> Path:
+        """Where the shared start script lives.
+
+        Defaulted rather than required so existing callers that build params by
+        hand keep working; the default sits beside the child wrapper.
+        """
+        return self.start_path or (self.child_path.parent / f"maceff_harness_start_{self.agent}")
+
+    @property
+    def functions(self) -> Path:
+        return self.functions_path or (self.home / ".maceff" / f"harness_functions_{self.agent}.bash")
+
+    @property
+    def prefix(self) -> str:
+        """Short handle for the generated shell functions.
+
+        Defaults to the moniker half of the Calling Card, lowercased — the part
+        a human already says out loud when naming the agent.
+        """
+        if self.shell_prefix:
+            return self.shell_prefix
+        head, sep, _tail = self.agent.rpartition("_")
+        return (head if sep else self.agent).lower()
+
+    @property
+    def registry(self) -> Path:
+        """Where the supervisor writes its per-process registry.
+
+        Taken from the supervisor rather than restated, because it has already
+        moved once: a shared ``/tmp/macf/auto-restart`` is owned by whichever uid
+        creates it first, so it became per-user. Any copy of the old literal
+        still silently matches nothing — which is not a crash but a stop that
+        stops nothing, and an "is it running" check that always answers no.
+        """
+        if self.registry_dir is not None:
+            return self.registry_dir
+        from ..supervisor import REGISTRY_DIR
+        return REGISTRY_DIR
 
     @property
     def env_path(self) -> str:
@@ -73,6 +129,57 @@ class HarnessParams:
         return ":".join(parts)
 
 
+def installed_agents(unit_dir: Optional[Path] = None) -> list:
+    """Agent slugs that actually have a harness unit installed here."""
+    unit_dir = unit_dir or (Path.home() / ".config" / "systemd" / "user")
+    if not unit_dir.is_dir():
+        return []
+    return sorted(
+        f.name[len("cc-harness-"):-len(".service")]
+        for f in unit_dir.glob("cc-harness-*.service")
+    )
+
+
+def resolve_agent(explicit: Optional[str] = None,
+                  unit_dir: Optional[Path] = None) -> "tuple":
+    """Resolve which agent this harness command is about, and say how.
+
+    Returns ``(agent, source)``. The source is not decoration — it is the whole
+    point. ``harness status`` used to default the agent to the literal string
+    ``agent`` and then print ``unit: ... (ABSENT)`` while a healthy harness ran
+    under another name. Nothing in that output was false, and it still read as
+    "there is no harness here", because **the output never said the name was a
+    guess**. A reader cannot discount a default they cannot see.
+
+    Order: explicit flag, then the environment override, then the agent's own
+    Calling Card, then the single installed unit if there is exactly one. When
+    several are installed the caller is expected to list them rather than pick;
+    ``source == "ambiguous"`` says so, and the candidates come back in place of
+    a name.
+    """
+    if explicit:
+        return explicit, "flag"
+    env = os.environ.get("MACEFF_AGENT_NAME")
+    if env:
+        return env, "MACEFF_AGENT_NAME"
+    try:
+        from .identity import get_agent_identity, session_identifier
+        card = get_agent_identity()
+        # 'unknown' is what identity returns when no UUID resolves; deriving a
+        # session name from it would manufacture an identifier for an agent
+        # whose identity is precisely what could not be established.
+        if card and not card.endswith("@unknown"):
+            return session_identifier(card), "calling card"
+    except Exception:
+        pass
+    units = installed_agents(unit_dir)
+    if len(units) == 1:
+        return units[0], "the only installed unit"
+    if len(units) > 1:
+        return units, "ambiguous"
+    return "agent", "default"
+
+
 def default_params(agent: Optional[str] = None, home: Optional[Path] = None) -> HarnessParams:
     """Derive parameters from the running environment.
 
@@ -82,7 +189,11 @@ def default_params(agent: Optional[str] = None, home: Optional[Path] = None) -> 
     boot path ended up without the module.
     """
     home = Path(home) if home else Path(os.environ.get("MACEFF_AGENT_HOME_DIR") or Path.home())
-    agent = agent or os.environ.get("MACEFF_AGENT_NAME") or "agent"
+    resolved, _source = resolve_agent(agent)
+    # An ambiguous resolution is a list of candidates; rendering for "the first
+    # one" would silently pick an agent. Callers that can ask are expected to
+    # use resolve_agent() directly and surface the choice.
+    agent = resolved if isinstance(resolved, str) else "agent"
     # Prefer the unversioned python3 beside the running interpreter. sys.executable
     # is often versioned (python3.10), and baking that into a unit pins the harness
     # to a specific minor release — an interpreter upgrade would leave a unit
@@ -99,56 +210,169 @@ def default_params(agent: Optional[str] = None, home: Optional[Path] = None) -> 
         python=python,
         macf_tools=macf_tools,
         child_path=home / ".local" / "bin" / f"maceff_cc_child_{agent}",
+        start_path=home / ".local" / "bin" / f"maceff_harness_start_{agent}",
+        functions_path=home / ".maceff" / f"harness_functions_{agent}.bash",
         path_prepend=(str(python.parent), str(home / ".local" / "bin")),
     )
 
 
-def render_unit(p: HarnessParams, attach_proxy: bool = True) -> str:
-    """Render the systemd user unit.
+def render_start(p: HarnessParams, attach_proxy: bool = True) -> str:
+    """Render the one script that decides whether to create the session.
 
-    Four properties of this text are load-bearing and each has a test:
+    This exists because the decision had three implementations — the unit, an
+    operator shell function, and a stored artifact — which is not a style
+    complaint. They disagreed, and the disagreement was silent: the shell
+    function set ``ANTHROPIC_BASE_URL`` without the first-party flag, so a
+    harness launched from the terminal ran on a 200K window while every surface
+    reported 1M. One implementation cannot disagree with itself, so systemd and
+    the shell now call this same script.
 
-    1. ``$${BASE}`` is escaped. systemd expands ``$VAR``/``${VAR}`` in ``Exec*``
-       using the UNIT's environment before any shell runs. ``BASE`` is not a unit
-       variable, so an unescaped ``${BASE}`` was substituted with an empty string
-       and the shell's own assignment never mattered — the proxy opt-in was
-       silently inert, with only "Referenced but unset environment variable" in
-       the journal.
-    2. The first-party flag is emitted in the SAME assignment as the base URL.
-       Their separation is what let the context-window defect survive for months.
-    3. Proxy attachment is probed and degrades to direct. A dead proxy must
-       degrade to a direct agent, never to a dead one.
-    4. ``StartLimit*`` directives, when emitted, go in ``[Unit]``. systemd honours
-       them nowhere else, so in ``[Service]`` they read as configured and do
-       nothing.
+    The other half of the script is the identity guard. Establishing that the
+    harness is already up is harder than it looks, and the two obvious checks
+    are both wrong in ways observed on a live host:
+
+    * ``tmux has-session -t <agent>`` matches a NAME. On 2026-07-29 an unrelated
+      ssh login owned the name, the guard matched, and the harness silently
+      never started — there was no error to see, because a session did exist.
+    * ``pgrep -f 'macf.supervisor ... --name <agent>'`` matches the TMUX SERVER.
+      When tmux starts a server it keeps the command it was asked to run in its
+      own argv, so this reports a live supervisor for as long as the server
+      lives — nine days after the supervisor exited, when measured on
+      2026-08-07.
+
+    So identity is taken from the supervisor's own registry, which is keyed by
+    the supervisor's pid, and then confirmed against the process table: an entry
+    can outlive its process, and a pid can be recycled.
+
+    Every ``-t`` target is written ``=<name>``, which forces tmux to match the
+    session name EXACTLY. Without it tmux resolves a target by prefix, so
+    ``-t thm`` matches a session called ``thm-stale-ssh`` — and "rename it out of
+    the way" is exactly the remedy an operator reaches for, so the workaround for
+    a name collision silently failed to resolve the collision. Measured on tmux
+    3.6, 2026-08-07: the harness still reported its session "up" nine days after
+    the only session by that prefix had been renamed and handed to an ssh login.
     """
     proxy_url = f"http://localhost:{p.proxy_port}"
     probe_url = f"http://127.0.0.1:{p.proxy_port}/"
 
     if attach_proxy:
-        # INVARIANT 2: base URL and first-party flag in one assignment. Never
-        # split these — the flag is what keeps the long-context window, and a
-        # base URL without it silently drops the client to the 200K fallback
-        # while every UI surface continues to display the full window.
-        base_branch = (
-            f'BASE=""; '
-            f'if curl -s --max-time {PROXY_PROBE_TIMEOUT} -o /dev/null {probe_url}; then '
-            f'BASE="ANTHROPIC_BASE_URL={proxy_url} _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 "; '
-            f'fi; '
-        )
+        # INVARIANT: the base URL and the first-party flag are ONE assignment.
+        # Splitting them is what cost months of unexplained early compaction —
+        # a base URL whose host is not api.anthropic.com makes the client stop
+        # extending the long-context window and fall back to 200K, silently,
+        # while every UI surface keeps displaying the full window.
+        probe = f"""if curl -s --max-time {PROXY_PROBE_TIMEOUT} -o /dev/null {probe_url}; then
+  BASE="ANTHROPIC_BASE_URL={proxy_url} _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 "
+fi"""
+    else:
+        probe = "# proxy attachment not configured for this agent"
+
+    return f"""#!/bin/bash
+# MacEff harness start — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent} --what start
+#
+# The single implementation of "create the session unless it is already ours".
+# systemd's ExecStart and the operator's shell function both call this, because
+# when they each had their own copy the copies drifted and the drift was silent.
+#
+# Exit codes: 0 created or already running; 3 the session NAME is held by
+# something that is not this harness (a decision for a human, not for a script).
+set -u
+
+AGENT={p.agent}
+SESSION="$AGENT"
+
+# --- identity -------------------------------------------------------------
+# Which pid, if any, is a LIVE supervisor for this agent. Read the module
+# docstring before replacing this with something shorter; the two shorter
+# checks are both known to report a harness that is not there.
+harness_supervisor_pid() {{
+  local f pid
+  for f in {p.registry}/*.json; do
+    [ -e "$f" ] || continue
+    grep -q "\\"name\\": \\"$AGENT\\"" "$f" || continue
+    grep -q '"status": "running"' "$f" || continue
+    pid=${{f##*/}}; pid=${{pid%.json}}
+    # The registry entry outlives the process it describes, so liveness is
+    # confirmed here rather than assumed from the file existing...
+    kill -0 "$pid" 2>/dev/null || continue
+    # ...and the pid may have been recycled by something unrelated, so the
+    # process is confirmed to still BE a supervisor.
+    ps -o args= -p "$pid" 2>/dev/null | grep -q 'macf\\.supervisor' || continue
+    printf '%s\\n' "$pid"
+    return 0
+  done
+  return 1
+}}
+
+if pid=$(harness_supervisor_pid); then
+  if tmux has-session -t "=$SESSION" 2>/dev/null; then
+    echo "[harness] already running (supervisor $pid, session $SESSION)"
+    exit 0
+  fi
+  # A live supervisor with no session is not a state to start over; starting a
+  # second one would give this agent two clients writing one task store.
+  echo "[harness] supervisor $pid is running but session '$SESSION' is gone." >&2
+  echo "[harness] stop it first: {p.macf_tools} auto-restart disable $pid" >&2
+  exit 3
+fi
+
+if tmux has-session -t "=$SESSION" 2>/dev/null; then
+  # The 2026-07-29 failure, now said out loud instead of silently attached to.
+  echo "[harness] ERROR: a tmux session named '$SESSION' exists but hosts no" >&2
+  echo "[harness] macf supervisor, so it is not this harness. Launch has NOT" >&2
+  echo "[harness] started anything -- the previous behaviour was to attach to" >&2
+  echo "[harness] whatever held the name, which is how the harness once stayed" >&2
+  echo "[harness] down for days without an error." >&2
+  echo "[harness]   inspect:      tmux attach -t =$SESSION" >&2
+  echo "[harness]   move aside:   tmux rename-session -t =$SESSION $SESSION-stale" >&2
+  exit 3
+fi
+
+# --- start ----------------------------------------------------------------
+BASE=""
+# Probed, never assumed: a dead proxy must degrade to a direct agent rather
+# than to no agent at all.
+{probe}
+
+# Everything the session needs is stated HERE. The launching shell's exported
+# environment does not reach a command started with `tmux new-session` — the
+# command runs under the tmux SERVER, which may have been created days earlier
+# by an unrelated login (verified 2026-08-07: an exported probe variable did
+# not arrive, and the server in question predated the shell by nine days).
+tmux new-session -d -s "$SESSION" \\
+  "MACF_CONTEXT_WINDOW={p.context_window} TERM={p.term} $BASE{p.python} -m macf.supervisor _run_loop --name $AGENT --delay 5 --tmux-session $SESSION -- {p.child_path}"
+echo "[harness] started session '$SESSION'"
+"""
+
+
+def render_unit(p: HarnessParams, attach_proxy: bool = True) -> str:
+    """Render the systemd user unit.
+
+    ``ExecStart`` delegates to the rendered start script rather than carrying
+    its own copy of the launch logic. That is not tidiness: the unit and the
+    operator's shell function each used to carry a copy, they drifted, and the
+    drift was a silently degraded context window. It also removes a whole class
+    of systemd escaping hazard from this file — an earlier ``ExecStart`` had to
+    write ``$${BASE}`` because systemd expands ``$VAR`` in ``Exec*`` from the
+    UNIT's environment before any shell runs, and the one time it was written
+    unescaped the proxy opt-in became inert with nothing but "Referenced but
+    unset environment variable" in the journal.
+
+    Two properties of what remains are load-bearing and each has a test:
+
+    1. ``ExecStart`` invokes the start script, so there is exactly one
+       implementation of the decision to create a session.
+    2. ``StartLimit*`` directives, when emitted, go in ``[Unit]``. systemd
+       honours them nowhere else, so in ``[Service]`` they read as configured
+       and do nothing at all.
+    """
+    if attach_proxy:
         wants = "\nAfter=network-online.target macf-proxy.service\nWants=network-online.target macf-proxy.service"
     else:
-        base_branch = 'BASE=""; '
         wants = "\nAfter=network-online.target\nWants=network-online.target"
 
-    # INVARIANT 1: $${BASE} — a literal ${BASE} must reach bash.
-    exec_start = (
-        f"ExecStart=/bin/bash -c '{base_branch}"
-        f'tmux has-session -t {p.agent} 2>/dev/null || '
-        f'tmux new-session -d -s {p.agent} '
-        f'"$${{BASE}}{p.python} -m macf.supervisor _run_loop '
-        f'--name {p.agent} --delay 5 --tmux-session {p.agent} -- {p.child_path}"\''
-    )
+    exec_start = f"ExecStart={p.start}"
 
     return f"""# MacEff persistent Claude Code harness — generated, do not hand-edit.
 # Regenerate with: macf_tools harness generate --agent {p.agent}
@@ -175,17 +399,20 @@ Environment=MACF_CONTEXT_WINDOW={p.context_window}
 Environment=PATH={p.env_path}
 Environment=TERM={p.term}
 
-# Idempotent: creates the detached session only when absent, so re-running is safe.
+# Idempotent, and safe to re-run: the start script establishes whether THIS
+# harness is already up before creating anything. Re-running is exactly when a
+# name-only check goes wrong, because that is when someone else may hold the
+# name — so the check lives in one script both entry points share.
 {exec_start}
 
 # The client re-asks its workspace-trust prompt when launched under the
 # supervisor. At boot nobody is attached to answer, so nudge Enter twice.
 # Harmless when no prompt is showing.
-ExecStartPost=/bin/bash -c 'sleep 20; tmux send-keys -t {p.agent} Enter 2>/dev/null; sleep 8; tmux send-keys -t {p.agent} Enter 2>/dev/null; true'
+ExecStartPost=/bin/bash -c 'sleep 20; tmux send-keys -t ={p.agent} Enter 2>/dev/null; sleep 8; tmux send-keys -t ={p.agent} Enter 2>/dev/null; true'
 
 # Stop the SUPERVISOR, not the child. Killing the child just makes the
 # supervisor restart it, so a stop that targets the child is not a stop.
-ExecStop=/bin/bash -c 'for f in /tmp/macf/auto-restart/*.json; do grep -q "{p.agent}" "$f" 2>/dev/null && grep -q "running" "$f" 2>/dev/null && {p.macf_tools} auto-restart disable "$(basename "$f" .json)"; done; true'
+ExecStop=/bin/bash -c 'for f in {p.registry}/*.json; do grep -q "{p.agent}" "$f" 2>/dev/null && grep -q "running" "$f" 2>/dev/null && {p.macf_tools} auto-restart disable "$(basename "$f" .json)"; done; true'
 
 [Install]
 WantedBy=default.target
@@ -200,6 +427,7 @@ def render_child(p: HarnessParams) -> str:
     SessionStart returning the turn to a user who is not there. Both are nudged
     here rather than left to whoever notices the agent has gone quiet.
     """
+    channels = f" --channels {','.join(p.channels)}" if p.channels else ""
     return f"""#!/bin/bash
 # MacEff harness child wrapper — generated, do not hand-edit.
 # Regenerate with: macf_tools harness generate --agent {p.agent}
@@ -211,17 +439,17 @@ MACF={p.macf_tools}
 (
   # 1. The client can park at the workspace-trust prompt. Enter is a no-op on an
   #    empty input, so this is safe when no prompt is showing.
-  sleep 18; tmux send-keys -t "$SESS" Enter 2>/dev/null
+  sleep 18; tmux send-keys -t "=$SESS" Enter 2>/dev/null
   sleep 12
   # 2. SessionStart:resume hands the turn back to the user. With nobody attached
   #    an autonomous session would idle at the prompt forever, so if persistent
   #    AUTO_MODE is active, type a re-orientation prompt and submit it.
   if "$MACF" mode get 2>/dev/null | grep -q AUTO_MODE; then
-    tmux send-keys -t "$SESS" "AUTO_MODE RESUME: session restarted (SessionStart:resume returned the turn with nobody attached). Re-orient via the task tree and continue authorized scoped work." 2>/dev/null
+    tmux send-keys -t "=$SESS" "AUTO_MODE RESUME: session restarted (SessionStart:resume returned the turn with nobody attached). Re-orient via the task tree and continue authorized scoped work." 2>/dev/null
     # Paste-detection debounces an Enter that follows a fast text burst: settle,
     # then Enter twice. The second is a no-op if the first already submitted.
-    sleep 3; tmux send-keys -t "$SESS" Enter 2>/dev/null
-    sleep 2; tmux send-keys -t "$SESS" Enter 2>/dev/null
+    sleep 3; tmux send-keys -t "=$SESS" Enter 2>/dev/null
+    sleep 2; tmux send-keys -t "=$SESS" Enter 2>/dev/null
   fi
 ) &
 
@@ -229,7 +457,130 @@ MACF={p.macf_tools}
 # one must be a deliberate act, because an unattended restart that silently
 # began a fresh session would discard the agent's working context with nothing
 # to show that it had happened.
-exec claude -c "$@"
+#
+# Channels are part of that continuity. Losing them costs no error and no log
+# line -- the session comes up, the terminal looks right, and the agent is
+# simply unreachable from outside. It has happened here: a resume that dropped
+# --channels took the inbound link down with nothing to see.
+exec claude -c{channels} "$@"
+"""
+
+
+def render_launch_functions(p: HarnessParams) -> str:
+    """Render the operator's shell entry points to the harness.
+
+    These were the last hand-maintained copy of the harness. The unit and the
+    child wrapper were moved into this generator precisely because a stored copy
+    had drifted from the live one; the shell functions were left behind, drifted
+    the same way, and drifted worse — a terminal launch set the proxy base URL
+    without the first-party flag, so the operator's own session ran on a fifth of
+    the context window it reported.
+
+    Nothing here re-implements starting: ``launch`` calls the start script and
+    then attaches. The functions exist for what a systemd unit cannot do, which
+    is put a human at a terminal in front of the session.
+    """
+    a = p.agent          # session / unit / supervisor identity
+    n = p.prefix         # what the operator types
+    return f"""# MacEff harness shell functions — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {a} --what functions
+# Source this from your shell profile:  . {p.functions}
+#
+# These are entry points, not a second implementation. Creating the session is
+# {p.start}, which systemd calls too, so a terminal
+# launch and a boot launch cannot disagree about what they started.
+
+# Terminal-window title: which agent am I attached to, and how did I get here.
+__maceff_title()   {{ printf '\\033]0;%s\\007' "$1"; }}
+__maceff_untitle() {{ printf '\\033]0;%s\\007' "${{USER}}@${{HOSTNAME}}: ${{PWD/#$HOME/\\~}}"; }}
+
+# The supervisor registry is the source of truth for "is it up". Same reasoning
+# as the start script: a session name proves nothing, and pgrep on the
+# supervisor's command line matches the tmux server that merely carries it.
+__maceff_{n}_supervisor_pid() {{
+  local f pid
+  for f in {p.registry}/*.json; do
+    [ -e "$f" ] || continue
+    grep -q '"name": "{a}"' "$f" || continue
+    grep -q '"status": "running"' "$f" || continue
+    pid=${{f##*/}}; pid=${{pid%.json}}
+    kill -0 "$pid" 2>/dev/null || continue
+    ps -o args= -p "$pid" 2>/dev/null | grep -q 'macf\\.supervisor' || continue
+    printf '%s\\n' "$pid"; return 0
+  done
+  return 1
+}}
+
+# Create the session if needed, then put this terminal in front of it.
+maceff_{n}_harness_launch() {{
+  {p.start} || return $?
+  __maceff_title "{a} via tmux on $(hostname)"
+  # -d evicts other clients. Two clients of different geometries was the root
+  # cause of the fragmented redraws; single-client is the discipline.
+  tmux attach -d -t ={a}
+  __maceff_untitle
+}}
+
+# Attach without creating: for joining a session that should already be up.
+__maceff_{n}_attach() {{
+  local flags="$1"
+  tmux has-session -t ={a} 2>/dev/null || {{
+    echo "no {a} session — use maceff_{n}_harness_launch" >&2; return 1
+  }}
+  __maceff_title "{a} via tmux on $(hostname)${{flags:+ [read-only]}}"
+  tmux attach -t ={a} ${{flags:--d}}
+  __maceff_untitle
+}}
+maceff_{n}_harness_attach() {{ __maceff_{n}_attach ""; }}
+maceff_{n}_harness_watch()  {{ __maceff_{n}_attach "-r"; }}
+
+# Clean stop from any login, including over ssh. Never bare-kill the tmux
+# server: that leaves the supervisor to restart a client into nothing.
+maceff_{n}_harness_stop() {{
+  local pid
+  pid=$(__maceff_{n}_supervisor_pid) || {{ echo "no running {a} supervisor found"; return 1; }}
+  {p.macf_tools} auto-restart disable "$pid" && echo "harness {a} (supervisor $pid) disabled"
+}}
+
+# Reclaim from a remote client: evict, attach, and trigger one restart so the
+# client re-measures THIS terminal. Without the restart it keeps the geometry of
+# the terminal that attached first, which is the "untrimmed input box" symptom.
+# The conversation survives, because the child wrapper resumes with -c.
+maceff_{n}_harness_reclaim() {{
+  local pid
+  tmux has-session -t ={a} 2>/dev/null || {{
+    echo "no {a} session — use maceff_{n}_harness_launch" >&2; return 1
+  }}
+  if pid=$(__maceff_{n}_supervisor_pid); then
+    echo "[harness] reclaiming: evicting clients, re-measuring geometry (supervisor $pid)"
+    ( setsid nohup bash -c "sleep 6; {p.macf_tools} auto-restart restart $pid" >/dev/null 2>&1 & )
+  else
+    echo "[harness] warning: no running supervisor; attaching without a restart" >&2
+  fi
+  __maceff_title "{a} via tmux on $(hostname) [reclaimed]"
+  tmux attach -d -t ={a}
+  __maceff_untitle
+}}
+
+# Status reports what IS, from the same sources the start script decides on, so
+# it cannot claim a harness the launcher would refuse to reuse.
+maceff_{n}_harness_status() {{
+  local pid
+  if pid=$(__maceff_{n}_supervisor_pid); then
+    echo "supervisor: running (pid $pid)"
+  else
+    echo "supervisor: not running"
+  fi
+  if tmux has-session -t ={a} 2>/dev/null; then
+    echo "session:    present (tmux -t {a})"
+    # Say whose it is. A present session that is NOT ours is the failure this
+    # whole family exists to stop being invisible.
+    [ -n "${{pid:-}}" ] || echo "            ^ holds the name but is NOT this harness"
+  else
+    echo "session:    absent"
+  fi
+  {p.macf_tools} harness status --agent {a} 2>/dev/null
+}}
 """
 
 

--- a/macf/src/macf/utils/harness.py
+++ b/macf/src/macf/utils/harness.py
@@ -118,6 +118,16 @@ class HarnessParams:
         return (head if sep else self.agent).lower()
 
     @property
+    def log_path(self) -> Path:
+        """Where the child's own output is kept.
+
+        The pane is not a log. It scrolls, it dies with the session, and it is
+        unreadable from a phone. Three launch failures in one evening printed
+        their explanation into a pane that vanished before anyone could read it.
+        """
+        return self.home / ".maceff" / f"harness_{self.agent}.log"
+
+    @property
     def registry(self) -> Path:
         """Where the supervisor writes its per-process registry.
 
@@ -147,9 +157,14 @@ def installed_agents(unit_dir: Optional[Path] = None) -> list:
     unit_dir = unit_dir or (Path.home() / ".config" / "systemd" / "user")
     if not unit_dir.is_dir():
         return []
+    # The watchdog unit shares the prefix but is not an agent. Without this it
+    # would enumerate as an agent literally named "<agent>-watch", which then
+    # makes resolution "ambiguous" and stops every harness command that resolves
+    # by enumeration -- an installed helper breaking the thing it helps.
     return sorted(
         f.name[len("cc-harness-"):-len(".service")]
         for f in unit_dir.glob("cc-harness-*.service")
+        if not f.name.endswith("-watch.service")
     )
 
 
@@ -381,9 +396,17 @@ BASE=""
 # command runs under the tmux SERVER, which may have been created days earlier
 # by an unrelated login (verified 2026-08-07: an exported probe variable did
 # not arrive, and the server in question predated the shell by nine days).
-tmux new-session -d -s "$SESSION" \\
-  "MACF_CONTEXT_WINDOW={p.context_window} TERM={p.term} $BASE{p.python} -m macf.supervisor _run_loop --name $AGENT --delay 5 --tmux-session $SESSION -- {p.child_path}"
+tmux new-session -d -s "$SESSION" "MACF_CONTEXT_WINDOW={p.context_window} TERM={p.term} $BASE{p.python} -m macf.supervisor _run_loop --name $AGENT --delay 5 --tmux-session $SESSION -- {p.child_path}" \\; set-option -t "=$SESSION" remain-on-exit on
+# ^ remain-on-exit is chained into the SAME tmux invocation, not run after it.
+# Without this a pane whose command dies immediately can take the session with
+# it before a second `tmux` process gets to set the option -- so the one case
+# the option exists for, a launch that fails instantly, is the case it would
+# most often miss. Keeping a dead pane readable is why this is here at all: the
+# same failure showed up three times in one evening as nothing but "[exited]"
+# and a shell prompt, the explanation printed and discarded each time.
+
 echo "[harness] started session '$SESSION'"
+echo "[harness] child log: {p.log_path}"
 """
 
 
@@ -481,17 +504,10 @@ MACF={p.macf_tools}
   # 1. The client can park at the workspace-trust prompt. Enter is a no-op on an
   #    empty input, so this is safe when no prompt is showing.
   sleep 18; tmux send-keys -t "=$SESS" Enter 2>/dev/null
-  sleep 12
-  # 2. SessionStart:resume hands the turn back to the user. With nobody attached
-  #    an autonomous session would idle at the prompt forever, so if persistent
-  #    AUTO_MODE is active, type a re-orientation prompt and submit it.
-  if "$MACF" mode get 2>/dev/null | grep -q AUTO_MODE; then
-    tmux send-keys -t "=$SESS" "AUTO_MODE RESUME: session restarted (SessionStart:resume returned the turn with nobody attached). Re-orient via the task tree and continue authorized scoped work." 2>/dev/null
-    # Paste-detection debounces an Enter that follows a fast text burst: settle,
-    # then Enter twice. The second is a no-op if the first already submitted.
-    sleep 3; tmux send-keys -t "=$SESS" Enter 2>/dev/null
-    sleep 2; tmux send-keys -t "=$SESS" Enter 2>/dev/null
-  fi
+  # The re-orientation prompt is no longer typed in here. It is passed to the
+  # client as its initial prompt below, which is both earlier and unconditional
+  # -- send-keys had to guess when the client was ready, and a resume that never
+  # started could not be rescued by typing into it.
 ) &
 
 # Continuity is the DEFAULT. `-c` resumes the prior conversation; starting a new
@@ -503,8 +519,96 @@ MACF={p.macf_tools}
 # line -- the session comes up, the terminal looks right, and the agent is
 # simply unreachable from outside. It has happened here: a resume that dropped
 # --channels took the inbound link down with nothing to see.
-exec claude -c{channels} "$@"
+# Tee, not redirect: the pane stays live for whoever is attached AND the output
+# survives the pane for whoever is not. `exec` keeps this process replaced by
+# the client, so the supervisor still waits on the client itself and not on a
+# wrapper -- a pipeline here would make the supervisor watch `tee` instead, and
+# a client that died would look alive.
+LOG="{p.log_path}"
+mkdir -p "$(dirname "$LOG")"
+{{ echo; echo "=== $(date -Is) starting: claude -c{channels} ==="; }} >> "$LOG"
+exec > >(tee -a "$LOG") 2>&1
+
+# A RESUME MUST CARRY A PROMPT. `claude -c` with no prompt can refuse to resume
+# outright -- "No deferred tool marker found in the resumed session ... Provide a
+# prompt to continue the conversation" -- and then exit 1. The supervisor does
+# exactly what it should with that: it retries, forever, a command that cannot
+# succeed. Measured A/B on one conversation, same minute: without a prompt, exit
+# 1 every time; with one, the client came up.
+#
+# It also replaces a timing hack. The re-orientation used to be typed in by
+# send-keys ~30s after launch, which meant guessing when the client was ready
+# and defeating paste-detection with a double Enter. Passing it as the initial
+# prompt is not a workaround for that -- it is the thing send-keys was
+# approximating, done at the only moment that cannot race.
+if "$MACF" mode get 2>/dev/null | grep -q AUTO_MODE; then
+  PROMPT="AUTO_MODE RESUME: this session restarted. Re-orient via the task tree and continue authorized scoped work."
+else
+  PROMPT="Session resumed by the harness. Summarize where things stand and await instructions."
+fi
+
+exec claude -c{channels} "$@" "$PROMPT"
 """
+
+
+def render_watchdog(p: HarnessParams) -> tuple:
+    """Render a periodic health check that resurrects a dead session.
+
+    The harness has a single point of failure that is easy to miss because the
+    diagram hides it: **the supervisor is a child of the tmux server.** It
+    restarts the client in place, which is what it is for, but if the tmux
+    server itself dies the supervisor dies with it — and the main unit is
+    ``oneshot`` with ``RemainAfterExit=yes``, so systemd neither notices nor
+    acts. Supervision nested inside the thing whose death it should survive
+    survives nothing. Observed: the session went away, two registry entries were
+    left still claiming "running" because the cleanup never ran, and the harness
+    stayed down until a human typed the launcher.
+
+    The repair is cheap because the start script is already idempotent and
+    already refuses to touch a name it does not own: run it on a timer. When the
+    harness is healthy this costs one registry read and one ``has-session``;
+    when it is gone, it comes back without anyone noticing it left.
+
+    Returned as (service, timer) and installed only on request — a machine that
+    resurrects an agent unattended is a decision for the operator, not a default.
+    """
+    service = f"""# MacEff harness watchdog — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent} --what watchdog
+#
+# Runs the SAME idempotent start script the boot unit runs. It exits 0 when the
+# harness is already up and refuses (3) when the session name is held by
+# something else, so a timer cannot start a second client or steal a name.
+[Unit]
+Description=Ensure the {p.agent} harness session exists
+After=cc-harness-{p.agent}.service
+
+[Service]
+Type=oneshot
+WorkingDirectory={p.home}
+Environment=PATH={p.env_path}
+ExecStart={p.start}
+# 3 means "a session by this name exists and is not ours" — a state a human
+# must resolve. Reporting it as failure is correct; retrying would not help.
+SuccessExitStatus=0
+"""
+    timer = f"""# MacEff harness watchdog timer — generated, do not hand-edit.
+# Regenerate with: macf_tools harness generate --agent {p.agent} --what watchdog
+[Unit]
+Description=Periodically ensure the {p.agent} harness session exists
+
+[Timer]
+# First check shortly after boot, then steadily. A minute is well under the
+# time it takes anyone to notice an agent has gone quiet, and the check is
+# cheap enough that frequency is not the cost.
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Unit=cc-harness-{p.agent}-watch.service
+
+[Install]
+WantedBy=timers.target
+"""
+    return service, timer
 
 
 def render_launch_functions(p: HarnessParams) -> str:

--- a/macf/src/macf/utils/identity.py
+++ b/macf/src/macf/utils/identity.py
@@ -83,6 +83,86 @@ def get_agent_identity() -> str:
     return f"{display_name}@{uuid_prefix}"
 
 
+# Characters that cannot survive a round trip through the session and service
+# managers, established by measurement on 2026-08-07 (tmux 3.6, systemd 257)
+# rather than from documentation:
+#
+#   tmux     '.' and ':' are accepted by ``new-session`` and then SILENTLY
+#            rewritten to '_'. The session is created, the command reports
+#            success, and the name you asked for no longer addresses anything.
+#            That is the worst available failure: it does not announce itself,
+#            and every later `-t` lookup simply misses.
+#   systemd  ':' breaks unit processing ("Couldn't process aliases").
+#
+# '@' is NOT in this set on the evidence: a concrete unit file named
+# ``cc-harness-Name@abc123.service`` enables, symlinks into default.target.wants,
+# starts, and reports is-active, and tmux keeps it verbatim. It is substituted
+# anyway, by CONVENTION — '@' is how systemd spells a template instance, and a
+# concrete unit wearing that shape invites both human and tooling confusion.
+# Recording the distinction matters: this is a style choice we could revisit,
+# not a constraint we discovered, and an earlier write-up of this work asserted
+# the opposite ("@ → _ is correct for systemd") without having measured it.
+_UNSAFE_IN_IDENTIFIER = ".:/@ \t"
+
+_IDENTIFIER_SEPARATOR = "_"
+
+
+def session_identifier(calling_card: Optional[str] = None) -> str:
+    """Map a Calling Card to a session/service identifier.
+
+    The harness names a tmux session, a systemd unit and a supervisor instance.
+    Before this existed those carried a nickname that appeared nowhere else in
+    the framework, so an operator holding the Calling Card could not derive the
+    session name and a tool holding the session name could not recover the
+    Calling Card. The identifier is now a pure function of identity.
+
+    ``TheHarborMaster@ee5cd8`` becomes ``TheHarborMaster_ee5cd8``.
+
+    Collisions are possible in principle — two Calling Cards differing only in a
+    substituted character map to one identifier — and are not resolved here.
+    They are made harmless downstream instead: the harness resolver refuses to
+    pick between multiple matching units rather than guessing, which is the same
+    rule that keeps a defaulted name from being reported as a resolved one. The
+    six-hex-character suffix comes from a UUID, so a real collision requires two
+    agents whose monikers differ only by punctuation *and* whose UUIDs share a
+    prefix.
+    """
+    card = (calling_card or get_agent_identity()).strip()
+    out = []
+    for ch in card:
+        if ch in _UNSAFE_IN_IDENTIFIER:
+            out.append(_IDENTIFIER_SEPARATOR)
+        elif ch.isalnum() or ch in "_-":
+            out.append(ch)
+        else:
+            # Anything else is unproven rather than known-bad. Substituting is
+            # the conservative move; passing it through would make the failure
+            # someone else's, in a tmux lookup that just quietly misses.
+            out.append(_IDENTIFIER_SEPARATOR)
+    # Collapse runs so "A..B" and "A_B" do not become distinguishable only by
+    # underscore count, which no human would notice in a session list.
+    ident = ""
+    for ch in out:
+        if ch == _IDENTIFIER_SEPARATOR and ident.endswith(_IDENTIFIER_SEPARATOR):
+            continue
+        ident += ch
+    return ident.strip(_IDENTIFIER_SEPARATOR)
+
+
+def calling_card_from_identifier(identifier: str) -> str:
+    """Recover the Calling Card from a session identifier.
+
+    Reversible by convention, not by escaping: a Calling Card is
+    ``Moniker@uuidprefix``, so the LAST separator is the one that was an '@'.
+    Splitting on the last one keeps monikers that legitimately contain '_'.
+
+    This direction is what lets ``harness status`` name the agent behind a
+    session it found, instead of reporting on an identifier nobody can trace.
+    """
+    head, sep, tail = identifier.rpartition(_IDENTIFIER_SEPARATOR)
+    return f"{head}@{tail}" if sep else identifier
+
+
 def _get_config_identity_name() -> Optional[str]:
     """Read display name from .maceff/config.json agent_identity block.
 

--- a/macf/src/macf/utils/supervision.py
+++ b/macf/src/macf/utils/supervision.py
@@ -1,0 +1,235 @@
+"""Answer "where am I running, and is it healthy?" without archaeology.
+
+Every fact here was derivable before this module existed, and every one of them
+was derived by hand — repeatedly, in a single evening, while actively working on
+the harness — from ``$TMUX``, ps ancestry walks, tmux introspection and greps of
+the supervisor registry. Two of those hand derivations were wrong.
+
+That is the argument for the module. An agent coming out of compaction has to
+establish where it is running before it can trust anything else it observes, and
+a derivation subtle enough to catch out the person who just wrote the harness is
+not one to leave to each caller.
+
+The design rule, inherited from the defect that motivated it: **a negative must
+name what was checked, and a default must be labelled a default.** ``harness
+status`` once printed ``ABSENT`` for a name it had guessed, and it read as
+"there is no harness here" — nothing in the output was false, and it was still
+misleading, because a reader cannot discount a guess they cannot see.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any, Dict, Optional
+
+# The host that makes a session first-party. Not a preference: the client
+# compares the base URL's host against this exact string to decide whether the
+# long-context grant applies.
+FIRST_PARTY_HOST = "api.anthropic.com"
+
+# Set alongside a non-first-party base URL, this restores the long-context
+# window. Underscore-prefixed and undocumented, so it can change or vanish in
+# any release — which is why this module reports the SYMPTOM (the two settings
+# disagreeing) rather than asserting the flag works.
+FIRST_PARTY_FLAG = "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL"
+
+
+def _tmux(*args: str) -> Optional[str]:
+    """Run a tmux query, or None if tmux is absent or has no server."""
+    try:
+        r = subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def live_supervisors() -> list:
+    """Every registry entry that describes a supervisor actually running now.
+
+    Uses the supervisor's own liveness predicate rather than repeating it, so
+    "is it running" cannot come to mean two different things in two places.
+    """
+    from ..supervisor import REGISTRY_DIR, is_live_supervisor
+    import json
+
+    out = []
+    if not REGISTRY_DIR.exists():
+        return out
+    for f in sorted(REGISTRY_DIR.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except (OSError, ValueError):
+            continue
+        if is_live_supervisor(data):
+            out.append(data)
+    return out
+
+
+def context_window_integrity() -> Dict[str, Any]:
+    """Is this session's context window what it appears to be?
+
+    The highest-value check here, because the failure it detects is invisible:
+    when ``ANTHROPIC_BASE_URL`` names a host other than ``api.anthropic.com``,
+    the client stops extending the long-context window and falls back to a fifth
+    of it — silently, with every surface still displaying the full window, no
+    log line and no warning. The only symptom is compacting early.
+
+    It cost months of intermittent debugging, and it recurred the same evening
+    it was fixed, from a shell that still held a pre-fix function. This check
+    would have shown it at a glance, which is the whole point of putting it
+    somewhere an agent already looks.
+    """
+    base = os.environ.get("ANTHROPIC_BASE_URL", "")
+    flag = os.environ.get(FIRST_PARTY_FLAG, "")
+    if not base:
+        return {"base_url": None, "first_party_flag": bool(flag), "status": "direct",
+                "detail": f"no ANTHROPIC_BASE_URL — first-party by default"}
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(base).netloc
+    except ValueError:
+        host = base
+    # The host comparison includes the port, deliberately: a first-party host on
+    # a non-default port does NOT pass the client's own check.
+    if host == FIRST_PARTY_HOST:
+        return {"base_url": base, "first_party_flag": bool(flag), "status": "first-party",
+                "detail": f"base URL host is {FIRST_PARTY_HOST}"}
+    if flag:
+        return {"base_url": base, "first_party_flag": True, "status": "proxied-ok",
+                "detail": f"host {host} is not {FIRST_PARTY_HOST}, but {FIRST_PARTY_FLAG} is set"}
+    return {
+        "base_url": base, "first_party_flag": False, "status": "DEGRADED",
+        "detail": (f"host {host} is not {FIRST_PARTY_HOST} and {FIRST_PARTY_FLAG} is "
+                   f"NOT set — the long-context window is silently reduced while "
+                   f"every surface still reports the full size"),
+    }
+
+
+def diagnose(agent: Optional[str] = None) -> Dict[str, Any]:
+    """Full supervision picture: who supervises me, in what session, how healthy."""
+    from .harness import default_params, installed_agents, resolve_agent
+    from .identity import calling_card_from_identifier
+
+    resolved, source = resolve_agent(agent)
+    ambiguous = source == "ambiguous"
+    expected = None if ambiguous else resolved
+
+    # --- supervision --------------------------------------------------------
+    sups = live_supervisors()
+    mine = [s for s in sups if s.get("name") == expected] if expected else []
+    others = [s for s in sups if s.get("name") != expected]
+
+    # --- this process's own session ----------------------------------------
+    in_tmux = bool(os.environ.get("TMUX"))
+    socket = os.environ.get("TMUX", "").split(",")[0] or None
+    # display-message answers about the CURRENT client, which is what "am I in
+    # it" means. list-sessions would answer about the server.
+    current = _tmux("display-message", "-p", "#{session_name}") if in_tmux else None
+    clients = None
+    if current:
+        listed = _tmux("list-clients", "-t", f"={current}", "-F", "#{client_tty}")
+        clients = len([l for l in (listed or "").splitlines() if l.strip()])
+
+    # --- artifacts ----------------------------------------------------------
+    drift = None
+    if not ambiguous:
+        try:
+            p = default_params(agent=expected)
+            drift = []
+            for path in (p.start, p.child_path, p.functions):
+                if not path.exists():
+                    drift.append(f"{path.name}: ABSENT")
+        except Exception:
+            drift = None
+
+    return {
+        "agent": {
+            "identifier": None if ambiguous else expected,
+            "calling_card": None if ambiguous else calling_card_from_identifier(expected),
+            "resolved_from": source,
+            "is_default": source == "default",
+            "candidates": resolved if ambiguous else None,
+            "installed": installed_agents(),
+        },
+        "supervision": {
+            "supervised": bool(mine),
+            "supervisors": [
+                {"pid": s.get("supervisor_pid"), "name": s.get("name"),
+                 "restarts": s.get("restart_count"), "session": s.get("tmux_session")}
+                for s in mine
+            ],
+            # The precondition for two clients writing one task store. Named
+            # rather than counted, because "another agent is also supervised
+            # here" and "a second supervisor claims MY name" are different
+            # facts and only the second one is a hazard.
+            "other_live_supervisors": [
+                {"pid": s.get("supervisor_pid"), "name": s.get("name")} for s in others
+            ],
+            "name_collision": bool(expected) and sum(
+                1 for s in sups if s.get("name") == expected) > 1,
+        },
+        "session": {
+            "in_tmux": in_tmux,
+            "socket": socket,
+            "name": current,
+            "clients_attached": clients,
+            # A client attached to a session that is not the harness's is the
+            # state in which every status surface looks right and none of them
+            # is describing the supervised session.
+            "matches_expected": (current == expected) if (current and expected) else None,
+        },
+        "context_window": context_window_integrity(),
+        "artifacts": {"missing": drift},
+    }
+
+
+def format_diagnosis(d: Dict[str, Any]) -> str:
+    """Render for a human, saying what was checked on every negative."""
+    lines = []
+    a, s, sess, cw = d["agent"], d["supervision"], d["session"], d["context_window"]
+
+    if a["candidates"]:
+        lines.append(f"  Agent:        AMBIGUOUS — {', '.join(a['candidates'])}")
+    elif a["is_default"]:
+        lines.append(f"  Agent:        {a['identifier']}  (DEFAULT — not resolved "
+                     f"from environment, config or any installed unit)")
+    else:
+        lines.append(f"  Agent:        {a['identifier']}  ({a['calling_card']}, via {a['resolved_from']})")
+
+    if s["supervised"]:
+        for sup in s["supervisors"]:
+            lines.append(f"  Supervisor:   pid {sup['pid']} — {sup['restarts']} restart(s), "
+                         f"session {sup['session']}")
+    else:
+        lines.append(f"  Supervisor:   NONE running for {a['identifier'] or 'any resolved agent'} "
+                     f"(this session is not supervised — a crash will not restart it)")
+
+    if s["name_collision"]:
+        lines.append("  ⚠️  COLLISION:  more than one live supervisor claims this agent name — "
+                     "two clients can write one task store")
+    if s["other_live_supervisors"]:
+        names = ", ".join(f"{o['name']}({o['pid']})" for o in s["other_live_supervisors"])
+        lines.append(f"  Other agents: {names}")
+
+    if sess["in_tmux"]:
+        match = ""
+        if sess["matches_expected"] is False:
+            match = "  ⚠️ NOT the harness session"
+        lines.append(f"  Session:      {sess['name']} — {sess['clients_attached']} client(s){match}")
+        if (sess["clients_attached"] or 0) > 1:
+            lines.append("  ⚠️  CLIENTS:    more than one client attached — mismatched geometry "
+                         "causes fragmented redraws; detach the others")
+    else:
+        lines.append("  Session:      not running under tmux (no detach/reattach, "
+                     "and nothing survives this terminal closing)")
+
+    if cw["status"] == "DEGRADED":
+        lines.append(f"  ⚠️  CONTEXT:    {cw['detail']}")
+    else:
+        lines.append(f"  Context:      {cw['status']} — {cw['detail']}")
+
+    if d["artifacts"]["missing"]:
+        lines.append(f"  ⚠️  ARTIFACTS:  {'; '.join(d['artifacts']['missing'])}")
+
+    return "\n".join(lines)

--- a/macf/tests/test_harness_integration.py
+++ b/macf/tests/test_harness_integration.py
@@ -1,0 +1,194 @@
+"""Integration tests: RUN the rendered artifacts instead of reading them.
+
+Every other test in this suite asserts on rendered *text*. That is a real gap
+and it cost a live host an evening: a render can be textually perfect and
+semantically invalid, and string assertions cannot tell the difference. Three
+defects shipped through a fully green suite on 2026-08-07, and all three are the
+same shape — *the command we generated does not do what the words suggest*:
+
+1. ``claude -c`` with no prompt is REFUSED on some conversations ("No deferred
+   tool marker found in the resumed session … Provide a prompt to continue"),
+   exit 1, which the supervisor then retried forever.
+2. ``--channels`` is VARIADIC, so a prompt placed after it was parsed as another
+   channel: "--channels entries must be tagged: AUTO_MODE RESUME: …".
+3. An f-string patch emitted ``\\\\`` where a line continuation was intended,
+   silently truncating the tmux command.
+
+None of those change whether an expected substring is present. All of them
+change what the shell and the client actually receive.
+
+The technique is a **stub on PATH**: a fake ``claude`` that records its argv and
+exits. That makes the child wrapper's real argument construction observable —
+quoting, ordering, and the empty-``$@`` case — offline, deterministically, and
+without spending a single API call. What the stub cannot know is how the real
+client PARSES that argv, so a second, skippable tier runs the real binary and
+asserts it does not reject its own arguments.
+"""
+
+import json
+import os
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+from macf.utils.harness import HarnessParams, render_child
+
+
+def _params(tmp_path, **kw):
+    return HarnessParams(
+        agent="probe",
+        home=tmp_path,
+        python=Path("/bin/true"),
+        macf_tools=tmp_path / "macf_tools",
+        child_path=tmp_path / "child",
+        registry_dir=tmp_path / "reg",
+        **kw,
+    )
+
+
+def _install_stubs(tmp_path, mode_output="MANUAL_MODE"):
+    """A bin/ containing a fake `claude` that records argv, and a fake macf_tools."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    argv_file = tmp_path / "argv.json"
+
+    claude = bin_dir / "claude"
+    claude.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        f"open({str(argv_file)!r}, 'w').write(json.dumps(sys.argv[1:]))\n"
+    )
+    claude.chmod(0o755)
+
+    # The child invokes macf_tools by ABSOLUTE path ($MACF = p.macf_tools), so
+    # a stub on PATH is never consulted. Write it where the child will look --
+    # found when the AUTO_MODE test received the MANUAL prompt.
+    macf = tmp_path / "macf_tools"
+    macf.write_text(f"#!/bin/bash\n[ \"$1\" = mode ] && echo {mode_output}\nexit 0\n")
+    macf.chmod(0o755)
+    return bin_dir, argv_file
+
+
+def _run_child(tmp_path, p, mode_output="MANUAL_MODE", args=()):
+    """Render the child wrapper, run it against stubs, return the argv it built."""
+    bin_dir, argv_file = _install_stubs(tmp_path, mode_output)
+    child = tmp_path / "child"
+    child.write_text(render_child(p))
+    child.chmod(0o755)
+    env = {**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    # DEVNULL, not capture_output: the wrapper backgrounds a trust-prompt nudge
+    # (`sleep 18; tmux send-keys ...`) that inherits stdout. With a pipe,
+    # subprocess.run waits ~20s for EOF from a process we do not care about --
+    # which stalled this whole file past pytest's timeout and looked like a
+    # hang. Diagnosed by running one child outside pytest with a stopwatch:
+    # argv was recorded instantly, the wait was all pipe.
+    subprocess.run([str(child), *args], env=env, timeout=30,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return json.loads(argv_file.read_text())
+
+
+class TestTheChildBuildsTheArgvItMeansTo:
+    def test_a_prompt_is_actually_passed(self, tmp_path):
+        """Defect 1: a resume with no prompt can be refused outright, and the
+        supervisor retries the refusal forever."""
+        argv = _run_child(tmp_path, _params(tmp_path))
+        assert "-c" in argv
+        prompts = [a for a in argv if not a.startswith("-") and " " in a]
+        assert prompts, f"no prompt-like argument in {argv}"
+
+    def test_the_prompt_is_one_argument_not_shattered_by_quoting(self, tmp_path):
+        """A prompt has spaces. Losing the quotes turns it into a dozen
+        positional arguments, which no string assertion would notice."""
+        argv = _run_child(tmp_path, _params(tmp_path))
+        multiword = [a for a in argv if len(a.split()) > 3]
+        assert len(multiword) == 1, f"prompt is not a single argument: {argv}"
+
+    def test_channels_receive_only_the_channel(self, tmp_path):
+        """Defect 2, exactly. `--channels` is variadic; the prompt must not land
+        in it. This is the assertion that was missing when the client died with
+        "--channels entries must be tagged: AUTO_MODE RESUME: …"."""
+        p = _params(tmp_path, channels=("plugin:tg@mkt",))
+        argv = _run_child(tmp_path, p)
+        i = argv.index("--channels")
+        consumed = argv[i + 1:]
+        assert consumed == ["plugin:tg@mkt"], \
+            f"--channels swallowed more than its value: {consumed}"
+
+    def test_the_mode_selects_the_prompt(self, tmp_path):
+        auto = _run_child(tmp_path, _params(tmp_path), mode_output="AUTO_MODE")
+        manual = _run_child(tmp_path, _params(tmp_path), mode_output="MANUAL_MODE")
+        assert any("AUTO_MODE RESUME" in a for a in auto)
+        assert not any("AUTO_MODE RESUME" in a for a in manual)
+
+    def test_extra_arguments_survive(self, tmp_path):
+        """`"$@"` is empty in practice, so a mistake there is invisible until the
+        day it is not."""
+        argv = _run_child(tmp_path, _params(tmp_path), args=("--verbose",))
+        assert "--verbose" in argv
+
+    def test_no_channels_configured_still_produces_a_valid_invocation(self, tmp_path):
+        argv = _run_child(tmp_path, _params(tmp_path))
+        assert "--channels" not in argv
+        assert "-c" in argv
+
+    def test_the_child_writes_its_log(self, tmp_path):
+        """The log is what made defect 1 findable; if it silently stopped being
+        written, the next failure goes back to being invisible."""
+        p = _params(tmp_path)
+        _run_child(tmp_path, p)
+        assert p.log_path.exists(), "the child produced no log"
+        assert "starting:" in p.log_path.read_text()
+
+
+@pytest.mark.skipif(shutil.which("claude") is None, reason="claude client not installed")
+class TestTheRealClientAcceptsWhatWeGenerate:
+    """The stub proves what argv we BUILD; only the real binary proves it PARSES.
+
+    Run in an empty directory so `-c` has nothing to resume: the client then
+    exits on its own without a conversation, and any *usage* error it prints is
+    about our arguments rather than about the session. Skipped where the client
+    is absent, so CI without it stays green — but on a developer machine this is
+    the test that would have caught the variadic-flag defect in seconds.
+    """
+
+    def _usage_error(self, tmp_path, argv):
+        """Return the client's usage complaint, or None if it had none.
+
+        The asymmetry is the test: a usage error is printed and the process
+        exits AT ONCE, while a valid invocation goes on to run. So a timeout is
+        a PASS signal, not a failure — it means the arguments were accepted and
+        the client got as far as doing work. stdin is closed so a client that
+        does start cannot sit waiting on input forever.
+        """
+        try:
+            r = subprocess.run(["claude", *argv], cwd=tmp_path, capture_output=True,
+                               text=True, timeout=20, stdin=subprocess.DEVNULL)
+            out = r.stdout + r.stderr
+        except subprocess.TimeoutExpired as e:
+            out = ((e.stdout or b"") + (e.stderr or b"")).decode(errors="replace")
+        for marker in ("must be tagged", "unknown option", "unrecognized",
+                       "Invalid", "usage:"):
+            if marker.lower() in out.lower():
+                return out.strip().splitlines()[0]
+        return None
+
+    def test_the_generated_argument_order_is_accepted(self, tmp_path):
+        work = tmp_path / "empty"
+        work.mkdir()
+        err = self._usage_error(work, [
+            "-c", "AUTO_MODE RESUME: this session restarted.",
+            "--channels", "plugin:telegram@claude-plugins-official"])
+        assert err is None, f"the client rejected our own arguments: {err}"
+
+    def test_the_order_we_replaced_really_was_rejected(self, tmp_path):
+        """Negative control. Without it, the test above passes for any order —
+        including one the client happens to tolerate — and proves nothing."""
+        work = tmp_path / "empty2"
+        work.mkdir()
+        err = self._usage_error(work, [
+            "-c", "--channels", "plugin:telegram@claude-plugins-official",
+            "AUTO_MODE RESUME: this session restarted."])
+        assert err is not None and "must be tagged" in err, \
+            "the old broken order was NOT rejected — this check proves nothing"

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -491,16 +491,45 @@ class TestAFailedLaunchStaysReadable:
     def test_the_child_keeps_its_own_log(self):
         child = render_child(SYNTH)
         assert str(SYNTH.log_path) in child
-        assert "tee -a" in child
+        assert "pipe-pane" in child
 
-    def test_the_child_tees_rather_than_redirects(self):
-        """Redirecting would blank the pane for an attached human; a pipeline
-        would make the supervisor wait on `tee` instead of the client, so a
-        dead client would look alive."""
+    def test_the_child_logs_without_touching_the_clients_descriptors(self):
+        """This test previously asserted the DEFECT as a requirement.
+
+        It demanded `exec > >(tee -a ...)`, reasoning that a plain redirect
+        would blank the pane and a `| tee` pipeline would make the supervisor
+        wait on tee instead of the client. Both halves of that were true, and
+        the conclusion was still wrong: process substitution avoids the
+        pipeline but still replaces the client's stdout with a PIPE, and an
+        interactive client deprived of a terminal can render one turn and exit
+        0 -- producing a restart loop with no error in any log.
+
+        The deeper mistake is the shape of the old assertion. Pinning a literal
+        line of shell pins an IMPLEMENTATION; the property that actually
+        matters -- the client still has a terminal -- is not visible in the
+        source at all. It is measured in tests/test_harness_runtime.py, which
+        runs the wrapper in a real pane and asks the client what it received.
+        Keep this test negative and thin; the positive claim lives there.
+        """
         child = _code_only(render_child(SYNTH))
-        assert "exec > >(tee -a" in child
         assert "exec claude" in child
+        assert "exec >" not in child, (
+            "the wrapper must not redirect the client's stdout; log the pane "
+            "from outside with tmux pipe-pane"
+        )
         assert "| tee" not in child, "a pipeline would hide the client's exit from the supervisor"
+        assert "pipe-pane" in child
+
+    def test_no_blind_keystrokes_are_sent_on_launch(self):
+        """An unattended Enter accepts whatever is focused, not the prompt we
+        had in mind. Startup dialogs are not stable across client versions, and
+        a resume dialog defaulting to 'summarize' would silently discard the
+        session's context with nothing recording that a choice was made."""
+        child = _code_only(render_child(SYNTH))
+        assert "send-keys" not in child, (
+            "first launch is the operator's to answer; a menu a human has not "
+            "seen is a menu a machine must not answer"
+        )
 
     def test_the_launcher_says_where_the_log_is(self):
         assert str(SYNTH.log_path) in render_start(SYNTH)

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -335,8 +335,31 @@ class TestStartScriptBehaviour:
         script = tmp_path / "start"
         script.write_text(render_start(p, attach_proxy=False))
         script.chmod(0o755)
-        env = {**os.environ, "TMUX_TMPDIR": str(sock)}
+        # TMUX MUST BE STRIPPED, not merely overridden by TMUX_TMPDIR.
+        #
+        # A tmux client that inherits $TMUX attaches to THAT server and ignores
+        # TMUX_TMPDIR entirely. Every process inside a tmux pane has $TMUX set,
+        # so `{**os.environ, "TMUX_TMPDIR": ...}` isolates only when the suite
+        # is run from OUTSIDE tmux. Run from inside one -- which is how an agent
+        # runs it, and never how CI does -- the sandbox silently operated on the
+        # host's default server, and this fixture's teardown `kill-server`
+        # destroyed every session on it.
+        #
+        # That is not hypothetical: it killed the live agent harness on this
+        # host. Measured afterwards -- with $TMUX inherited, a sandbox session
+        # appears in the DEFAULT server's list; with $TMUX removed, it appears
+        # only in the private one and the default survives the kill-server.
+        #
+        # The property that makes this dangerous is that it is invisible in the
+        # environment where tests are normally run. A green suite in CI says
+        # nothing about the blast radius in the environment that matters.
+        env = {k: v for k, v in os.environ.items() if k != "TMUX"}
+        env["TMUX_TMPDIR"] = str(sock)
         yield script, reg, env
+        # Belt and braces: target the private socket explicitly as well, so a
+        # future edit that reintroduces $TMUX cannot turn this into kill-server
+        # on the host. This teardown is the destructive one; it should be the
+        # most defensive line in the file.
         subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
 
     def _run(self, script, env):

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -375,6 +375,27 @@ class TestStartScriptBehaviour:
             f'{{"supervisor_pid": {proc.pid}, "name": "{name}", "status": "running"}}')
         return proc
 
+    def test_the_sandbox_env_carries_no_TMUX(self, sandbox):
+        """Blast-radius guard, and the most important test in this class.
+
+        This fixture tears down with `tmux kill-server`. That is only survivable
+        because the env selects a private server, and it selects one ONLY while
+        $TMUX is absent -- an inherited $TMUX silently overrides TMUX_TMPDIR and
+        points every client at the host's server. Restoring the natural
+        `{**os.environ, ...}` spelling would make this class destroy the live
+        agent harness again, with a green suite in CI to say it was fine.
+
+        Asserted on the env rather than by running the destructive path, so the
+        guard costs nothing and cannot itself be the thing that goes wrong.
+        """
+        _script, _reg, env = sandbox
+        assert "TMUX" not in env, (
+            "the sandbox env inherited $TMUX; tmux will ignore TMUX_TMPDIR, this "
+            "fixture's kill-server will run against the host, and every session "
+            "on it -- including a live agent harness -- will be destroyed"
+        )
+        assert env.get("TMUX_TMPDIR"), "the private socket dir must still be set"
+
     def test_creates_a_session_when_nothing_holds_the_name(self, sandbox):
         script, _reg, env = sandbox
         r = self._run(script, env)

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -304,7 +304,7 @@ class TestChildEntrypoint:
         (line,) = [l for l in render_child(p).splitlines() if l.startswith("exec claude")]
         # "$PROMPT" trails deliberately — a resume with no prompt can be refused
         # outright; see TestAResumeCarriesAPrompt.
-        assert line == 'exec claude -c --channels plugin:a@x,plugin:b@y "$@" "$PROMPT"'
+        assert line == 'exec claude -c "$PROMPT" "$@" --channels plugin:a@x,plugin:b@y'
 
 
 needs_tmux = pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not available")
@@ -518,7 +518,21 @@ class TestAResumeCarriesAPrompt:
 
     def test_the_client_is_given_an_initial_prompt(self):
         (line,) = [l for l in render_child(SYNTH).splitlines() if l.startswith("exec claude")]
-        assert line.endswith('"$PROMPT"'), "a resume with no prompt can be refused outright"
+        assert '"$PROMPT"' in line, "a resume with no prompt can be refused outright"
+
+    def test_the_prompt_does_not_follow_a_variadic_flag(self):
+        """`--channels` keeps consuming following words. A prompt placed after it
+        is parsed as another channel and the client dies with "--channels entries
+        must be tagged: <your prompt>" — which is what happened, in a restart
+        loop, on a live host. The variadic flag must come last, where the only
+        thing left to consume is its own values."""
+        from dataclasses import replace
+        p = replace(SYNTH, channels=("plugin:a@x",))
+        (line,) = [l for l in render_child(p).splitlines() if l.startswith("exec claude")]
+        assert line.index('"$PROMPT"') < line.index("--channels"), \
+            "the prompt must precede the variadic flag"
+        assert line.rstrip().endswith("plugin:a@x"), \
+            "--channels must be last so nothing follows it to be swallowed"
 
     def test_the_prompt_is_never_empty(self):
         """An empty string would satisfy the shell and not the client."""

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -302,7 +302,9 @@ class TestChildEntrypoint:
         from dataclasses import replace
         p = replace(SYNTH, channels=("plugin:a@x", "plugin:b@y"))
         (line,) = [l for l in render_child(p).splitlines() if l.startswith("exec claude")]
-        assert line == 'exec claude -c --channels plugin:a@x,plugin:b@y "$@"'
+        # "$PROMPT" trails deliberately — a resume with no prompt can be refused
+        # outright; see TestAResumeCarriesAPrompt.
+        assert line == 'exec claude -c --channels plugin:a@x,plugin:b@y "$@" "$PROMPT"'
 
 
 needs_tmux = pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not available")
@@ -365,9 +367,13 @@ class TestStartScriptBehaviour:
         r = self._run(script, env)
         assert r.returncode == 0, r.stderr
         assert "started session" in r.stdout
+        # Assert only what this test is about: the imposter was NOT mistaken for
+        # ours and was left alone. Whether the newly created pane still exists a
+        # moment later is tmux pane lifetime, not the guard -- asserting it made
+        # this test flaky, which is worse than not asserting it.
         sessions = subprocess.run(["tmux", "list-sessions", "-F", "#{session_name}"],
                                   env=env, capture_output=True, text=True).stdout.split()
-        assert "probe" in sessions and "probe-stale-ssh" in sessions
+        assert "probe-stale-ssh" in sessions
 
     def test_refuses_a_session_name_held_by_something_else(self, sandbox):
         """THE regression. A name-only guard returns 'already running' here and
@@ -462,6 +468,111 @@ class TestInstallChoicesSurviveForTheNextCheck:
         p.settings_path.parent.mkdir(parents=True, exist_ok=True)
         p.settings_path.write_text("{not json")
         assert load_settings(p).channels == ()
+
+
+class TestAFailedLaunchStaysReadable:
+    """A launch you cannot diagnose costs more than a launch that fails.
+
+    Three failures in one evening printed their explanation into a tmux pane
+    that vanished the instant the command exited, leaving nothing but `[exited]`
+    and a shell prompt. The message existed; nobody could read it.
+    """
+
+    def test_the_pane_survives_its_command(self):
+        assert "remain-on-exit on" in render_start(SYNTH)
+
+    def test_remain_on_exit_targets_the_session_exactly(self):
+        """Prefix matching again: setting the option on the wrong session
+        would leave the real one vanishing exactly as before."""
+        (line,) = [l for l in _code_only(render_start(SYNTH)).splitlines()
+                   if "remain-on-exit" in l]
+        assert '-t "=$SESSION"' in line
+
+    def test_the_child_keeps_its_own_log(self):
+        child = render_child(SYNTH)
+        assert str(SYNTH.log_path) in child
+        assert "tee -a" in child
+
+    def test_the_child_tees_rather_than_redirects(self):
+        """Redirecting would blank the pane for an attached human; a pipeline
+        would make the supervisor wait on `tee` instead of the client, so a
+        dead client would look alive."""
+        child = _code_only(render_child(SYNTH))
+        assert "exec > >(tee -a" in child
+        assert "exec claude" in child
+        assert "| tee" not in child, "a pipeline would hide the client's exit from the supervisor"
+
+    def test_the_launcher_says_where_the_log_is(self):
+        assert str(SYNTH.log_path) in render_start(SYNTH)
+
+
+class TestAResumeCarriesAPrompt:
+    """`claude -c` with no prompt can refuse to resume and exit 1.
+
+    Measured A/B on one conversation, same minute: without a prompt the client
+    printed "No deferred tool marker found in the resumed session ... Provide a
+    prompt to continue the conversation" and exited 1, every time; with a prompt
+    it came up. The supervisor then did the right thing with exit 1 — retry —
+    which turned an unsatisfiable command into an unbounded loop.
+    """
+
+    def test_the_client_is_given_an_initial_prompt(self):
+        (line,) = [l for l in render_child(SYNTH).splitlines() if l.startswith("exec claude")]
+        assert line.endswith('"$PROMPT"'), "a resume with no prompt can be refused outright"
+
+    def test_the_prompt_is_never_empty(self):
+        """An empty string would satisfy the shell and not the client."""
+        child = _code_only(render_child(SYNTH))
+        assigns = [l for l in child.splitlines() if l.strip().startswith("PROMPT=")]
+        assert len(assigns) >= 2, "expected a mode-aware prompt with a fallback"
+        for a in assigns:
+            value = a.split("=", 1)[1].strip().strip('"')
+            assert len(value) > 10, f"empty or trivial prompt: {a}"
+
+    def test_the_prompt_depends_on_the_mode(self):
+        child = render_child(SYNTH)
+        assert "mode get" in child
+        assert "AUTO_MODE RESUME" in child
+
+    def test_the_send_keys_timing_hack_is_gone(self):
+        """It guessed when the client was ready, and could not rescue a resume
+        that never started. The initial prompt does the same job unconditionally."""
+        child = _code_only(render_child(SYNTH))
+        assert "AUTO_MODE RESUME" not in child.split("PROMPT=")[0], \
+            "the re-orientation must arrive as the initial prompt, not via send-keys"
+
+
+class TestWatchdogIsOptInAndSafe:
+    """The supervisor is a child of the tmux server, so it dies with it, and the
+    boot unit is oneshot+RemainAfterExit — systemd neither notices nor acts.
+    The watchdog re-runs the already-idempotent start script on a timer."""
+
+    def test_it_reuses_the_one_start_script(self):
+        from macf.utils.harness import render_watchdog
+        svc, _timer = render_watchdog(SYNTH)
+        assert f"ExecStart={SYNTH.start}" in svc, "a second implementation would defeat the point"
+
+    def test_the_timer_targets_the_watch_unit_not_the_boot_unit(self):
+        from macf.utils.harness import render_watchdog
+        _svc, timer = render_watchdog(SYNTH)
+        assert f"Unit=cc-harness-{SYNTH.agent}-watch.service" in timer
+        assert "OnUnitActiveSec" in timer
+
+    @needs_systemd
+    def test_both_units_pass_systemds_own_parser(self, tmp_path):
+        from dataclasses import replace
+        from macf.utils.harness import render_watchdog
+        script = tmp_path / "start"
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(0o755)
+        svc, timer = render_watchdog(replace(SYNTH, start_path=script))
+        for name, text in ((f"cc-harness-testbot-watch.service", svc),
+                           (f"cc-harness-testbot-watch.timer", timer)):
+            p = tmp_path / name
+            p.write_text(text)
+            r = subprocess.run(["systemd-analyze", "verify", str(p)],
+                               capture_output=True, text=True)
+            assert (r.stdout + r.stderr).strip() == "", f"{name}: {(r.stdout + r.stderr).strip()}"
 
 
 class TestStopTargetsTheSupervisor:

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -427,6 +427,43 @@ class TestStartScriptBehaviour:
             proc.kill(); proc.wait()
 
 
+class TestInstallChoicesSurviveForTheNextCheck:
+    """Channels and the shell prefix cannot be re-derived from the environment.
+
+    If they are not recorded, a later flagless `install --check` renders
+    DIFFERENT artifacts and reports drift that does not exist — and the natural
+    response to that report, `--force`, would strip the channel and take the
+    agent off the air with nothing to see. Observed on a live host before this
+    was added.
+    """
+
+    def _p(self, tmp_path, **kw):
+        from dataclasses import replace
+        return replace(SYNTH, home=tmp_path, **kw)
+
+    def test_a_flagless_render_reproduces_what_was_installed(self, tmp_path):
+        from macf.utils.harness import load_settings, save_settings
+        installed = self._p(tmp_path, channels=("plugin:tg@x",), shell_prefix="short")
+        save_settings(installed)
+        assert load_settings(self._p(tmp_path)) == installed
+
+    def test_explicit_flags_still_win_over_the_record(self, tmp_path):
+        from macf.utils.harness import load_settings, save_settings
+        save_settings(self._p(tmp_path, channels=("old:one",), shell_prefix="old"))
+        got = load_settings(self._p(tmp_path, channels=("new:one",), shell_prefix="new"))
+        assert got.channels == ("new:one",) and got.shell_prefix == "new"
+
+    def test_a_missing_or_corrupt_record_is_not_fatal(self, tmp_path):
+        """A first install has no record, and a truncated one must not stop the
+        harness from being reinstallable."""
+        from macf.utils.harness import load_settings
+        assert load_settings(self._p(tmp_path)).channels == ()
+        p = self._p(tmp_path)
+        p.settings_path.parent.mkdir(parents=True, exist_ok=True)
+        p.settings_path.write_text("{not json")
+        assert load_settings(p).channels == ()
+
+
 class TestStopTargetsTheSupervisor:
     def test_exec_stop_disables_the_supervisor_rather_than_killing_the_child(self):
         """Killing the child just makes the supervisor restart it, so a stop

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -13,6 +13,7 @@ Gating on the exit code would be the same instrument-reports-success defect thes
 invariants exist to catch.
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -25,20 +26,51 @@ import pytest
 from macf.utils.harness import (
     HarnessParams,
     render_child,
+    render_launch_functions,
+    render_start,
     render_tmux_conf,
     render_unit,
 )
 
 # Deliberately synthetic: nothing here may appear in a published artifact, and
 # nothing about the developer's machine may leak into a render made from these.
+# registry_dir is pinned too — its default is resolved from the real environment,
+# and a test that renders the developer's own runtime path would both leak it and
+# pass for the wrong reason.
 SYNTH = HarnessParams(
     agent="testbot",
     home=Path("/opt/agents/testbot"),
     python=Path("/opt/py/bin/python3"),
     macf_tools=Path("/opt/py/bin/macf_tools"),
     child_path=Path("/opt/agents/testbot/.local/bin/maceff_cc_child_testbot"),
+    registry_dir=Path("/run/testbot/macf/auto-restart"),
     path_prepend=("/opt/py/bin", "/opt/agents/testbot/.local/bin"),
 )
+
+
+def _code_only(text):
+    """Drop comment lines.
+
+    A concept named in a comment is a MENTION, not a USE. Without this, an
+    assertion that some construct is absent fails on the comment explaining why
+    it is absent — which would push an author to delete the explanation in order
+    to satisfy the check.
+    """
+    return "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("#"))
+
+
+def _real_start(tmp_path):
+    """SYNTH, but with a start script that exists on disk.
+
+    ``systemd-analyze`` checks that ExecStart's binary is executable, and it
+    became able to say so only once ExecStart stopped being ``/bin/bash -c``.
+    Keeping the oracle strict is worth materialising the file for.
+    """
+    script = tmp_path / "maceff_harness_start_testbot"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o755)
+    from dataclasses import replace
+    return replace(SYNTH, start_path=script)
 
 
 def _verify(unit_text, tmp_path):
@@ -61,22 +93,34 @@ needs_systemd = pytest.mark.skipif(
 class TestUnitIsWellFormed:
     @needs_systemd
     def test_rendered_unit_passes_systemds_own_parser(self, tmp_path):
-        assert _verify(render_unit(SYNTH), tmp_path) == ""
+        assert _verify(render_unit(_real_start(tmp_path)), tmp_path) == ""
 
     @needs_systemd
     def test_rendered_unit_without_proxy_also_passes(self, tmp_path):
-        assert _verify(render_unit(SYNTH, attach_proxy=False), tmp_path) == ""
+        assert _verify(render_unit(_real_start(tmp_path), attach_proxy=False), tmp_path) == ""
 
     @needs_systemd
     def test_the_oracle_can_actually_fail(self, tmp_path):
         """Negative control on the oracle itself.
 
-        Stripping the ExecStart= prefix is a real bug this caught during
-        development: the exec line became an unknown key and the unit would
-        never have started anything.
+        A misspelled directive is silently ignored by systemd — the unit loads,
+        reports as configured, and starts nothing. That is the whole reason this
+        file reads the oracle's OUTPUT instead of its exit status, which stays 0
+        throughout.
         """
-        broken = render_unit(SYNTH).replace("ExecStart=/bin/bash", "/bin/bash")
+        broken = render_unit(_real_start(tmp_path)).replace("ExecStart=", "ExecStartt=")
         assert "Unknown key" in _verify(broken, tmp_path)
+
+    @needs_systemd
+    def test_the_oracle_notices_an_exec_start_that_cannot_run(self, tmp_path):
+        """Second negative control, and the one that made this file honest.
+
+        ExecStart used to be ``/bin/bash -c '<everything>'``, so systemd only
+        ever checked that bash exists. Now that it names the start script
+        directly, systemd verifies the real target — and a unit pointing at a
+        script that was never installed is caught here rather than at boot.
+        """
+        assert "not executable" in _verify(render_unit(SYNTH), tmp_path)
 
     def test_exec_start_is_present_and_prefixed(self):
         lines = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStart=")]
@@ -84,34 +128,124 @@ class TestUnitIsWellFormed:
 
 
 class TestProxyAndFirstPartyFlag:
+    """These invariants live in the start script now, because the launch decision
+    does. They used to be asserted on the unit — while a second, unasserted copy
+    of the same logic sat in the operator's shell profile and had already lost the
+    flag. Asserting the invariant on one of two implementations is how it stayed
+    lost; there is now only one place for it to hold."""
+
     def test_flag_travels_in_the_same_assignment_as_the_base_url(self):
         """Their separation is what let the context-window defect survive months."""
-        unit = render_unit(SYNTH)
-        (exec_line,) = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
-        assert "ANTHROPIC_BASE_URL=" in exec_line
-        i = exec_line.index("ANTHROPIC_BASE_URL=")
-        j = exec_line.index("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
+        (line,) = [l for l in render_start(SYNTH).splitlines()
+                   if "ANTHROPIC_BASE_URL=" in l]
+        i = line.index("ANTHROPIC_BASE_URL=")
+        j = line.index("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
         # Same quoted BASE assignment: the flag must follow the URL with nothing
         # but the URL's own value between them.
         assert 0 < j - i < 80, "flag is not in the same assignment as the base URL"
 
     def test_neither_appears_without_the_other(self):
-        unit = render_unit(SYNTH)
-        assert unit.count("ANTHROPIC_BASE_URL=") == unit.count("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
+        start = render_start(SYNTH)
+        assert start.count("ANTHROPIC_BASE_URL=") == start.count("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1")
 
     def test_proxy_attachment_is_probed_not_assumed(self):
         """A dead proxy must degrade to a direct agent, never a dead one."""
-        exec_line = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStart=")][0]
-        assert 'BASE=""' in exec_line          # default is direct
-        assert "curl" in exec_line             # attachment is conditional on a probe
-        assert "--max-time" in exec_line       # and cannot hang the boot path
+        start = render_start(SYNTH)
+        assert 'BASE=""' in start          # default is direct
+        assert "curl" in start             # attachment is conditional on a probe
+        assert "--max-time" in start       # and cannot hang the boot path
 
     def test_no_proxy_render_carries_no_base_url_at_all(self):
-        unit = render_unit(SYNTH, attach_proxy=False)
+        start = render_start(SYNTH, attach_proxy=False)
+        assert "ANTHROPIC_BASE_URL" not in start
+        assert "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL" not in start
+        assert 'BASE=""' in start
+        assert "macf-proxy.service" not in render_unit(SYNTH, attach_proxy=False)
+
+    def test_the_unit_carries_no_launch_logic_of_its_own(self):
+        """The regression that started this: two implementations, one of which
+        had lost the flag. The unit must delegate, not re-implement."""
+        unit = render_unit(SYNTH)
         assert "ANTHROPIC_BASE_URL" not in unit
-        assert "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL" not in unit
-        assert "macf-proxy.service" not in unit
-        assert 'BASE=""' in unit
+        assert "tmux new-session" not in unit
+
+
+class TestOneImplementationOfStarting:
+    def test_exec_start_invokes_the_start_script(self):
+        (exec_line,) = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStart=")]
+        assert exec_line == f"ExecStart={SYNTH.start}"
+
+    def test_shell_launch_calls_the_same_script(self):
+        """A terminal launch and a boot launch must not be able to disagree."""
+        assert str(SYNTH.start) in render_launch_functions(SYNTH)
+
+    def test_shell_launch_does_not_create_a_session_itself(self):
+        fns = render_launch_functions(SYNTH)
+        assert "tmux new-session" not in fns, "the shell must delegate starting, not repeat it"
+
+    def test_start_script_is_executable_shell(self):
+        assert render_start(SYNTH).startswith("#!/bin/bash")
+
+
+class TestIdentityIsNotTakenFromTheName:
+    """The failure this rewrite exists to prevent: on 2026-07-29 an unrelated ssh
+    login owned the tmux session name, `has-session` matched, and launch attached
+    to a shell while the harness stayed down for days with nothing logged."""
+
+    def test_the_registry_and_the_process_table_are_both_consulted(self):
+        start = render_start(SYNTH)
+        assert str(SYNTH.registry) in start        # registry: keyed by supervisor pid
+        assert "kill -0" in start                  # an entry outlives its process
+        assert "ps -o args=" in start              # and a pid can be recycled
+
+    def test_a_present_but_foreign_session_is_refused_not_reused(self):
+        start = render_start(SYNTH)
+        assert "exit 3" in start
+        assert "rename-session" in start, "the remedy must be named, not left to the reader"
+
+    @pytest.mark.parametrize("render", [render_unit, render_start, render_launch_functions, render_child])
+    def test_every_tmux_target_matches_the_session_exactly(self, render):
+        """tmux resolves `-t name` by PREFIX. `-t thm` matches "thm-stale-ssh",
+        which is the very name an operator gives the imposter while moving it
+        aside — so the remedy for a name collision did not resolve it. Measured
+        on tmux 3.6."""
+        for line in _code_only(render(SYNTH)).splitlines():
+            for marker in ("has-session -t ", "send-keys -t ", "attach -t ", "attach -d -t "):
+                if marker in line:
+                    target = line.split(marker, 1)[1].lstrip()
+                    assert target.startswith(("=", '"=')), f"loose target in: {line.strip()}"
+
+    def test_pgrep_is_not_used_for_liveness(self):
+        """pgrep -f on the supervisor's command line matches the TMUX SERVER,
+        which keeps that command in its own argv — it reported a live supervisor
+        nine days after the supervisor exited (measured 2026-08-07). This is the
+        same mistake as trusting the name, one level down."""
+        assert "pgrep" not in _code_only(render_start(SYNTH))
+        assert "pgrep" not in _code_only(render_launch_functions(SYNTH))
+
+
+class TestRegistryPathIsResolvedNotRestated:
+    """The registry moved from a shared /tmp path to a per-user one because the
+    shared directory is owned by whichever uid creates it first. A stale copy of
+    the old literal does not crash — it matches nothing, so `stop` stops nothing
+    and `is it running` always answers no."""
+
+    @pytest.mark.parametrize("render", [render_unit, render_start, render_launch_functions])
+    def test_no_render_hardcodes_the_superseded_shared_path(self, render):
+        assert "/tmp/macf/auto-restart" not in render(SYNTH)
+
+    def test_stop_looks_where_the_supervisor_actually_writes(self):
+        (stop,) = [l for l in render_unit(SYNTH).splitlines() if l.startswith("ExecStop=")]
+        assert str(SYNTH.registry) in stop
+
+    def test_the_default_comes_from_the_supervisor_itself(self):
+        from macf.supervisor import REGISTRY_DIR
+        unpinned = HarnessParams(
+            agent="testbot", home=Path("/opt/agents/testbot"),
+            python=Path("/opt/py/bin/python3"), macf_tools=Path("/opt/py/bin/macf_tools"),
+            child_path=Path("/opt/agents/testbot/.local/bin/maceff_cc_child_testbot"),
+        )
+        assert unpinned.registry == REGISTRY_DIR
 
 
 class TestNoHostIdentifiersLeak:
@@ -120,6 +254,9 @@ class TestNoHostIdentifiersLeak:
     @pytest.mark.parametrize("render", [
         lambda: render_unit(SYNTH),
         lambda: render_unit(SYNTH, attach_proxy=False),
+        lambda: render_start(SYNTH),
+        lambda: render_start(SYNTH, attach_proxy=False),
+        lambda: render_launch_functions(SYNTH),
         lambda: render_child(SYNTH),
         lambda: render_tmux_conf(SYNTH),
     ])
@@ -153,6 +290,141 @@ class TestChildEntrypoint:
 
     def test_session_name_defaults_to_the_agent(self):
         assert 'MACEFF_TMUX_SESSION:-testbot' in render_child(SYNTH)
+
+    def test_channels_are_absent_unless_declared(self):
+        """No default: a guessed channel is a claim about reachability."""
+        assert "--channels" not in _code_only(render_child(SYNTH))
+
+    def test_declared_channels_reach_the_client(self):
+        """Dropping these costs no error and no log line — the session comes up
+        and the agent is simply unreachable, which is the worst way to fail for
+        the unattended case the harness exists to serve."""
+        from dataclasses import replace
+        p = replace(SYNTH, channels=("plugin:a@x", "plugin:b@y"))
+        (line,) = [l for l in render_child(p).splitlines() if l.startswith("exec claude")]
+        assert line == 'exec claude -c --channels plugin:a@x,plugin:b@y "$@"'
+
+
+needs_tmux = pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not available")
+
+
+@needs_tmux
+class TestStartScriptBehaviour:
+    """Run the rendered script rather than only reading it.
+
+    Asserting on render text is how a scope defect shipped elsewhere in this
+    codebase: every string assertion passed while the thing examined the wrong
+    set. These tests execute the script against a private tmux server
+    (TMUX_TMPDIR) and a private registry directory, so the outcomes are observed
+    rather than inferred.
+    """
+
+    @pytest.fixture
+    def sandbox(self, tmp_path):
+        reg = tmp_path / "registry"
+        reg.mkdir()
+        sock = tmp_path / "tmuxdir"
+        sock.mkdir()
+        p = HarnessParams(
+            agent="probe", home=tmp_path,
+            python=Path("/bin/sleep"), macf_tools=Path("/bin/true"),
+            child_path=Path("/bin/true"), registry_dir=reg,
+        )
+        script = tmp_path / "start"
+        script.write_text(render_start(p, attach_proxy=False))
+        script.chmod(0o755)
+        env = {**os.environ, "TMUX_TMPDIR": str(sock)}
+        yield script, reg, env
+        subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
+
+    def _run(self, script, env):
+        return subprocess.run([str(script)], env=env, capture_output=True, text=True)
+
+    def _fake_supervisor(self, reg, name="probe"):
+        """A process the guard should accept: alive, and looking like a
+        supervisor to `ps`, registered under its own pid."""
+        proc = subprocess.Popen(
+            ["bash", "-c",
+             f'exec -a "python3 -m macf.supervisor _run_loop --name {name}" sleep 30'])
+        (reg / f"{proc.pid}.json").write_text(
+            f'{{"supervisor_pid": {proc.pid}, "name": "{name}", "status": "running"}}')
+        return proc
+
+    def test_creates_a_session_when_nothing_holds_the_name(self, sandbox):
+        script, _reg, env = sandbox
+        r = self._run(script, env)
+        assert r.returncode == 0
+        assert "started session" in r.stdout
+
+    def test_a_session_whose_name_merely_starts_with_the_agent_is_not_ours(self, sandbox):
+        """The live regression: renaming the imposter to "<agent>-stale-ssh" did
+        NOT free the name, because tmux matched it by prefix for nine more days."""
+        script, _reg, env = sandbox
+        subprocess.run(["tmux", "new-session", "-d", "-s", "probe-stale-ssh", "sleep 30"],
+                       env=env, check=True)
+        r = self._run(script, env)
+        assert r.returncode == 0, r.stderr
+        assert "started session" in r.stdout
+        sessions = subprocess.run(["tmux", "list-sessions", "-F", "#{session_name}"],
+                                  env=env, capture_output=True, text=True).stdout.split()
+        assert "probe" in sessions and "probe-stale-ssh" in sessions
+
+    def test_refuses_a_session_name_held_by_something_else(self, sandbox):
+        """THE regression. A name-only guard returns 'already running' here and
+        the harness silently never starts."""
+        script, _reg, env = sandbox
+        subprocess.run(["tmux", "new-session", "-d", "-s", "probe", "sleep 30"],
+                       env=env, check=True)
+        r = self._run(script, env)
+        assert r.returncode == 3
+        assert "not this harness" in r.stderr
+        # and it must not have started a second thing alongside the imposter
+        panes = subprocess.run(["tmux", "list-panes", "-t", "probe", "-F", "#{pane_pid}"],
+                               env=env, capture_output=True, text=True).stdout.split()
+        assert len(panes) == 1
+
+    def test_is_a_no_op_when_this_harness_is_already_up(self, sandbox):
+        script, reg, env = sandbox
+        proc = self._fake_supervisor(reg)
+        try:
+            subprocess.run(["tmux", "new-session", "-d", "-s", "probe", "sleep 30"],
+                           env=env, check=True)
+            r = self._run(script, env)
+            assert r.returncode == 0
+            assert "already running" in r.stdout
+        finally:
+            proc.kill(); proc.wait()
+
+    def test_refuses_to_start_a_second_client_for_a_live_supervisor(self, sandbox):
+        """One agent with two clients on one task store is the state BUG #66
+        describes; a missing session is not a reason to add another."""
+        script, reg, env = sandbox
+        proc = self._fake_supervisor(reg)
+        try:
+            r = self._run(script, env)
+            assert r.returncode == 3
+            assert "session 'probe' is gone" in r.stderr
+        finally:
+            proc.kill(); proc.wait()
+
+    def test_a_registry_entry_whose_process_died_does_not_count(self, sandbox):
+        """Entries outlive their processes — the live host had seven of them,
+        one 'running' for a supervisor that exited nine days earlier."""
+        script, reg, env = sandbox
+        proc = self._fake_supervisor(reg)
+        proc.kill(); proc.wait()
+        r = self._run(script, env)
+        assert r.returncode == 0
+        assert "started session" in r.stdout
+
+    def test_an_entry_for_a_different_agent_does_not_count(self, sandbox):
+        script, reg, env = sandbox
+        proc = self._fake_supervisor(reg, name="someone-else")
+        try:
+            r = self._run(script, env)
+            assert r.returncode == 0, "another agent's supervisor is not ours"
+        finally:
+            proc.kill(); proc.wait()
 
 
 class TestStopTargetsTheSupervisor:

--- a/macf/tests/test_harness_runtime.py
+++ b/macf/tests/test_harness_runtime.py
@@ -93,6 +93,7 @@ class Probe:
         self.bin = tmp_path / "bin"
         self.bin.mkdir(exist_ok=True)
         self.macf_tools = tmp_path / "macf_tools"
+        self.pane_marker = "PANE-MARKER-" + uuid.uuid4().hex[:8]
 
     def install_client(self, mode="stay", lifetime=0.5, exit_code=0):
         """A fake client that records the world it was handed, then behaves.
@@ -117,6 +118,12 @@ class Probe:
             f"with open({str(self.reports)!r}, 'a') as fh:\n"
             "    fh.write(json.dumps(rec) + '\\n')\n"
             "    fh.flush()\n"
+            # Print to the PANE as well. The log test needs the client to
+            # render something: driving the pane with send-keys and relying on
+            # tty echo tests the terminal's line discipline, not whether the
+            # CLIENT's output reaches the log, which is the property that
+            # matters. A real client is never silent.
+            f"print({self.pane_marker!r}, flush=True)\n"
             f"mode, lifetime, code = {mode!r}, {lifetime!r}, {exit_code!r}\n"
             "if mode == 'stay':\n"
             "    time.sleep(3600)\n"
@@ -237,6 +244,62 @@ class TestTheClientKeepsTheTerminalItWasGiven:
             "correctly treats as a clean exit and restarts -- a loop in which "
             "no layer is misbehaving."
         )
+
+
+class TestTheLogIsStillWritten:
+    """Replacing a redirect with `pipe-pane` swapped a mechanism that certainly
+    logged for one that might not.
+
+    `tmux pipe-pane` fails quietly when its target does not resolve, and the
+    wrapper appends `|| true` so a failure cannot take the session down. Both
+    are correct choices and together they mean a broken pipe-pane is INVISIBLE:
+    the client comes up, the pane looks right, and the log is simply empty.
+    That is the same shape as the defect this whole tier exists for -- and the
+    log is the only diagnostic surface for it, so losing it silently would cost
+    the next investigation everything it cost this one.
+
+    Removing an instrument is a change to the system; it needs its own test.
+    """
+
+    def test_pane_output_reaches_the_log(self, probe):
+        probe.install_client(mode="stay")
+        wrapper = probe.render_wrapper()
+        log = probe.dir / ".maceff" / f"harness_{probe.session}.log"
+        probe.start_pane(str(wrapper))
+        probe.wait_for_records(1)
+
+        # The client prints a unique marker to the pane. Assert on THAT rather
+        # than on echoed keystrokes: send-keys plus tty echo would exercise the
+        # terminal's line discipline, while the property under test is whether
+        # the CLIENT's own output reaches the log.
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if log.exists() and probe.pane_marker in log.read_text(errors="replace"):
+                return
+            time.sleep(0.25)
+
+        contents = log.read_text(errors="replace") if log.exists() else "<no file>"
+        pytest.fail(
+            f"the client's output never reached {log}. pipe-pane fails quietly "
+            f"and a log holding only the start banner looks exactly like a "
+            f"working one.\n--- log contents ---\n{contents}"
+        )
+
+    def test_the_start_banner_is_recorded(self, probe):
+        """Every launch appends a timestamped marker. The start SEQUENCE is what
+        makes a restart loop legible, so this line is not decoration -- it is
+        the primary evidence, and it was what finally distinguished a real loop
+        (five starts in twenty-six seconds) from three isolated restarts."""
+        probe.install_client(mode="stay")
+        probe.start_pane(str(probe.render_wrapper()))
+        probe.wait_for_records(1)
+        log = probe.dir / ".maceff" / f"harness_{probe.session}.log"
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if log.exists() and "starting:" in log.read_text(errors="replace"):
+                return
+            time.sleep(0.25)
+        pytest.fail("no start marker was written; a loop would leave no trace")
 
 
 class TestARestartLoopIsVisibleAsASequence:

--- a/macf/tests/test_harness_runtime.py
+++ b/macf/tests/test_harness_runtime.py
@@ -1,0 +1,275 @@
+"""Runtime tier: the harness as a SUBJECT, observed from outside itself.
+
+Why this file exists, and why the existing tiers could not have caught the
+defect that motivated it.
+
+`test_harness_render.py` asserts on the TEXT the generator produces.
+`test_harness_integration.py` EXECUTES the generated wrapper and asserts on the
+argv it builds -- a real improvement, and it caught the variadic `--channels`
+defect. But it runs the wrapper with `stdout=subprocess.DEVNULL` and no
+controlling terminal, and those are precisely the two conditions under which a
+wrapper that REDIRECTS the client's stdout is invisible. A test that has already
+thrown the client's stdout away cannot notice that something else threw it away
+first. The tier was structurally incapable of the finding, which is a different
+thing from having missed it.
+
+Two properties of this subsystem defeat in-situ debugging and dictate the shape
+here:
+
+1. **Observation participates.** Instrumenting the harness changes it. The
+   logging added to diagnose a restart loop is itself a redirection of the
+   client's stdout. The measuring device sits inside the circuit, so the only
+   trustworthy measurement is one taken by a process that is not the subject.
+
+2. **The debugger is the subject.** An agent debugging its own harness dies when
+   the harness restarts, so it can never observe its own restart -- only read a
+   log written by the process that died. Hypotheses cannot survive their own
+   experiment.
+
+So: a real tmux pane (so a terminal exists to be lost), the real supervisor, a
+fake client that REPORTS what it actually received, and observation across
+wall-clock time. A restart loop is a property of a SEQUENCE of starts; no
+single-point observation can express one, which is how a loop got read as a
+clean restart-in-place.
+
+Fixtures are torn down unconditionally and strays are reaped at session start
+and end -- a probe that outlives its probing is a tmux session nobody owns.
+"""
+
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from macf.utils.harness import HarnessParams, render_child
+
+PROBE_PREFIX = "maceff-probe-"
+
+pytestmark = pytest.mark.skipif(
+    subprocess.run(["which", "tmux"], capture_output=True).returncode != 0,
+    reason="runtime tier needs tmux: the property under test is the presence of a terminal",
+)
+
+
+def _tmux(*args, **kw):
+    return subprocess.run(["tmux", *args], capture_output=True, text=True, **kw)
+
+
+def _live_probe_sessions():
+    r = _tmux("list-sessions", "-F", "#{session_name}")
+    if r.returncode != 0:
+        return []
+    return [s for s in r.stdout.split() if s.startswith(PROBE_PREFIX)]
+
+
+def _reap():
+    """Kill any probe session. Exact-match targeting (`=name`): tmux resolves a
+    bare name as a prefix, so `kill-session -t maceff-probe` would also match a
+    real agent session that happened to share the prefix."""
+    for name in _live_probe_sessions():
+        _tmux("kill-session", "-t", f"={name}")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _no_stray_probes():
+    """Reap before and after the whole run, so a crashed test cannot leave a
+    session running past the probing it belonged to."""
+    _reap()
+    yield
+    _reap()
+
+
+class Probe:
+    """One isolated harness subject: its own tmux session, client, and spool."""
+
+    def __init__(self, tmp_path):
+        self.dir = tmp_path
+        self.session = PROBE_PREFIX + uuid.uuid4().hex[:8]
+        self.reports = tmp_path / "client_reports.jsonl"
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir(exist_ok=True)
+        self.macf_tools = tmp_path / "macf_tools"
+
+    def install_client(self, mode="stay", lifetime=0.5, exit_code=0):
+        """A fake client that records the world it was handed, then behaves.
+
+        `mode='stay'` holds the pane like a healthy interactive client.
+        `mode='exit'` returns `exit_code` after `lifetime` -- the shape of a
+        client that gives up cleanly, which is the case indistinguishable from
+        an operator typing /exit.
+        """
+        client = self.bin / "claude"
+        client.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys, time\n"
+            "rec = {\n"
+            "    'argv': sys.argv[1:],\n"
+            "    'stdin_tty': os.isatty(0),\n"
+            "    'stdout_tty': os.isatty(1),\n"
+            "    'stderr_tty': os.isatty(2),\n"
+            "    'pid': os.getpid(),\n"
+            "    'started': time.time(),\n"
+            "}\n"
+            f"with open({str(self.reports)!r}, 'a') as fh:\n"
+            "    fh.write(json.dumps(rec) + '\\n')\n"
+            "    fh.flush()\n"
+            f"mode, lifetime, code = {mode!r}, {lifetime!r}, {exit_code!r}\n"
+            "if mode == 'stay':\n"
+            "    time.sleep(3600)\n"
+            "time.sleep(lifetime)\n"
+            "sys.exit(code)\n"
+        )
+        client.chmod(0o755)
+
+        self.macf_tools.write_text(
+            '#!/bin/bash\n[ "$1" = mode ] && echo MANUAL_MODE\nexit 0\n'
+        )
+        self.macf_tools.chmod(0o755)
+        return client
+
+    def render_wrapper(self):
+        wrapper = self.dir / "child"
+        wrapper.write_text(
+            render_child(
+                HarnessParams(
+                    agent=self.session,
+                    home=self.dir,
+                    python=Path("/bin/true"),
+                    macf_tools=self.macf_tools,
+                    child_path=wrapper,
+                    registry_dir=self.dir / "reg",
+                )
+            )
+        )
+        wrapper.chmod(0o755)
+        return wrapper
+
+    def start_pane(self, command):
+        """Run `command` in a detached tmux session -- a real pane, therefore a
+        real terminal on all three descriptors."""
+        env = f'PATH={self.bin}:{os.environ["PATH"]}'
+        _tmux("new-session", "-d", "-s", self.session,
+              f"env {env} {command}")
+
+    def records(self):
+        if not self.reports.exists():
+            return []
+        return [json.loads(l) for l in self.reports.read_text().splitlines() if l.strip()]
+
+    def wait_for_records(self, n, timeout=20):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if len(self.records()) >= n:
+                return self.records()
+            time.sleep(0.25)
+        return self.records()
+
+    def kill(self):
+        _tmux("kill-session", "-t", f"={self.session}")
+
+
+@pytest.fixture
+def probe(tmp_path):
+    p = Probe(tmp_path)
+    try:
+        yield p
+    finally:
+        p.kill()
+
+
+class TestTheFixtureIsolatesAndCleansUp:
+    """The fixture is itself a subject. A probe that leaks sessions is worse
+    than no probe: it makes the host's tmux state a function of test history."""
+
+    def test_the_probe_runs_in_its_own_session(self, probe):
+        probe.install_client(mode="stay")
+        probe.start_pane(str(probe.render_wrapper()))
+        probe.wait_for_records(1)
+        assert probe.session in _live_probe_sessions()
+
+    def test_no_probe_session_survives_teardown(self, tmp_path):
+        p = Probe(tmp_path)
+        p.install_client(mode="stay")
+        p.start_pane(str(p.render_wrapper()))
+        p.wait_for_records(1)
+        assert p.session in _live_probe_sessions()
+        p.kill()
+        deadline = time.time() + 5
+        while time.time() < deadline and p.session in _live_probe_sessions():
+            time.sleep(0.2)
+        assert p.session not in _live_probe_sessions()
+
+
+class TestTheClientKeepsTheTerminalItWasGiven:
+    """The defect this tier was built for.
+
+    A tmux pane hands the child a terminal on all three descriptors. Anything
+    the wrapper does to stdout before exec'ing the client is done to the
+    client's terminal, and a terminal is not a detail -- it is what an
+    interactive client checks to decide whether it is interactive at all.
+    """
+
+    def test_a_bare_pane_gives_the_client_a_terminal(self, probe):
+        """Positive control. Without it, a failure below is unattributable:
+        `stdout_tty is False` would be equally consistent with 'the wrapper
+        redirected it' and 'this test never had a terminal to begin with'."""
+        probe.install_client(mode="stay")
+        probe.start_pane(f"{probe.bin}/claude --no-wrapper")
+        recs = probe.wait_for_records(1)
+        assert recs, "the client never ran; the probe, not the subject, is broken"
+        assert recs[0]["stdout_tty"] is True
+        assert recs[0]["stdin_tty"] is True
+
+    def test_the_wrapper_does_not_take_the_terminal_away(self, probe):
+        """The wrapper must not leave the client's stdout a pipe."""
+        probe.install_client(mode="stay")
+        probe.start_pane(str(probe.render_wrapper()))
+        recs = probe.wait_for_records(1)
+        assert recs, "the client never ran under the wrapper"
+        assert recs[0]["stdout_tty"] is True, (
+            "the wrapper replaced the client's stdout with a pipe. An "
+            "interactive client that cannot see a terminal may decline to be "
+            "interactive: it renders once and exits 0, which the supervisor "
+            "correctly treats as a clean exit and restarts -- a loop in which "
+            "no layer is misbehaving."
+        )
+
+
+class TestARestartLoopIsVisibleAsASequence:
+    """A loop cannot be observed at a point. These assert on the SHAPE of the
+    start sequence over time, which is the observation that was missing when a
+    loop was read as a deliberate exit."""
+
+    def test_a_healthy_client_is_started_exactly_once(self, probe):
+        probe.install_client(mode="stay")
+        probe.start_pane(
+            f"/usr/bin/env python3 -m macf.supervisor _run_loop "
+            f"--name {probe.session} --delay 1 --tmux-session {probe.session} "
+            f"-- {probe.bin}/claude"
+        )
+        probe.wait_for_records(1)
+        time.sleep(4)
+        assert len(probe.records()) == 1, (
+            f"a client that stays up was restarted: {probe.records()}"
+        )
+
+    def test_a_client_that_exits_zero_produces_a_detectable_loop(self, probe):
+        """Negative control on the detector itself: plant the defect and
+        require the observation to fire. A loop detector never seen to detect a
+        loop is not a detector."""
+        probe.install_client(mode="exit", lifetime=0.3, exit_code=0)
+        probe.start_pane(
+            f"/usr/bin/env python3 -m macf.supervisor _run_loop "
+            f"--name {probe.session} --delay 1 --tmux-session {probe.session} "
+            f"-- {probe.bin}/claude"
+        )
+        recs = probe.wait_for_records(3, timeout=25)
+        assert len(recs) >= 3, (
+            f"expected repeated starts from a client that exits 0; saw {len(recs)}"
+        )
+        span = recs[-1]["started"] - recs[0]["started"]
+        assert span < 20, "starts should cluster; a loop is starts-per-time"

--- a/macf/tests/test_operational_invariants.py
+++ b/macf/tests/test_operational_invariants.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from macf.utils.harness import HarnessParams, render_unit
+from macf.utils.harness import HarnessParams, render_start, render_unit
 
 SYNTH = HarnessParams(
     agent="testbot",
@@ -39,10 +39,28 @@ PROXY_SRC = (
 # holds. Kept tiny and total so a negative control can exercise them directly.
 # --------------------------------------------------------------------------
 
-def check_escaped_variable(unit: str) -> bool:
-    """Shell variables in Exec* survive the service manager's own expansion."""
-    exec_lines = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
-    return all("$${BASE}" in l for l in exec_lines if "BASE=" in l)
+def check_no_shell_expansion_in_exec(unit: str) -> bool:
+    """Exec* carries no shell variable for the service manager to eat.
+
+    Strengthened from its original form. The invariant used to be "a shell
+    variable in Exec* must be written $${VAR} so a literal ${VAR} reaches the
+    shell", which is true but only defends a hazard we chose to keep. Exec* now
+    invokes a script, so there is no shell variable in the unit at ALL and the
+    hazard is gone by construction rather than by remembering to escape.
+
+    An unescaped ${VAR} would be replaced from the UNIT's environment before any
+    shell ran; a correctly escaped one still means the unit carries launch logic
+    that something else also carries. Absence is the stronger property.
+    """
+    for line in unit.splitlines():
+        if not line.startswith(("ExecStart=", "ExecStop=", "ExecStartPre=")):
+            continue
+        # ExecStop legitimately uses shell parameter expansion in a loop it owns
+        # outright; the rule is about the LAUNCH path carrying a variable that
+        # systemd will expand out from under it.
+        if line.startswith("ExecStart=") and ("$" in line):
+            return False
+    return True
 
 
 def check_restart_responsibility_is_explicit(unit: str) -> bool:
@@ -109,17 +127,30 @@ def _unit() -> str:
     return render_unit(SYNTH)
 
 
+def _start() -> str:
+    """The launch decision moved here, and its invariants moved with it.
+
+    Leaving them pointed at the unit is how an invariant quietly stops covering
+    anything: the checker still passes, on text that no longer contains the
+    thing it was written to protect. Both negative controls below caught exactly
+    that — they failed with "mutation was a no-op", which is the check reporting
+    that it had nothing to check.
+    """
+    return render_start(SYNTH)
+
+
 INVARIANTS = [
     (
-        "escaped-variable",
+        "no-shell-expansion-in-exec",
         _unit,
-        check_escaped_variable,
-        lambda u: u.replace("$${BASE}", "${BASE}"),
+        check_no_shell_expansion_in_exec,
+        lambda u: u.replace("ExecStart=", "ExecStart=/bin/bash -c '${BASE}", 1),
         "The service manager expands ${VAR} in Exec* from the UNIT's environment "
         "before any shell runs. An unescaped ${BASE} was replaced with an empty "
         "string, so the shell's own assignment never mattered and the proxy "
         "opt-in was silently inert — the only trace was a 'Referenced but unset "
-        "environment variable' line in the journal.",
+        "environment variable' line in the journal. ExecStart now invokes a "
+        "script and carries no variable at all, so the hazard cannot recur.",
     ),
     (
         "restart-responsibility",
@@ -144,7 +175,7 @@ INVARIANTS = [
     ),
     (
         "flag-travels-with-base-url",
-        _unit,
+        _start,
         check_flag_travels_with_base_url,
         lambda u: u.replace(" _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 ", " "),
         "When the API base URL's host is not the default, the client stops "

--- a/macf/tests/test_session_identifier.py
+++ b/macf/tests/test_session_identifier.py
@@ -1,0 +1,156 @@
+"""Calling Card → session identifier, and the harness agent resolver.
+
+Session-management identity used to be a second, unregistered namespace: the
+harness named its tmux session and systemd unit after a nickname that appeared
+nowhere else in the framework. An operator holding the Calling Card could not
+derive the session name, a tool holding the session name could not recover the
+Calling Card, and `harness status` therefore had no default it could resolve —
+so it guessed, and reported the guess as a finding.
+
+The character rules asserted here were MEASURED on 2026-08-07 (tmux 3.6,
+systemd 257), not read from documentation. The measurement mattered: it refuted
+the claim in the originating issue that '@' had to be substituted for systemd's
+sake. It does not — a concrete unit named `cc-harness-Name@abc.service` enables,
+symlinks, starts and reports active. '@' is substituted by convention, because
+that is how systemd spells a template instance. The two reasons are different
+and only one of them is a constraint.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from macf.utils.harness import installed_agents, resolve_agent
+from macf.utils.identity import (
+    calling_card_from_identifier,
+    session_identifier,
+)
+
+CARD = "TheHarborMaster@ee5cd8"
+IDENT = "TheHarborMaster_ee5cd8"
+
+
+class TestSubstitution:
+    def test_the_calling_card_maps_to_a_derivable_identifier(self):
+        assert session_identifier(CARD) == IDENT
+
+    def test_an_operator_can_get_back_from_the_identifier_to_the_agent(self):
+        """The direction that lets status name the agent behind a session."""
+        assert calling_card_from_identifier(IDENT) == CARD
+
+    def test_a_moniker_containing_the_separator_survives_the_round_trip(self):
+        """Split on the LAST separator: the one that was the '@'."""
+        assert calling_card_from_identifier(session_identifier("Under_Score@ff0011")) == "Under_Score@ff0011"
+
+    @pytest.mark.parametrize("card", [
+        "A.B@abc123",     # tmux rewrites '.' silently
+        "A:B@abc123",     # tmux rewrites ':' silently; systemd rejects it
+        "A B@abc123",     # whitespace
+        "A/B@abc123",     # path separator
+    ])
+    def test_characters_that_do_not_survive_a_tool_are_substituted(self, card):
+        ident = session_identifier(card)
+        assert not (set(ident) & set(".:/ \t@"))
+
+    def test_runs_are_collapsed(self):
+        """"A..B" and "A_B" differing only by underscore count is a distinction
+        no human reads correctly out of a session list."""
+        assert session_identifier("A..B@abc123") == "A_B_abc123"
+
+    def test_identifier_is_stable(self):
+        assert session_identifier(CARD) == session_identifier(CARD)
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux not available")
+class TestTheSubstitutionIsActuallyNecessary:
+    """Negative controls. Without these the rules above are just assertions —
+    and the originating issue shows how easily an unmeasured assertion about
+    these tools turns out to be wrong."""
+
+    def _roundtrip(self, name, tmp_path):
+        """Create a session under `name`; report the name tmux actually stored."""
+        env = {"TMUX_TMPDIR": str(tmp_path)}
+        subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
+        subprocess.run(["tmux", "new-session", "-d", "-s", name, "sleep 5"],
+                       env=env, capture_output=True)
+        stored = subprocess.run(["tmux", "list-sessions", "-F", "#{session_name}"],
+                                env=env, capture_output=True, text=True).stdout.strip()
+        addressable = subprocess.run(["tmux", "has-session", "-t", f"={name}"],
+                                     env=env, capture_output=True).returncode == 0
+        subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
+        return stored, addressable
+
+    @pytest.mark.parametrize("bad", ["Name.suffix", "Name:suffix"])
+    def test_tmux_silently_rewrites_these_and_the_name_stops_addressing(self, bad, tmp_path):
+        """The failure mode that motivates substituting at all: new-session
+        SUCCEEDS, and the name you asked for addresses nothing afterwards."""
+        stored, addressable = self._roundtrip(bad, tmp_path)
+        assert stored != bad, "tmux accepted this verbatim — the rule may be stale"
+        assert not addressable
+
+    def test_the_substituted_form_survives_and_addresses(self, tmp_path):
+        stored, addressable = self._roundtrip(IDENT, tmp_path)
+        assert stored == IDENT
+        assert addressable
+
+    def test_at_sign_is_a_convention_choice_not_a_tmux_constraint(self, tmp_path):
+        """Recorded so the choice stays revisable: tmux keeps '@' verbatim, so
+        substituting it is ours to reconsider, not a limit we ran into."""
+        stored, addressable = self._roundtrip(CARD, tmp_path)
+        assert stored == CARD
+        assert addressable
+
+
+class TestResolverNeverPassesAGuessOffAsAFinding:
+    def test_an_explicit_flag_wins_and_says_so(self):
+        assert resolve_agent("chosen") == ("chosen", "flag")
+
+    def test_the_environment_override_is_named_as_the_source(self, monkeypatch):
+        monkeypatch.setenv("MACEFF_AGENT_NAME", "fromenv")
+        assert resolve_agent() == ("fromenv", "MACEFF_AGENT_NAME")
+
+    def test_falls_back_to_the_calling_card(self, monkeypatch):
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: CARD)
+        assert resolve_agent() == (IDENT, "calling card")
+
+    def test_a_single_installed_unit_resolves(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: "x@unknown")
+        (tmp_path / "cc-harness-solo.service").write_text("")
+        assert resolve_agent(unit_dir=tmp_path) == ("solo", "the only installed unit")
+
+    def test_several_installed_units_are_listed_rather_than_picked(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: "x@unknown")
+        for n in ("alpha", "beta"):
+            (tmp_path / f"cc-harness-{n}.service").write_text("")
+        agents, source = resolve_agent(unit_dir=tmp_path)
+        assert source == "ambiguous"
+        assert agents == ["alpha", "beta"]
+
+    def test_an_unresolvable_identity_does_not_manufacture_a_name(self, monkeypatch, tmp_path):
+        """'unknown' is what identity returns when no UUID resolves. Deriving a
+        session name from it would invent an identifier for the one agent whose
+        identity could not be established."""
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: "Someone@unknown")
+        assert resolve_agent(unit_dir=tmp_path) == ("agent", "default")
+
+    def test_the_default_is_labelled_as_a_default(self, monkeypatch, tmp_path):
+        """The whole defect in one assertion: the caller must be able to tell a
+        guess from a resolution, because it is the caller that prints ABSENT."""
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: "x@unknown")
+        assert resolve_agent(unit_dir=tmp_path)[1] == "default"
+
+
+class TestInstalledAgents:
+    def test_lists_only_harness_units(self, tmp_path):
+        (tmp_path / "cc-harness-one.service").write_text("")
+        (tmp_path / "unrelated.service").write_text("")
+        assert installed_agents(tmp_path) == ["one"]
+
+    def test_a_missing_unit_directory_is_empty_not_an_error(self, tmp_path):
+        assert installed_agents(tmp_path / "nope") == []

--- a/macf/tests/test_session_identifier.py
+++ b/macf/tests/test_session_identifier.py
@@ -154,3 +154,21 @@ class TestInstalledAgents:
 
     def test_a_missing_unit_directory_is_empty_not_an_error(self, tmp_path):
         assert installed_agents(tmp_path / "nope") == []
+
+
+class TestWatchdogUnitsAreNotAgents:
+    """The watchdog shares the unit-name prefix but is not an agent. Counting it
+    would make resolution ambiguous and break every command that resolves by
+    enumeration — an installed helper disabling the thing it helps."""
+
+    def test_a_watchdog_unit_is_not_enumerated_as_an_agent(self, tmp_path):
+        (tmp_path / "cc-harness-Real_abc123.service").write_text("")
+        (tmp_path / "cc-harness-Real_abc123-watch.service").write_text("")
+        assert installed_agents(tmp_path) == ["Real_abc123"]
+
+    def test_resolution_stays_unambiguous_with_a_watchdog_installed(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MACEFF_AGENT_NAME", raising=False)
+        monkeypatch.setattr("macf.utils.identity.get_agent_identity", lambda: "x@unknown")
+        (tmp_path / "cc-harness-Real_abc123.service").write_text("")
+        (tmp_path / "cc-harness-Real_abc123-watch.service").write_text("")
+        assert resolve_agent(unit_dir=tmp_path) == ("Real_abc123", "the only installed unit")

--- a/macf/tests/test_supervision_diagnostics.py
+++ b/macf/tests/test_supervision_diagnostics.py
@@ -1,0 +1,154 @@
+"""Supervision diagnostics: the facts an agent needs before trusting anything else.
+
+Written after an evening in which "am I running under the harness?" was answered
+by hand at least six times — from ``$TMUX``, ps ancestry walks, tmux
+introspection and greps of the supervisor registry — by the person who had just
+written the harness, and came out wrong twice.
+
+The load-bearing test here is the context-window one. That failure is invisible
+by construction: a non-first-party base URL without the escape-hatch flag drops
+the window to a fifth of what every surface reports, with no log line and no
+error. An alarm for it is only worth having if it has been observed firing, so
+each state has an explicit case.
+"""
+
+import json
+
+import pytest
+
+from macf.supervisor import is_live_supervisor
+from macf.utils.supervision import (
+    FIRST_PARTY_FLAG,
+    context_window_integrity,
+    format_diagnosis,
+)
+
+
+class TestContextWindowIntegrity:
+    def test_no_base_url_is_first_party(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.delenv(FIRST_PARTY_FLAG, raising=False)
+        assert context_window_integrity()["status"] == "direct"
+
+    def test_the_default_host_is_first_party(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+        monkeypatch.delenv(FIRST_PARTY_FLAG, raising=False)
+        assert context_window_integrity()["status"] == "first-party"
+
+    def test_a_proxy_with_the_flag_is_reported_ok(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8019")
+        monkeypatch.setenv(FIRST_PARTY_FLAG, "1")
+        assert context_window_integrity()["status"] == "proxied-ok"
+
+    def test_a_proxy_without_the_flag_is_DEGRADED(self, monkeypatch):
+        """THE check. This state costs 80% of the context window and announces
+        itself nowhere — it recurred the same evening it was fixed, from a shell
+        still holding a pre-fix function."""
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8019")
+        monkeypatch.delenv(FIRST_PARTY_FLAG, raising=False)
+        r = context_window_integrity()
+        assert r["status"] == "DEGRADED"
+        assert FIRST_PARTY_FLAG in r["detail"], "the remedy must be named, not implied"
+
+    def test_the_first_party_host_on_another_port_does_not_pass(self, monkeypatch):
+        """The host comparison includes the port. api.anthropic.com:8443 is NOT
+        first-party to the client, and a check that ignored the port would give
+        a false all-clear to exactly the interception setup that causes this."""
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com:8443")
+        monkeypatch.delenv(FIRST_PARTY_FLAG, raising=False)
+        assert context_window_integrity()["status"] == "DEGRADED"
+
+    def test_a_malformed_base_url_does_not_claim_first_party(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "not a url")
+        monkeypatch.delenv(FIRST_PARTY_FLAG, raising=False)
+        assert context_window_integrity()["status"] == "DEGRADED"
+
+
+class TestLiveSupervisorPredicate:
+    """Three conditions, each excluding a state observed on a live host."""
+
+    def test_a_stopped_entry_is_not_live(self):
+        assert not is_live_supervisor({"status": "stopped", "supervisor_pid": 1})
+
+    def test_an_entry_for_a_dead_pid_is_not_live(self):
+        """Entries outlive their processes; seven stale ones sat in one
+        registry, the oldest still claiming a supervisor nine days gone."""
+        assert not is_live_supervisor({"status": "running", "supervisor_pid": 999999})
+
+    def test_a_live_pid_that_is_not_a_supervisor_is_not_live(self, monkeypatch):
+        """Pids are recycled. An entry pointing at whatever inherited the
+        number is worse than no entry: it asserts health about a stranger."""
+        import os
+        assert not is_live_supervisor({"status": "running", "supervisor_pid": os.getpid()})
+
+    def test_the_predicate_can_say_yes(self, monkeypatch):
+        """Negative control on the predicate itself — three ways to say no and
+        no way to say yes would pass every test above and be useless."""
+        import os
+        monkeypatch.setattr("macf.supervisor.subprocess.run",
+                            lambda *a, **k: type("R", (), {"stdout": "python -m macf.supervisor x"})())
+        assert is_live_supervisor({"status": "running", "supervisor_pid": os.getpid()})
+
+
+class TestFormatting:
+    """A negative must name what was checked; a default must say it is one."""
+
+    def _d(self, **over):
+        base = {
+            "agent": {"identifier": "Agent_abc123", "calling_card": "Agent@abc123",
+                      "resolved_from": "calling card", "is_default": False,
+                      "candidates": None, "installed": []},
+            "supervision": {"supervised": False, "supervisors": [],
+                            "other_live_supervisors": [], "name_collision": False},
+            "session": {"in_tmux": False, "socket": None, "name": None,
+                        "clients_attached": None, "matches_expected": None},
+            "context_window": {"status": "direct", "detail": "no ANTHROPIC_BASE_URL"},
+            "artifacts": {"missing": None},
+        }
+        for k, v in over.items():
+            base[k] = {**base[k], **v}
+        return base
+
+    def test_an_unsupervised_session_says_what_that_costs(self):
+        out = format_diagnosis(self._d())
+        assert "NONE running" in out
+        assert "not supervised" in out
+
+    def test_a_defaulted_agent_is_labelled_a_default(self):
+        """The defect this whole line of work started from: a guessed name
+        reported as a finding, so ABSENT read as 'there is no harness here'."""
+        out = format_diagnosis(self._d(agent={"is_default": True, "identifier": "agent"}))
+        assert "DEFAULT" in out
+
+    def test_a_name_collision_is_called_out(self):
+        out = format_diagnosis(self._d(supervision={"name_collision": True}))
+        assert "COLLISION" in out
+        assert "one task store" in out
+
+    def test_multiple_attached_clients_are_called_out(self):
+        out = format_diagnosis(self._d(
+            session={"in_tmux": True, "name": "s", "clients_attached": 3,
+                     "matches_expected": True}))
+        assert "CLIENTS" in out
+
+    def test_a_session_that_is_not_the_harness_is_called_out(self):
+        out = format_diagnosis(self._d(
+            session={"in_tmux": True, "name": "other", "clients_attached": 1,
+                     "matches_expected": False}))
+        assert "NOT the harness session" in out
+
+    def test_a_degraded_window_is_warned_about(self):
+        out = format_diagnosis(self._d(
+            context_window={"status": "DEGRADED", "detail": "flag not set"}))
+        assert "⚠️" in out and "CONTEXT" in out
+
+
+class TestDiagnoseIsTotal:
+    def test_it_returns_every_section_even_with_nothing_running(self, monkeypatch, tmp_path):
+        from macf.utils import supervision
+        monkeypatch.setattr(supervision, "live_supervisors", lambda: [])
+        monkeypatch.setenv("MACEFF_AGENT_NAME", "probe")
+        d = supervision.diagnose()
+        for key in ("agent", "supervision", "session", "context_window", "artifacts"):
+            assert key in d, f"{key} missing — a diagnostic that omits a section reads as a clean one"
+        assert d["supervision"]["supervised"] is False

--- a/macf/tests/test_supervisor_tmux_sendkeys.py
+++ b/macf/tests/test_supervisor_tmux_sendkeys.py
@@ -63,10 +63,17 @@ def test_tmux_wrap_passes_single_shell_string():
 def _seed_registry(tmp_path, monkeypatch, entries):
     monkeypatch.setattr(sup, "REGISTRY_DIR", tmp_path)
     for data in entries:
+        data = {"status": "running", **data}
         (tmp_path / f"{data['supervisor_pid']}.json").write_text(json.dumps(data))
     # treat every seeded supervisor pid as alive unless overridden
     alive = {e["supervisor_pid"] for e in entries if e.get("_alive", True)}
     monkeypatch.setattr(sup, "_is_alive", lambda pid: pid in alive)
+    # A registry entry describes a live supervisor only if it SAYS it is
+    # running, its pid is alive, AND that pid is still a supervisor. The first
+    # and third were added after a stopped entry with a recycled pid could be
+    # matched; seeding them here keeps the fixture modelling a live supervisor
+    # rather than a file that merely exists.
+    monkeypatch.setattr(sup, "_is_supervisor_process", lambda pid: pid in alive)
 
 
 def test_find_supervisor_by_name(tmp_path, monkeypatch):

--- a/macf/tests/test_supervisor_unlaunchable.py
+++ b/macf/tests/test_supervisor_unlaunchable.py
@@ -1,0 +1,149 @@
+"""A command that can never run must not be retried forever.
+
+The supervisor treated every child exit the same: count it, wait, relaunch. But
+restarting is a response to a process that FAILED, and a command that does not
+exist has not failed — it was never launchable, and no number of retries changes
+that.
+
+Measured before this existed (2026-08-07, live host): with the child binary
+removed, the loop reached three restarts in eight seconds, kept its registry
+entry marked "running", and surfaced nothing. The shell's "command not found"
+went to a tmux pane that had already gone, so from every status surface a
+silently spinning harness was indistinguishable from a healthy one.
+
+Found while verifying a claim that turned out to be wrong. Migrating the harness
+to Calling-Card-derived names orphaned the old child wrapper; the argument for
+deleting it was that a stale shell would then "fail loudly" instead of quietly
+launching a degraded session. It did not fail loudly. The deletion was still
+right, but the reasoning was not, and this is where the real defect lived.
+
+The negative controls are the important half of this file: a child that
+genuinely crashes must still be restarted, or the fix would have replaced an
+infinite loop with a supervisor that gives up on the first hiccup.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from macf.supervisor import _unlaunchable_reason
+
+
+class TestUnlaunchableReason:
+    def test_a_missing_path_is_reported_with_its_path(self, tmp_path):
+        reason = _unlaunchable_reason([str(tmp_path / "nope")])
+        assert reason and "does not exist" in reason
+        assert str(tmp_path / "nope") in reason, "the message must name what is missing"
+
+    def test_a_non_executable_path_is_distinguished_from_a_missing_one(self, tmp_path):
+        f = tmp_path / "present"
+        f.write_text("#!/bin/sh\n")
+        f.chmod(0o644)
+        reason = _unlaunchable_reason([str(f)])
+        assert reason and "not executable" in reason
+
+    def test_an_executable_path_is_launchable(self, tmp_path):
+        f = tmp_path / "ok"
+        f.write_text("#!/bin/sh\nexit 0\n")
+        f.chmod(0o755)
+        assert _unlaunchable_reason([str(f)]) is None
+
+    def test_a_bare_word_is_never_refused_here(self):
+        """The child runs through an interactive shell precisely so aliases and
+        shell functions resolve. Refusing a bare word would break the
+        indirection that invocation exists to provide — the shell gets to
+        decide, and its verdict arrives as an exit code instead."""
+        assert _unlaunchable_reason(["definitely_not_a_command_xyz"]) is None
+        assert _unlaunchable_reason(["claude"]) is None
+
+    def test_an_empty_command_is_refused(self):
+        assert _unlaunchable_reason([]) is not None
+
+
+def _run_supervisor(tmp_path, name, target, delay=1, timeout=20):
+    """Run a real supervisor against an isolated registry; return (rc, output)."""
+    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path)}
+    try:
+        r = subprocess.run(
+            [sys.executable, "-m", "macf.supervisor", "_run_loop",
+             "--name", name, "--delay", str(delay), "--", target],
+            env=env, capture_output=True, text=True, timeout=timeout)
+        return r.returncode, r.stdout + r.stderr
+    except subprocess.TimeoutExpired as e:
+        out = (e.stdout or b"") + (e.stderr or b"")
+        return None, out.decode(errors="replace")
+
+
+def _registry(tmp_path, name):
+    d = tmp_path / "macf" / "auto-restart"
+    for f in d.glob("*.json") if d.is_dir() else []:
+        data = json.loads(f.read_text())
+        if data.get("name") == name:
+            return data
+    return None
+
+
+def _script(tmp_path, name, body):
+    f = tmp_path / name
+    f.write_text(textwrap.dedent(body))
+    f.chmod(0o755)
+    return str(f)
+
+
+class TestSupervisorRefusesTheUnlaunchable:
+    def test_a_missing_child_is_refused_before_anything_is_registered(self, tmp_path):
+        """No registry entry: a supervisor that never supervised anything must
+        not leave a record saying it is running."""
+        rc, out = _run_supervisor(tmp_path, "t", str(tmp_path / "gone"))
+        assert rc == 1, "a refusal must exit non-zero or the service manager reads it as success"
+        assert "REFUSING TO START" in out
+        assert _registry(tmp_path, "t") is None
+
+    def test_an_unresolvable_command_stops_instead_of_spinning(self, tmp_path):
+        """The case the pre-flight cannot see: the shell resolves the name, not
+        the filesystem, so the verdict arrives as exit 127."""
+        rc, out = _run_supervisor(tmp_path, "t", "definitely_not_a_command_xyz")
+        assert rc == 1
+        assert "FATAL" in out
+        assert out.count("Restart #") == 0, "it must not have entered the restart loop"
+
+    def test_giving_up_is_recorded_as_failed_not_stopped(self, tmp_path):
+        """"stopped" means someone asked it to stop. Overwriting "failed" with
+        it erases the only signal that says the supervisor could not run what it
+        was given."""
+        _run_supervisor(tmp_path, "t", "definitely_not_a_command_xyz")
+        reg = _registry(tmp_path, "t")
+        assert reg is not None
+        assert reg["status"] == "failed"
+        assert "not found" in reg.get("failure_reason", "")
+
+
+class TestSupervisionStillWorks:
+    """Negative controls. Without these the fix above could have replaced an
+    infinite retry loop with a supervisor that quits at the first exit."""
+
+    def test_a_child_that_genuinely_crashes_is_still_restarted(self, tmp_path):
+        crasher = _script(tmp_path, "crasher", """\
+            #!/bin/bash
+            exit 1
+            """)
+        rc, out = _run_supervisor(tmp_path, "t", crasher, delay=1, timeout=10)
+        assert out.count("Restart #") >= 2, "supervision must survive a crashing child"
+        assert "FATAL" not in out
+
+    def test_exit_127_from_a_long_lived_child_is_not_treated_as_never_launched(self, tmp_path):
+        """A child is entitled to exit 127 as its own considered result. Pairing
+        the code with the lifetime is what separates "the shell could not find
+        it" from "the program ran and returned that"."""
+        late = _script(tmp_path, "late", """\
+            #!/bin/bash
+            sleep 4
+            exit 127
+            """)
+        rc, out = _run_supervisor(tmp_path, "t", late, delay=1, timeout=16)
+        assert "FATAL" not in out
+        assert out.count("Restart #") >= 1


### PR DESCRIPTION
Four commits, all from one evening of the harness failing in ways that produced no error message. Each defect hid the next.

## What was broken

**The shell entry points were the last hand-maintained copy of the harness.** The unit and child wrapper had been moved into the generator precisely because a stored copy drifts from a live one; the shell functions were left behind and drifted worse — a terminal launch set `ANTHROPIC_BASE_URL` **without** `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`, so the operator's own session ran on a fifth of the context window it reported, for a week.

**The idempotence guard trusted a session NAME.** An unrelated ssh login held the name; the guard matched, launch attached to a shell, and the harness stayed down for nine days with nothing logged.

**tmux resolves `-t` targets by PREFIX.** `-t thm` matches `thm-stale-ssh` — so renaming the imposter aside, the obvious remedy, did not free the name. Every `-t` is now written `=name`.

**`ExecStop` looked in a registry path the supervisor had already left.** A stale path does not crash; it matches nothing, so `systemctl --user stop` silently stopped nothing.

**A resume with no prompt can be refused outright.** `claude -c` printed `No deferred tool marker found in the resumed session … Provide a prompt to continue the conversation` and exited 1; the supervisor correctly retried, turning an unsatisfiable command into an unbounded loop. Measured A/B, same conversation, same minute: no prompt → exit 1 every time; with a prompt → the client came up.

**And none of it was diagnosable**, because a tmux pane vanishes with its command, discarding the only copy of the error. The same failure presented three times as `[exited]` and a shell prompt.

## What changed

- **One start script** that systemd and the shell both call. Two implementations are what allowed the flag to go missing from one of them.
- **Identity from the Calling Card** (closes #209): the session and unit derive from it, so an operator holding one can derive the other, and `harness status` can resolve its own subject instead of guessing `agent` and reporting ABSENT for a running harness. What the machine *names* and what a human *types* stay separate identifiers on purpose.
- **`remain-on-exit` + a child log**, so a failed launch leaves evidence. This is what found the resume defect, on its first outing.
- **An opt-in watchdog** (`install --watchdog`) for the structural gap: the supervisor is a *child* of the tmux server, so it dies with it, and the boot unit is `oneshot`+`RemainAfterExit`.
- **`macf_tools env` reports supervision, session and context-window integrity** (idea #077). The window check is load-bearing: that failure costs 80% of the window with no log line, and it recurred the same evening it was fixed.
- **Supervisor refuses a command that can never run** rather than retrying it forever, and records `failed` rather than `stopped`.
- **A policy** — `base/infrastructure/agent_harness.md`. The generator had shipped with none, and this changes what an operator types.

## Evidence

**1368 tests pass, 0 fail.** New coverage is negative-controlled throughout: a genuinely crashing child must still restart; a child that sleeps then exits 127 must not be treated as never-launched; the liveness predicate must be able to say *yes*; `systemd-analyze` must be observed rejecting a broken unit.

Character rules for the identifier were **measured**, not assumed — which refuted the originating issue's own claim that `@` had to be substituted for systemd's sake. It doesn't; that's a convention, and the policy says so, so it stays revisable. The real constraints are `.` and `:`, which tmux *accepts* and then silently rewrites.

Closes #209