### PR TITLE
fix(task): survive gh-version JSON field drift in GH_PR/GH_ISSUE creation (#123)

### DIFF
--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -1142,6 +1142,10 @@ def _gh_view_json(view_args: List[str], fields: List[str], *, timeout: int = 15)
     import json as _json
     import re as _re
 
+    # Preserve the specific command in error text ("gh pr view failed",
+    # "gh issue view failed") that callers and tests rely on.
+    label = " ".join(view_args[:3]) if len(view_args) >= 3 else "gh view"
+
     remaining = list(fields)
     dropped: List[str] = []
     while remaining:
@@ -1153,11 +1157,11 @@ def _gh_view_json(view_args: List[str], fields: List[str], *, timeout: int = 15)
             return _json.loads(result.stdout)
         m = _re.search(r"Unknown JSON field:\s*[\"']?(\w+)", result.stderr or "")
         if not m or m.group(1) not in remaining:
-            raise ValueError(f"gh view failed: {result.stderr.strip()}")
+            raise ValueError(f"{label} failed: {result.stderr.strip()}")
         dropped.append(m.group(1))
         remaining.remove(m.group(1))
     raise ValueError(
-        "gh view failed: this gh version supports none of the requested fields "
+        f"{label} failed: this gh version supports none of the requested fields "
         f"(dropped: {', '.join(dropped)})"
     )
 

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -1114,6 +1114,54 @@ def create_bug(
     )
 
 
+def _gh_view_json(view_args: List[str], fields: List[str], *, timeout: int = 15) -> Dict[str, Any]:
+    """Run ``gh <view_args> --json <fields>`` and degrade across gh versions.
+
+    Current ``gh`` rejects the WHOLE call with ``Unknown JSON field: X`` when any
+    single requested field is unsupported (version-compat drift). That made a
+    drifted optional field — e.g. ``closingIssuesReferences`` on an older gh —
+    fatal, so GH_PR/GH_ISSUE tasks could not be created at all
+    (cversek/MacEff#123). Rather than hard-fail over an optional field, drop the
+    field gh names and retry. Callers read fields with ``.get(...)`` defaults, so
+    a dropped field degrades gracefully instead of taking the whole task down.
+
+    Args:
+        view_args: the gh command up to (not including) ``--json``, e.g.
+            ``["gh", "pr", "view", "213", "--repo", "owner/repo"]``.
+        fields: requested JSON field names, richest-first.
+        timeout: per-invocation subprocess timeout in seconds.
+
+    Returns:
+        Parsed JSON object from gh.
+
+    Raises:
+        ValueError: on a gh failure that is not a droppable unknown-field error,
+            or if every requested field was unsupported.
+    """
+    import subprocess as _subprocess
+    import json as _json
+    import re as _re
+
+    remaining = list(fields)
+    dropped: List[str] = []
+    while remaining:
+        result = _subprocess.run(
+            view_args + ["--json", ",".join(remaining)],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if result.returncode == 0:
+            return _json.loads(result.stdout)
+        m = _re.search(r"Unknown JSON field:\s*[\"']?(\w+)", result.stderr or "")
+        if not m or m.group(1) not in remaining:
+            raise ValueError(f"gh view failed: {result.stderr.strip()}")
+        dropped.append(m.group(1))
+        remaining.remove(m.group(1))
+    raise ValueError(
+        "gh view failed: this gh version supports none of the requested fields "
+        f"(dropped: {', '.join(dropped)})"
+    )
+
+
 def create_gh_issue(
     issue_url: str,
     parent_id: Optional[str] = None,
@@ -1143,18 +1191,11 @@ def create_gh_issue(
                          f"Expected: https://github.com/owner/repo/issues/N")
     owner, repo, issue_number = url_match.group(1), url_match.group(2), int(url_match.group(3))
 
-    # Fetch issue metadata via gh CLI
-    gh_result = _subprocess.run(
-        ["gh", "issue", "view", str(issue_number),
-         "--repo", f"{owner}/{repo}",
-         "--json", "title,labels,state,url"],
-        capture_output=True, text=True, timeout=15
+    # Fetch issue metadata via gh CLI (resilient to gh-version field drift, #123)
+    gh_data = _gh_view_json(
+        ["gh", "issue", "view", str(issue_number), "--repo", f"{owner}/{repo}"],
+        ["title", "labels", "state", "url"],
     )
-    if gh_result.returncode != 0:
-        raise ValueError(f"gh issue view failed: {gh_result.stderr.strip()}")
-
-    import json as _json
-    gh_data = _json.loads(gh_result.stdout)
     title = gh_data["title"]
     labels = [label["name"] for label in gh_data.get("labels", [])]
     state = gh_data.get("state", "OPEN")
@@ -1239,19 +1280,14 @@ def create_gh_pr(
                          f"Expected: https://github.com/owner/repo/pull/N")
     owner, repo, pr_number = url_match.group(1), url_match.group(2), int(url_match.group(3))
 
-    # Fetch PR metadata via gh CLI. `mergeable` is intentionally NOT fetched or
-    # gated on — it is a lazy/stale field; the merge operation is ground truth.
-    gh_result = _subprocess.run(
-        ["gh", "pr", "view", str(pr_number),
-         "--repo", f"{owner}/{repo}",
-         "--json", "title,labels,state,url,headRefName,baseRefName,isDraft,"
-                   "reviewDecision,closingIssuesReferences,body"],
-        capture_output=True, text=True, timeout=15
+    # Fetch PR metadata via gh CLI, resilient to gh-version field drift (#123).
+    # `mergeable` is intentionally NOT fetched or gated on — it is a lazy/stale
+    # field; the merge operation is ground truth.
+    gh_data = _gh_view_json(
+        ["gh", "pr", "view", str(pr_number), "--repo", f"{owner}/{repo}"],
+        ["title", "labels", "state", "url", "headRefName", "baseRefName",
+         "isDraft", "reviewDecision", "closingIssuesReferences", "body"],
     )
-    if gh_result.returncode != 0:
-        raise ValueError(f"gh pr view failed: {gh_result.stderr.strip()}")
-
-    gh_data = _json.loads(gh_result.stdout)
     title = gh_data["title"]
     labels = [label["name"] for label in gh_data.get("labels", [])]
     state = gh_data.get("state", "OPEN")

--- a/macf/tests/test_gh_view_field_drift.py
+++ b/macf/tests/test_gh_view_field_drift.py
@@ -1,0 +1,74 @@
+"""Regression tests for gh-version field drift in GH_PR/GH_ISSUE creation (GH #123).
+
+Current `gh` rejects the whole `gh <view> --json <fields>` call with
+`Unknown JSON field: X` if any single field is unsupported. That made a drifted
+optional field (`closingIssuesReferences`) fatal, so GH_PR/GH_ISSUE tasks could
+not be created at all. `_gh_view_json` degrades: it drops the field gh names and
+retries, instead of taking the whole task down over one optional field.
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from macf.task.create import _gh_view_json
+
+
+def _result(returncode, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _requested_fields(cmd):
+    return cmd[cmd.index("--json") + 1]
+
+
+def test_drops_unsupported_field_and_retries():
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "closingIssuesReferences" in _requested_fields(cmd):
+            return _result(1, stderr="unknown JSON field.\nUnknown JSON field: closingIssuesReferences")
+        return _result(0, stdout=json.dumps({"title": "T", "state": "OPEN"}))
+
+    with patch("subprocess.run", side_effect=fake_run):
+        data = _gh_view_json(
+            ["gh", "pr", "view", "1", "--repo", "o/r"],
+            ["title", "state", "closingIssuesReferences"],
+        )
+
+    assert data == {"title": "T", "state": "OPEN"}
+    assert len(calls) == 2  # failed once, retried without the drifted field
+    assert "closingIssuesReferences" not in _requested_fields(calls[1])
+
+
+def test_drops_multiple_drifted_fields_one_at_a_time():
+    def fake_run(cmd, **kwargs):
+        fields = _requested_fields(cmd)
+        for bad in ("closingIssuesReferences", "reviewDecision"):
+            if bad in fields:
+                return _result(1, stderr=f"Unknown JSON field: {bad}")
+        return _result(0, stdout=json.dumps({"title": "T"}))
+
+    with patch("subprocess.run", side_effect=fake_run):
+        data = _gh_view_json(
+            ["gh", "pr", "view", "1", "--repo", "o/r"],
+            ["title", "reviewDecision", "closingIssuesReferences"],
+        )
+    assert data == {"title": "T"}
+
+
+def test_success_on_first_try_returns_all_fields():
+    with patch("subprocess.run", return_value=_result(0, stdout=json.dumps({"title": "T", "url": "u"}))):
+        data = _gh_view_json(["gh", "issue", "view", "1", "--repo", "o/r"], ["title", "url"])
+    assert data == {"title": "T", "url": "u"}
+
+
+def test_non_field_error_still_raises():
+    with patch("subprocess.run", return_value=_result(1, stderr="gh: not authenticated")):
+        with pytest.raises(ValueError, match="not authenticated"):
+            _gh_view_json(["gh", "pr", "view", "1", "--repo", "o/r"], ["title"])


### PR DESCRIPTION
## What
`macf_tools task create gh_pr <url>` failed on the current `gh`: `gh pr view failed: Unknown JSON field: closingIssuesReferences`. `gh` rejects the **whole** `--json` call when any single field is unsupported, so one drifted optional field made GH_PR/GH_ISSUE tasks uncreatable — PR review work had no tracked home.

Task #123.

## Fix
A new `_gh_view_json` helper requests the rich field set and, on `Unknown JSON field: X`, drops `X` and retries (one field at a time) until it succeeds. Downstream reads already use `.get(...)` defaults, so a dropped field degrades gracefully. Non-field `gh` errors still raise. Both `create_gh_pr` and `create_gh_issue` route through it, so this covers version drift generally, not just one field. `closingIssuesReferences` becomes best-effort: used when supported, and the `Fixes/Closes #N` body parse still recovers the linkage otherwise.

## Evidence
- **Live** against a real PR on the drifting `gh`: `create gh_pr` now succeeds and still captures `linked_issues=[208]` from the body despite the dropped field.
- Unit tests: single-field drop + retry, multi-field drop, first-try success, and a genuine (non-field) `gh` error still raising. All green.
