### PR TITLE
registry: declared-but-not-participating locations

### DIFF
--- a/macf/src/macf/ideas.py
+++ b/macf/src/macf/ideas.py
@@ -443,6 +443,20 @@ CA_PARTICIPATION: Dict[str, Dict[str, Any]] = {
     # resolves only in some agent's private tree.
     "policies":     {"dirs": [""], "root": "framework",
                      "unit": "all", "node_class": "normative"},
+    # Declared-but-not-participating locations. The scholarship registry rule
+    # is "declare it — participating or explicitly not": these directories
+    # produce real artifacts, so the undeclared-directory check must know
+    # them, but they are deliberately outside the graph and the reason is
+    # recorded here rather than left to be re-derived.
+    "amail":        {"dirs": ["public/amail"], "participates": False,
+                     "reason": "transport copies of correspondence; canonical "
+                               "artifacts attached to a bundle participate from "
+                               "their home locations, so linking the copies "
+                               "would double-count them"},
+    "sprints":      {"dirs": ["public/sprints"], "participates": False,
+                     "reason": "sprint logs are execution records; the claims "
+                               "live in the roadmap and the task store, as "
+                               "with archived todos"},
 }
 
 
@@ -489,6 +503,8 @@ def build_knowledge_graph(scan_dirs: Optional[List[Path]] = None) -> Dict[str, A
             if agent_home:
                 scan_dirs = []
                 for spec in CA_PARTICIPATION.values():
+                    if spec.get("participates", True) is False:
+                        continue
                     if spec.get("root") == "framework":
                         from .utils.manifest import get_framework_policies_path
                         pol = get_framework_policies_path()

--- a/macf/src/macf/knowledge_doctor.py
+++ b/macf/src/macf/knowledge_doctor.py
@@ -33,6 +33,11 @@ _RAW_LINK = re.compile(r"\[\[([^\]]+)\]\]")
 def _participating_files(agent_home: Path, participation: Dict[str, Dict[str, Any]]):
     """Yield (ca_type, spec, path) for every file the graph should contain."""
     for ca_type, spec in participation.items():
+        # Declared-but-not-participating entries exist so the registry check
+        # knows the location is deliberate; their files are not graph members
+        # and must not be examined as such.
+        if spec.get("participates", True) is False:
+            continue
         for rel in spec["dirs"]:
             # Framework-rooted types live outside the agent tree. Resolving them
             # against agent_home was silently catastrophic: dirs=[""] became
@@ -203,7 +208,8 @@ def examine(agent_home: Optional[Path] = None,
 
     chart = Chart(
         corpus="knowledge web",
-        scope=sorted(CA_PARTICIPATION.keys()),
+        scope=sorted(t for t, s in CA_PARTICIPATION.items()
+                     if s.get("participates", True) is not False),
         vitals={
             "files_examined": examined,
             "nodes": stats.get("total_nodes", 0),

--- a/macf/tests/test_knowledge_doctor_registry.py
+++ b/macf/tests/test_knowledge_doctor_registry.py
@@ -1,0 +1,61 @@
+"""Registry-integrity behaviour of the knowledge doctor.
+
+Covers the declared-but-not-participating registry form (scholarship: "declare
+it — participating or explicitly not"). A location can produce real artifacts
+without being a graph member; the declaration is what separates a deliberate
+exclusion from the undeclared-but-real state the acute finding exists to catch.
+"""
+from pathlib import Path
+
+from macf.ideas import CA_PARTICIPATION
+from macf.knowledge_doctor import _participating_files, examine
+
+EMPTY_KG = {"ca_nodes": {}, "wiki_index": {}, "stats": {}}
+
+
+def _registry_findings(agent_home: Path):
+    diagnosis = examine(agent_home=agent_home, kg=EMPTY_KG)
+    return [f for f in diagnosis.findings if f.check == "registry integrity"]
+
+
+def test_undeclared_artifact_dir_is_acute(tmp_path):
+    d = tmp_path / "agent" / "public" / "mystery_output"
+    d.mkdir(parents=True)
+    (d / "artifact.md").write_text("# something real\n")
+    subjects = {f.subject for f in _registry_findings(tmp_path)
+                if str(f.severity) == "acute"}
+    assert "public/mystery_output" in subjects
+
+
+def test_declared_not_participating_dir_is_not_flagged(tmp_path):
+    d = tmp_path / "agent" / "public" / "amail"
+    d.mkdir(parents=True)
+    (d / "README.md").write_text("# correspondence\n")
+    subjects = {f.subject for f in _registry_findings(tmp_path)
+                if str(f.severity) == "acute"}
+    assert "public/amail" not in subjects
+
+
+def test_not_participating_files_are_never_examined(tmp_path):
+    d = tmp_path / "agent" / "public" / "amail"
+    d.mkdir(parents=True)
+    (d / "message.md").write_text("# a message with no links\n")
+    examined = [p for _t, _s, p in _participating_files(tmp_path, CA_PARTICIPATION)]
+    assert (d / "message.md") not in examined
+
+
+def test_participating_dirs_still_yield(tmp_path):
+    """Positive control: the skip must not swallow participating types."""
+    d = tmp_path / "agent" / "private" / "learnings"
+    d.mkdir(parents=True)
+    (d / "2026-01-01_000000_x_learning.md").write_text("# x\n")
+    examined = [p.name for _t, _s, p in
+                _participating_files(tmp_path, CA_PARTICIPATION)]
+    assert "2026-01-01_000000_x_learning.md" in examined
+
+
+def test_registry_declares_amail_and_sprints_with_reasons():
+    for name in ("amail", "sprints"):
+        spec = CA_PARTICIPATION[name]
+        assert spec.get("participates") is False
+        assert spec.get("reason"), f"{name} must record why it does not participate"


### PR DESCRIPTION
## What

The scholarship policy's registry rule is *'declare it — participating or explicitly not'*, but `CA_PARTICIPATION` had no form for the second half: any artifact-producing directory outside the table was an acute doctor finding with no sanctioned way to record that the exclusion is deliberate.

This adds `participates: False` registry entries carrying a recorded `reason`, honoured by all three consumers (graph scanner, doctor file walk, doctor scope line). A location declared this way satisfies the registry-integrity check, but its files are never examined as graph members — and the `examined:` line no longer claims types the walk deliberately skips.

## Why now

The first doctor run from an installed CLI (post-#213) surfaced exactly two acute findings: `public/amail` and `public/sprints`, both real artifact producers, both deliberate non-members:

- **amail** — transport copies of correspondence; the canonical artifacts attached to a bundle participate from their home locations, so linking the copies would double-count them
- **sprints** — sprint logs are execution records; the claims live in the roadmap and the task store, as with archived todos

## Policy alignment

No policy change ships with this because the policy already anticipates the mechanism — scholarship §3.5.4 names the declared-but-not-participating form and requires the reason be recorded. This is code catching up to spec, not a new boundary.

## Verification

- New `test_knowledge_doctor_registry.py`: acute finding for an undeclared producer (negative control), no finding for a declared non-participant, non-participant files never yielded by the walk, participating types still yielded (positive control), and the two declarations' reasons pinned
- Full suite: 1314 passed
- Live corpus: doctor acute findings 2 → 0; orphan census unchanged (77), confirming the excluded files were never counted as graph members