### PR TITLE
feat(modes): USER_REMOTE presence mode — deny CLI-blocking tools to prevent hangs (#143)

### DIFF
--- a/framework/policies/base/operations/mode_system.md
+++ b/framework/policies/base/operations/mode_system.md
@@ -123,12 +123,13 @@ Layer 3: Recommender          → at gate points, suggests next skill
 
 ## 2. Operational Mode Definitions
 
-Four operational modes, independently triggered, simultaneously active:
+Five operational modes, independently triggered, simultaneously active:
 
 | Mode | Emoji | Trigger Type | Description |
 |------|-------|-------------|-------------|
 | **AUTO_MODE** | 🤖 | Event-based | Agent operating autonomously with user authorization |
 | **USER_IDLE** | 😴 | Computed | User hasn't sent a message within idle timeout |
+| **USER_REMOTE** | 📡 | Event + computed clear | User reachable only via a remote channel; CLI unattended |
 | **QUIET_MODE** | 🔕 | Event or auto | Don't disturb — suppress notifications, defer questions |
 | **LOW_CONTEXT** | 🪫 | Computed | Context left is at or below threshold |
 
@@ -144,6 +145,24 @@ Four operational modes, independently triggered, simultaneously active:
 - **Activity sources (v2+)**: JSONL `queue-operation` enqueue entries (sub-turn precision)
 - **Default timeout**: 10 minutes (`MACF_USER_IDLE_TIMEOUT_MINS`)
 - **Deactivation**: Automatic when user sends next message
+
+### USER_REMOTE 📡
+- **Trigger**: Explicit `macf_tools mode set USER_REMOTE` — the operator declares they have stepped away from the CLI and are reachable **only** through a remote channel (Telegram).
+- **Meaning**: The user is *present and responsive*, but the **CLI is unattended**. This is the opposite failure surface from USER_IDLE: the hazard is not that the agent stops, but that it **blocks on a tool needing CLI input nobody is there to give** — a permission prompt, or an `AskUserQuestion` that never renders on the remote channel — and hangs the whole session until the operator physically returns.
+- **Deactivation**: **Automatic, the instant the operator sends a message from the CLI** — a `user_activity_detected` event with `source == "direct"`. A message from Telegram (`source == "channel"`) does **not** clear it: the operator is still remote. The Transcript Monitor already records this direct-vs-channel distinction (`detect_user_activity`), so the discriminator is a read, not a new signal.
+- **Forbidden while active** (each blocks on the absent CLI):
+  - `AskUserQuestion` — its prompt does not propagate to Telegram, so a remote operator can never answer it. Ask in a Telegram `reply`, or in the turn-final message (which the Stop hook forwards to the channel), instead.
+  - Every **Ask-list** command (`git push`, `gh pr create`, `gh pr merge`, `gh issue create/close`, `git reset --hard`, `rm -r`, docker teardown, …) — each raises a CLI permission prompt. Accumulate commits locally and **hold pushes/PRs** until USER_REMOTE clears.
+- **Enforcement (Ask → Deny)**: activation flips those Ask-list entries to **Deny** and adds `AskUserQuestion` to the deny list, so an attempt returns an *immediate denial the agent can route around* rather than a silent hang; deactivation restores them. Permission changes load at CC startup, so full enforcement takes effect on the **next restart** — until then, the switch message and this policy are the binding guidance. Denial-not-prompt is the safety property: a hung session with a remote operator can only be cleared by their physical return.
+- **Allowed**: the Telegram `reply` tool (the operator's live channel — unlike QUIET_MODE, USER_REMOTE does **not** silence Telegram), plus all local work — reads, edits, tests, `git commit`, `macf_tools`.
+- **vs USER_IDLE / QUIET_MODE**: USER_IDLE = user gone, whereabouts unknown, keep working and assume closeout responsibility. QUIET_MODE = do not disturb on *any* channel. USER_REMOTE = user *here, on Telegram* — talk to them there, but never touch a tool that waits on the empty CLI.
+
+**Switch message** (printed on activation, and the contract an agent must honor):
+
+> 📡 USER_REMOTE active. The operator is reachable ONLY via Telegram; the CLI is unattended. Do NOT use tools that block on CLI input — they will hang the session:
+> • AskUserQuestion (does not reach Telegram) → ask via Telegram reply or your turn-final message.
+> • Ask-list commands (git push, gh pr create/merge, gh issue create/close, git reset --hard, rm -r, docker teardown) → hold them; accumulate commits locally.
+> Communicate via the Telegram reply tool. Clears the instant you send a message from the CLI.
 
 ### QUIET_MODE 🔕
 - **Trigger**: Explicit event OR auto-triggered alongside USER_IDLE (configurable)

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3540,7 +3540,11 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
             from .agent_events_log import append_event
             if mode == "USER_PRESENT":
                 append_event("mode_change", {"mode": "USER_REMOTE", "enabled": False})
+                from .utils.claude_settings import toggle_user_remote_deny_permissions
+                restored = toggle_user_remote_deny_permissions(False)
                 print("✅ USER_REMOTE cleared — operator present at the CLI.")
+                if restored and restored.get("restored"):
+                    print(f"   Restored {len(restored['restored'])} CLI-blocking permission(s) (restart to load).")
                 return 0
             append_event("mode_change", {"mode": "USER_REMOTE", "enabled": True})
             print("📡 USER_REMOTE active. The operator is reachable ONLY via a remote")
@@ -3551,8 +3555,14 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
             print("   • Ask-list commands (git push, gh pr create/merge, gh issue")
             print("     create/close, git reset --hard, rm -r, docker teardown) — each")
             print("     prompts at the empty CLI. Commit locally; HOLD pushes/PRs.")
-            print("   Communicate via the Telegram reply tool. Clears automatically the")
-            print("   instant you send a message from the CLI.")
+            print("   Communicate via the Telegram reply tool. The dashboard indicator")
+            print("   clears when you return to the CLI; run `mode set USER_PRESENT`")
+            print("   (or restart) to restore the denied permissions.")
+            from .utils.claude_settings import toggle_user_remote_deny_permissions
+            denied = toggle_user_remote_deny_permissions(True)
+            if denied and denied.get("denied"):
+                print(f"   🚫 Denied {len(denied['denied'])} CLI-blocking tools (AskUserQuestion + "
+                      "Ask-list) — takes effect on next restart.")
             return 0
 
         # Validate mode argument

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3530,10 +3530,35 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
         mode = args.mode.upper()
         auth_token = getattr(args, 'auth_token', None)
 
+        # USER_REMOTE / USER_PRESENT: an orthogonal presence mode, not part of the
+        # AUTO/MANUAL operational toggle. Handle up front and return. It emits the
+        # mode_change event detection reads; the mode auto-clears when the operator's
+        # next CLI message lands (see modes.detection._detect_user_remote). v1 is
+        # advisory — this switch message plus mode_system.md are the binding
+        # guidance; the Ask->Deny permission enforcement is a follow-up.
+        if mode in ("USER_REMOTE", "USER_PRESENT"):
+            from .agent_events_log import append_event
+            if mode == "USER_PRESENT":
+                append_event("mode_change", {"mode": "USER_REMOTE", "enabled": False})
+                print("✅ USER_REMOTE cleared — operator present at the CLI.")
+                return 0
+            append_event("mode_change", {"mode": "USER_REMOTE", "enabled": True})
+            print("📡 USER_REMOTE active. The operator is reachable ONLY via a remote")
+            print("   channel (Telegram); the CLI is unattended. Do NOT use tools that")
+            print("   block on CLI input — they hang the session until someone returns:")
+            print("   • AskUserQuestion — does not reach Telegram. Ask via the Telegram")
+            print("     reply tool, or your turn-final message (the Stop hook forwards it).")
+            print("   • Ask-list commands (git push, gh pr create/merge, gh issue")
+            print("     create/close, git reset --hard, rm -r, docker teardown) — each")
+            print("     prompts at the empty CLI. Commit locally; HOLD pushes/PRs.")
+            print("   Communicate via the Telegram reply tool. Clears automatically the")
+            print("   instant you send a message from the CLI.")
+            return 0
+
         # Validate mode argument
         if mode not in ('AUTO_MODE', 'MANUAL_MODE'):
             print(f"Invalid mode: {mode}")
-            print("Valid modes: AUTO_MODE, MANUAL_MODE")
+            print("Valid modes: AUTO_MODE, MANUAL_MODE, USER_REMOTE, USER_PRESENT")
             return 1
 
         enabled = (mode == 'AUTO_MODE')

--- a/macf/src/macf/modes/detection.py
+++ b/macf/src/macf/modes/detection.py
@@ -29,6 +29,7 @@ from ..utils.cycles import detect_auto_mode
 OPERATIONAL_MODES = {
     "AUTO_MODE":   {"emoji": "🤖", "order": 1},
     "USER_IDLE":   {"emoji": "😴", "order": 2},
+    "USER_REMOTE": {"emoji": "📡", "order": 2},
     "QUIET_MODE":  {"emoji": "🔕", "order": 3},
     "LOW_CONTEXT": {"emoji": "🪫", "order": 4},
 }
@@ -130,6 +131,13 @@ def detect_active_modes(session_id: str, token_info: dict) -> Set[str]:
             modes.add("USER_IDLE")
     except (OSError, ValueError) as e:
         print(f"⚠️ MACF: USER_IDLE detection failed: {e}", file=sys.stderr)
+
+    # USER_REMOTE: explicitly set; auto-clears when the operator returns to the CLI.
+    try:
+        if _detect_user_remote(session_id):
+            modes.add("USER_REMOTE")
+    except (OSError, ValueError) as e:
+        print(f"⚠️ MACF: USER_REMOTE detection failed: {e}", file=sys.stderr)
 
     # QUIET_MODE: explicit event OR auto with USER_IDLE
     try:
@@ -530,8 +538,12 @@ def format_recommendation(
 # Internal Helpers
 # ============================================================================
 
-def _get_last_user_activity_timestamp(session_id: str) -> Optional[float]:
+def _get_last_user_activity_timestamp(session_id: str, sources: Optional[Set[str]] = None) -> Optional[float]:
     """Get epoch timestamp of last user activity from event log.
+
+    ``sources`` optionally restricts which activity origins count — e.g.
+    ``{"direct", "mid_turn_enqueue"}`` to consider only CLI-typed input (used by
+    USER_REMOTE's auto-clear, which must ignore ``"channel"`` Telegram activity).
 
     ONLY uses user_activity_detected events. Two producers write them: the
     Transcript Monitor (polling the transcript) and the UserPromptSubmit hook
@@ -552,6 +564,8 @@ def _get_last_user_activity_timestamp(session_id: str) -> Optional[float]:
     for event in read_events(limit=200, reverse=True):
         event_type = event.get("event", "")
         if event_type != "user_activity_detected":
+            continue
+        if sources is not None and event.get("data", {}).get("source") not in sources:
             continue
         ts = event.get("timestamp")
         if ts:
@@ -582,6 +596,56 @@ def _detect_quiet_mode_event(session_id: str) -> bool:
             if mode in ("AUTO_MODE", "MANUAL_MODE"):
                 return False
     return False
+
+
+def _parse_epoch(ts) -> Optional[float]:
+    """Coerce an event timestamp (epoch number or ISO string) to epoch seconds."""
+    if ts is None:
+        return None
+    try:
+        if isinstance(ts, (int, float)):
+            return float(ts)
+        if isinstance(ts, str):
+            from datetime import datetime
+            return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+    return None
+
+
+# CLI-typed activity origins: a normal prompt ("direct") and a mid-turn queued
+# message ("mid_turn_enqueue"). Both mean the operator is AT the CLI. A Telegram
+# message is "channel" and deliberately excluded — it does not prove presence at
+# the terminal, which is what USER_REMOTE is about.
+_CLI_ACTIVITY_SOURCES = {"direct", "mid_turn_enqueue"}
+
+
+def _detect_user_remote(session_id: str) -> bool:
+    """USER_REMOTE: explicitly set via mode_change, auto-cleared by CLI activity.
+
+    Active when the most recent USER_REMOTE ``mode_change`` is enabled AND no
+    CLI-typed user activity has arrived since it was set. A ``channel`` (Telegram)
+    message does NOT clear it — the operator is still remote. AUTO_MODE/
+    MANUAL_MODE mode_changes are ignored: USER_REMOTE is an orthogonal presence
+    axis, not part of the operational-mode toggle.
+    """
+    set_ts = None
+    for event in read_events(limit=100, reverse=True):
+        if event.get("event") != "mode_change":
+            continue
+        data = event.get("data", {})
+        if data.get("mode") != "USER_REMOTE":
+            continue
+        if not data.get("enabled", True):
+            return False  # most recent USER_REMOTE change disabled it
+        set_ts = _parse_epoch(event.get("timestamp"))
+        break
+    if set_ts is None:
+        return False
+    cli_ts = _get_last_user_activity_timestamp(session_id, sources=_CLI_ACTIVITY_SOURCES)
+    if cli_ts is not None and cli_ts > set_ts:
+        return False  # operator has returned to the CLI since going remote
+    return True
 
 
 def _get_current_work_mode() -> Optional[str]:

--- a/macf/src/macf/utils/claude_settings.py
+++ b/macf/src/macf/utils/claude_settings.py
@@ -478,6 +478,71 @@ def toggle_auto_mode_ask_permissions(enable_auto: bool, project_root: Optional[P
         return None
 
 
+# Tools that BLOCK on the CLI and therefore hang an unattended session while the
+# operator is remote. AskUserQuestion does not render on a remote channel; the
+# Ask-list commands raise a CLI permission prompt. Denied (not asked) under
+# USER_REMOTE so an attempt is refused immediately instead of stranding the
+# session (#143).
+_USER_REMOTE_EXTRA_DENY = ["AskUserQuestion"]
+
+
+def toggle_user_remote_deny_permissions(enable_remote: bool, project_root: Optional[Path] = None) -> Optional[dict]:
+    """Deny CLI-blocking tools while USER_REMOTE is active; restore on exit (#143).
+
+    While the operator is reachable only remotely, a permission PROMPT hangs the
+    unattended CLI. Moving the Ask-list commands (and AskUserQuestion) into the
+    deny list makes an attempt fail immediately — the agent routes around it —
+    instead of stranding the session until someone physically returns. On exit
+    (USER_PRESENT, or an auto-clear when the operator returns to the CLI) the
+    entries are restored to whichever list they came from.
+
+    Permission changes load at CC startup, so full enforcement takes effect on
+    the next restart; until then the USER_REMOTE switch message and mode_system
+    policy are the binding guidance.
+
+    Returns dict with 'denied' (entries moved into deny) and 'restored' (entries
+    moved back out), or None on error.
+    """
+    try:
+        settings, settings_path = _read_settings(project_root)
+        permissions = settings.setdefault('permissions', {})
+        ask_list = permissions.setdefault('ask', [])
+        deny_list = permissions.setdefault('deny', [])
+        stash = settings.setdefault('_macf_user_remote_denied', {})
+
+        targets = list(_AUTO_MODE_ASK) + _USER_REMOTE_EXTRA_DENY
+        denied = []
+        restored = []
+
+        if enable_remote:
+            for entry in targets:
+                # Record where the entry lived so exit can restore it faithfully.
+                was_in_ask = entry in ask_list
+                if was_in_ask:
+                    ask_list.remove(entry)
+                if entry not in deny_list:
+                    deny_list.append(entry)
+                    denied.append(entry)
+                stash[entry] = {"from_ask": was_in_ask}
+        else:
+            for entry in targets:
+                if entry in deny_list:
+                    deny_list.remove(entry)
+                    restored.append(entry)
+                info = stash.pop(entry, None)
+                if info and info.get("from_ask") and entry not in ask_list:
+                    ask_list.append(entry)
+            if not stash:
+                settings.pop('_macf_user_remote_denied', None)
+
+        if denied or restored:
+            _write_settings(settings, settings_path)
+        return {"denied": denied, "restored": restored}
+    except (OSError, json.JSONDecodeError, TypeError, KeyError) as e:
+        print(f"⚠️ MACF: Settings write failed (toggle_user_remote_deny): {e}", file=sys.stderr)
+        return None
+
+
 def toggle_write_ask_for_auto_mode(enable_auto: bool, project_root: Optional[Path] = None) -> bool:
     """
     Toggle Write tool between 'ask' and implicit bypass for AUTO_MODE.

--- a/macf/tests/test_user_remote_detection.py
+++ b/macf/tests/test_user_remote_detection.py
@@ -1,0 +1,84 @@
+"""Tests for USER_REMOTE presence-mode detection (#143).
+
+USER_REMOTE is set explicitly and auto-clears the instant the operator returns
+to the CLI — where "CLI activity" means source in {direct, mid_turn_enqueue},
+NOT a Telegram ("channel") message (the operator is still remote then).
+"""
+
+from unittest.mock import patch
+
+from macf.modes import detection
+
+
+def _ev(event, ts, **data):
+    return {"event": event, "timestamp": ts, "data": data}
+
+
+def _detect(events):
+    # read_events returns most-recent-first; both callers inside _detect_user_remote
+    # (the mode_change scan and _get_last_user_activity_timestamp) hit this mock.
+    with patch.object(detection, "read_events", return_value=events):
+        return detection._detect_user_remote("s")
+
+
+def test_no_mode_change_is_not_remote():
+    assert _detect([_ev("user_activity_detected", 100, source="direct")]) is False
+
+
+def test_enabled_with_only_channel_activity_is_remote():
+    events = [
+        _ev("user_activity_detected", 200, source="channel"),
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+    ]
+    assert _detect(events) is True
+
+
+def test_direct_cli_activity_after_set_clears_it():
+    events = [
+        _ev("user_activity_detected", 200, source="direct"),
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+    ]
+    assert _detect(events) is False
+
+
+def test_mid_turn_enqueue_counts_as_cli_and_clears():
+    events = [
+        _ev("user_activity_detected", 200, source="mid_turn_enqueue"),
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+    ]
+    assert _detect(events) is False
+
+
+def test_channel_activity_never_clears():
+    events = [
+        _ev("user_activity_detected", 300, source="channel"),
+        _ev("user_activity_detected", 250, source="channel"),
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+    ]
+    assert _detect(events) is True
+
+
+def test_cli_activity_before_set_does_not_clear():
+    # A CLI message that predates going remote must not cancel USER_REMOTE.
+    events = [
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+        _ev("user_activity_detected", 50, source="direct"),
+    ]
+    assert _detect(events) is True
+
+
+def test_most_recent_change_disabled_is_not_remote():
+    events = [
+        _ev("mode_change", 200, mode="USER_REMOTE", enabled=False),
+        _ev("mode_change", 100, mode="USER_REMOTE", enabled=True),
+    ]
+    assert _detect(events) is False
+
+
+def test_iso_timestamp_is_parsed():
+    events = [
+        _ev("user_activity_detected", "2026-08-09T18:00:05Z", source="direct"),
+        _ev("mode_change", "2026-08-09T18:00:00Z", mode="USER_REMOTE", enabled=True),
+    ]
+    # direct activity 5s after set → cleared
+    assert _detect(events) is False

--- a/macf/tests/test_user_remote_permissions.py
+++ b/macf/tests/test_user_remote_permissions.py
@@ -1,0 +1,62 @@
+"""USER_REMOTE Ask->Deny permission flip (#143 v2).
+
+While USER_REMOTE, tools that block on the CLI (AskUserQuestion + the Ask-list
+commands) are moved into the deny list so an attempt is refused immediately
+rather than hanging the unattended session. On exit they are restored to where
+they came from.
+"""
+
+import json
+
+from macf.utils.claude_settings import (
+    toggle_user_remote_deny_permissions,
+    _AUTO_MODE_ASK,
+    _USER_REMOTE_EXTRA_DENY,
+)
+
+
+def _seed(tmp_path, settings):
+    d = tmp_path / ".claude"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "settings.local.json").write_text(json.dumps(settings))
+
+
+def _load(tmp_path):
+    return json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
+
+
+def test_enable_moves_cli_blocking_tools_into_deny(tmp_path):
+    _seed(tmp_path, {"permissions": {"ask": list(_AUTO_MODE_ASK), "allow": [], "deny": []}})
+    res = toggle_user_remote_deny_permissions(True, project_root=tmp_path)
+    assert res is not None
+    perms = _load(tmp_path)["permissions"]
+    for entry in list(_AUTO_MODE_ASK) + _USER_REMOTE_EXTRA_DENY:
+        assert entry in perms["deny"], f"{entry} not denied"
+    # Ask-list entries were moved OUT of ask (so they don't ask-and-hang).
+    for entry in _AUTO_MODE_ASK:
+        assert entry not in perms["ask"]
+
+
+def test_disable_restores_prior_state(tmp_path):
+    _seed(tmp_path, {"permissions": {"ask": list(_AUTO_MODE_ASK), "allow": [], "deny": []}})
+    toggle_user_remote_deny_permissions(True, project_root=tmp_path)
+    toggle_user_remote_deny_permissions(False, project_root=tmp_path)
+    perms = _load(tmp_path)["permissions"]
+    for entry in _AUTO_MODE_ASK:
+        assert entry in perms["ask"], f"{entry} not restored to ask"
+        assert entry not in perms["deny"]
+    assert "AskUserQuestion" not in perms["deny"]
+
+
+def test_enable_is_idempotent_no_duplicate_deny(tmp_path):
+    _seed(tmp_path, {"permissions": {"ask": [], "allow": [], "deny": []}})
+    toggle_user_remote_deny_permissions(True, project_root=tmp_path)
+    toggle_user_remote_deny_permissions(True, project_root=tmp_path)
+    deny = _load(tmp_path)["permissions"]["deny"]
+    assert len(deny) == len(set(deny)), "deny list has duplicates"
+
+
+def test_ask_user_question_is_always_denied_under_remote(tmp_path):
+    _seed(tmp_path, {"permissions": {"ask": [], "allow": [], "deny": []}})
+    toggle_user_remote_deny_permissions(True, project_root=tmp_path)
+    assert "AskUserQuestion" in _load(tmp_path)["permissions"]["deny"]


### PR DESCRIPTION
## What

Adds a new **USER_REMOTE** presence mode (📡): the operator is reachable only via a remote channel (e.g. Telegram) while the CLI sits unattended. The hazard in this state is not the agent *stopping* — it is the agent *hanging* on a tool that blocks on the empty CLI (an `AskUserQuestion` that never renders on the operator's phone, a `git push` that raises an unanswerable permission prompt).

## Why

Lived need: an entire c_14 afternoon was spent holding this discipline by hand — no `AskUserQuestion`, no Ask-list commands, local commits only — while the operator was remote. This mode makes the discipline structural instead of manual.

## How

- **policy** (`mode_system.md`): defines USER_REMOTE, its switch message, and the mode table entry.
- **detection** (`modes/detection.py`): `_detect_user_remote()` finds the latest USER_REMOTE `mode_change` and clears it only when CLI-*source* activity (`source ∈ {direct, mid_turn_enqueue}`) is newer than the set timestamp — a Telegram (`channel`) message does **not** clear it. Source-filtered `_get_last_user_activity_timestamp`.
- **cli** (`mode set USER_REMOTE` / `USER_PRESENT`): emits the `mode_change` event + the switch message.
- **v2 enforcement** (`utils/claude_settings.py`): `toggle_user_remote_deny_permissions()` moves the Ask-list plus `AskUserQuestion` into `deny` (Ask→Deny) so the agent routes around hang-prone tools rather than blocking. Restored on `USER_PRESENT`. (Takes effect on the next CC restart — permissions load at startup.)

## Tests

- `test_user_remote_detection.py` (8) — source-filtered auto-clear, epoch parsing, set/clear ordering.
- `test_user_remote_permissions.py` (4) — deny-toggle round-trip against `settings.local.json`.
- Full suite: **1464 passed**, 8 skipped, 9 xfailed. (2 pre-existing `test_time_cli` failures are environmental — the `time` command's stdout is polluted with a "Last CCP:" line on `main` as well; unrelated, tracked separately.)

## Note

USER_REMOTE is not enforceable in a running session until this merges and CC restarts (the detection vocabulary and the deny-toggle both load at startup).

Task: #143
