### PR TITLE
fix(hybrid_search): guard optional imports + repair inverted graceful-import test (#75)

### DIFF
--- a/macf/src/macf/hybrid_search/policy_search.py
+++ b/macf/src/macf/hybrid_search/policy_search.py
@@ -10,8 +10,19 @@ import time
 from pathlib import Path
 from typing import Optional
 
-import lancedb
-from sentence_transformers import SentenceTransformer
+# Optional heavy deps are guarded so the module imports even when they are
+# absent — matching base_indexer/policy_indexer. Previously `import lancedb` at
+# module scope was unconditional, so importing this module (and therefore the
+# whole hybrid_search package, via __init__) failed whenever lancedb was missing,
+# which is exactly the graceful-degradation case the package claims to support
+# (GH #123's sibling, GH #75). Using the components without the deps raises a
+# clear error in __init__ instead.
+try:
+    import lancedb
+    from sentence_transformers import SentenceTransformer
+    DEPS_AVAILABLE = True
+except ImportError:
+    DEPS_AVAILABLE = False
 
 from .models import MatchedQuestion
 
@@ -26,16 +37,25 @@ class PolicySearch:
         Args:
             db_path: Path to LanceDB directory
             model_name: SentenceTransformer model name (lazy loaded)
+
+        Raises:
+            ImportError: if the optional search dependencies are not installed.
         """
+        if not DEPS_AVAILABLE:
+            raise ImportError(
+                "Optional dependencies not available. Install with: "
+                "pip install lancedb sentence-transformers"
+            )
+
         self.db_path = db_path
         self.model_name = model_name
-        self._model: Optional[SentenceTransformer] = None
+        self._model: Optional["SentenceTransformer"] = None
         self._db = None
         self._documents_table = None
         self._questions_table = None
 
     @property
-    def model(self) -> SentenceTransformer:
+    def model(self) -> "SentenceTransformer":
         """Lazy load embedding model."""
         if self._model is None:
             self._model = SentenceTransformer(self.model_name)

--- a/macf/tests/test_hybrid_search.py
+++ b/macf/tests/test_hybrid_search.py
@@ -16,23 +16,66 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-# Test graceful import behavior first
-def test_graceful_import_without_optional_deps():
-    """Module imports work even if optional dependencies missing."""
-    with patch.dict('sys.modules', {
-        'sqlite_vec': None,
-        'sentence_transformers': None
-    }):
-        # Should not raise ImportError
-        import macf.hybrid_search as hs
+def _reimport_with_deps_absent(*absent_deps):
+    """Force a fresh import of macf.hybrid_search with the named deps absent.
 
-        # Core models always available
+    A ``None`` entry in ``sys.modules`` makes ``import <name>`` raise ImportError
+    even when the package is installed, so we can simulate genuine absence. The
+    hybrid_search submodules must be cleared too, or the cached (deps-present)
+    copies would be returned and the patch would do nothing — which is part of
+    why the original test could never observe its own property (#75).
+    """
+    import sys
+    keys = [m for m in list(sys.modules)
+            if m == 'macf.hybrid_search' or m.startswith('macf.hybrid_search.')
+            or m in absent_deps]
+    saved = {m: sys.modules[m] for m in keys}
+
+    def restore():
+        for m in [m for m in list(sys.modules)
+                  if m == 'macf.hybrid_search' or m.startswith('macf.hybrid_search.')
+                  or m in absent_deps]:
+            del sys.modules[m]
+        sys.modules.update(saved)
+
+    for m in keys:
+        del sys.modules[m]
+    for dep in absent_deps:
+        sys.modules[dep] = None
+    import macf.hybrid_search as hs
+    return hs, restore
+
+
+def test_graceful_import_without_optional_deps():
+    """Import must survive the load-bearing deps being absent, and USING a
+    dep-backed component must fail loudly, naming the missing extra (#75).
+
+    The original test patched sqlite_vec (a removed dep) and sentence_transformers
+    but NOT lancedb — the load-bearing dep policy_search imported unconditionally.
+    In CI lancedb is always installed, so `assert BaseIndexer is not None` passed
+    for a reason unrelated to graceful degradation, while genuinely-absent lancedb
+    inverted it. This patches the real optional deps and forces a fresh import, so
+    the test observes the property it asserts.
+    """
+    hs, restore = _reimport_with_deps_absent('lancedb', 'sentence_transformers')
+    try:
+        # Core models need no optional deps.
         assert hs.RetrieverScore is not None
         assert hs.ExplainedRecommendation is not None
-        assert hs.BaseIndexer is not None
 
-        # Optional components gracefully None
-        assert hs.AbstractExtractor is None or hasattr(hs.AbstractExtractor, '__name__')
+        # Components are importable even without the deps (guarded imports), so
+        # calling code can reference them; they refuse to *run* without the deps.
+        assert hs.BaseIndexer is not None
+        assert hs.PolicySearch is not None
+
+        # Negative control: constructing a dep-backed component fails LOUDLY and
+        # names the missing extra, rather than degrading to a confusing error.
+        with pytest.raises(ImportError, match="pip install lancedb"):
+            hs.PolicySearch(db_path=Path("/tmp/does-not-matter"))
+        with pytest.raises(ImportError, match="pip install lancedb"):
+            hs.BaseIndexer(extractor=Mock())
+    finally:
+        restore()
 
 
 class TestAbstractExtractor:


### PR DESCRIPTION
## What
Two defects, one root — `policy_search.py` imported `lancedb`/`sentence_transformers` **unconditionally** at module scope (unlike `base_indexer`/`policy_indexer`, which guard them). Because `hybrid_search/__init__` imports all components in one `try/except`, that unconditional import made a missing `lancedb` take down the **whole** package (every component → `None`) — the opposite of the graceful degradation the package claims.

And `test_graceful_import_without_optional_deps` **could not observe the property it asserts**: it patched `sqlite_vec` (a removed dep) and `sentence_transformers` but **not** `lancedb`, the load-bearing one. In CI (lancedb installed) the import succeeded for an unrelated reason and `assert BaseIndexer is not None` passed; on a host with lancedb genuinely absent, the same assertion failed. A test that passes only when its premise is false is inverted.

Task #75.

## Fix
- **`policy_search.py`**: guard the optional imports (`try/except → DEPS_AVAILABLE`), raise a clear `pip install lancedb sentence-transformers` from `__init__` when absent, string-annotate the optional types. Mirrors the existing `base_indexer` pattern.
- **Test**: force a fresh import with the real optional deps absent (clearing cached submodules — a stale cache was another reason the old patch did nothing), assert components stay importable, and add a **negative control**: constructing `PolicySearch`/`BaseIndexer` without the deps raises `ImportError` naming the missing extra. Drops the dead `sqlite_vec` patch.

## Evidence
`pytest tests/test_hybrid_search.py` → **9 passed** — the rewritten graceful test (forced absence) and the real-deps tests both green, and `restore()` leaves module state clean for the rest.
