### PR TITLE
fix(hooks): capture full operator prompt, not first 200 chars (#119)

### DIFF
--- a/macf/src/macf/hooks/handle_user_prompt_submit.py
+++ b/macf/src/macf/hooks/handle_user_prompt_submit.py
@@ -215,9 +215,14 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
         from macf.utils.session import get_last_user_prompt_uuid
         current_prompt_uuid = get_last_user_prompt_uuid(session_id)
 
-        # Extract prompt preview for forensic recovery (first 200 chars)
+        # Capture the FULL operator prompt for forensic recovery and prompt-content
+        # analysis (#119). This was truncated to the first 200 chars, which silently
+        # biased any analysis of prompt content — 35% of prompts hit the cap exactly,
+        # so anything said mid-message was invisible and unrecoverable once logged.
+        # Follow-up (idea): store a transcript pointer rather than inlining full text,
+        # per 'Index Metadata, Not Content' — the transcript already holds the text.
         prompt = hook_input.get('prompt', '') if hook_input else ''
-        prompt_preview = prompt[:200] if prompt else None
+        prompt_preview = prompt if prompt else None
 
         # Record activity from the payload in hand before anything derives
         # staleness from the event log, so this render and the ones after it

--- a/macf/tests/test_handle_user_prompt_submit.py
+++ b/macf/tests/test_handle_user_prompt_submit.py
@@ -66,6 +66,24 @@ def test_dev_drv_start_tracking(mock_dependencies):
     assert result["continue"] is True
 
 
+def test_full_prompt_captured_not_truncated(mock_dependencies):
+    """dev_drv_started must capture the FULL prompt, not the first 200 chars (#119).
+
+    Truncation silently biased any analysis of operator prompt content — 35% of
+    prompts hit the 200-char cap exactly and lost everything said after it.
+    """
+    import json
+    from macf.hooks.handle_user_prompt_submit import run
+
+    long_prompt = "abcdefghij" * 50  # 500 chars, well past the old 200 cap
+    run(json.dumps({"session_id": "s1", "prompt": long_prompt}))
+
+    mock_dependencies['start_drv'].assert_called_once()
+    captured = mock_dependencies['start_drv'].call_args.kwargs.get('prompt_preview')
+    assert captured == long_prompt, "prompt was truncated; full content is required"
+    assert len(captured) == 500
+
+
 def test_temporal_awareness_included(mock_dependencies):
     """Test output includes temporal awareness context."""
     from macf.hooks.handle_user_prompt_submit import run


### PR DESCRIPTION
## What
`dev_drv_started` captured `data.prompt_preview` as `prompt[:200]`. Measured: of 457 prompts, **164 (35%) sat exactly at the 200-char cap** — truncated. Any analysis of operator prompt content silently measured only the first 200 chars, and the loss is unrecoverable once logged. This blocks the IL-grammar work (#117), whose comparison corpus used full prompt text.

Task #119.

## Fix
Capture the full prompt. The field keeps the name `prompt_preview` (to avoid rippling through `start_dev_drv` and its consumers) but now holds full text.

## Noted follow-up
Store a transcript **pointer** instead of inlining full content, per *Index Metadata, Not Content* — the transcript already holds the text and the event log is large. Left as a separate design (commented in code), not done here.

## Test
`test_full_prompt_captured_not_truncated`: a 500-char prompt reaches `start_dev_drv` in full. `pytest tests/test_handle_user_prompt_submit.py` → 11 passed.
