### PR TITLE
fix(config): session info points at private checkpoints/reflections (#116)

### DIFF
--- a/macf/src/macf/config.py
+++ b/macf/src/macf/config.py
@@ -179,19 +179,28 @@ class ConsciousnessConfig:
         """
         Get path to checkpoints directory.
 
+        Checkpoints (CCPs) are written under agent/private/ — that is where the
+        CCP command writes and where the corpus actually lives. Reporting the
+        public path (#116) pointed agents looking for their own consciousness
+        artifacts at a near-empty directory, so this resolves to the real
+        write location.
+
         Returns:
-            Path to agent/public/checkpoints/ directory.
+            Path to agent/private/checkpoints/ directory.
         """
-        return self.get_public_path() / "checkpoints"
+        return self.get_private_path() / "checkpoints"
 
     def get_reflections_path(self) -> Path:
         """
         Get path to reflections directory.
 
+        Reflections (JOTEWRs) are written under agent/private/, like checkpoints;
+        see get_checkpoints_path (#116).
+
         Returns:
-            Path to agent/public/reflections/ directory.
+            Path to agent/private/reflections/ directory.
         """
-        return self.get_public_path() / "reflections"
+        return self.get_private_path() / "reflections"
 
     @property
     def agent_id(self) -> str:

--- a/macf/tests/test_config.py
+++ b/macf/tests/test_config.py
@@ -399,3 +399,22 @@ def temp_config_file(tmp_path):
 def temp_dir(tmp_path):
     """Provide temporary directory for testing."""
     return tmp_path
+
+
+class TestConsciousnessArtifactPaths:
+    """checkpoints/reflections paths must point where the artifacts are written (#116)."""
+
+    def test_checkpoints_path_resolves_under_private(self):
+        config = ConsciousnessConfig(agent_name="test-agent")
+        path = config.get_checkpoints_path()
+        # Artifacts are written under agent/private/, not public.
+        assert path == config.get_private_path() / "checkpoints"
+        assert path.parent.name == "private"
+        assert "public" not in path.parts
+
+    def test_reflections_path_resolves_under_private(self):
+        config = ConsciousnessConfig(agent_name="test-agent")
+        path = config.get_reflections_path()
+        assert path == config.get_private_path() / "reflections"
+        assert path.parent.name == "private"
+        assert "public" not in path.parts


### PR DESCRIPTION
## What
`macf_tools session info` reported `checkpoints_path=agent/public/checkpoints` and `reflections_path=agent/public/reflections`, but the corpus is written under `agent/private/` (9 checkpoints, 7 reflections). `public/checkpoints` held 1 stray file; `public/reflections` did not exist. The command an agent uses to locate its own consciousness artifacts pointed at a near-empty dir and a missing one.

Task #116.

## Root cause
`config.get_checkpoints_path()` / `get_reflections_path()` returned `get_public_path()/…`, while the CCP and JOTEWR commands write under `agent/private/…`.

## Fix
Point both getters at `get_private_path()/…`. Verified these getters are used *only* by the `session info` reader in `cli.py` — no writer depends on them — so this aligns reporter with writer without moving any writes.

## Test
`TestConsciousnessArtifactPaths` asserts both paths resolve under `agent/private/` and never under `public/`. `pytest tests/test_config.py -k path` → 7 passed.
