### PR TITLE
fix(session_start): ensure the Transcript Monitor runs on every session (#144)

### DIFF
--- a/macf/src/macf/hooks/handle_session_start.py
+++ b/macf/src/macf/hooks/handle_session_start.py
@@ -149,6 +149,27 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             "session_id": session_id
         })
 
+        # Ensure the Transcript Monitor is running (#144). TM produces the
+        # user_activity_detected events that USER_IDLE / USER_REMOTE detection
+        # depend on. It was previously started only opportunistically (AUTO_MODE
+        # entry, task-create), so a session that did neither ran blind and
+        # activity detection silently degraded. Tying it to the session lifecycle
+        # here covers every fresh start and every resume. start_daemon()
+        # daemonizes (non-blocking) and is idempotent; failure is logged, never
+        # fatal to the hook.
+        try:
+            from macf.transcript_monitor.daemon import (
+                is_running as _tm_running, start_daemon as _tm_start,
+            )
+            if not _tm_running():
+                _tm_start()
+        except (ImportError, OSError, RuntimeError) as e:
+            emit_warning(Warning(
+                source="session_start",
+                kind="transcript_monitor_autostart_failed",
+                detail=f"could not ensure transcript monitor running: {e}",
+            ))
+
         # PHASE 1: Check source field FIRST (highest priority)
         # This distinguishes user-initiated /compact from crash-based session migration
         source = data.get('source')

--- a/macf/tests/test_handle_session_start.py
+++ b/macf/tests/test_handle_session_start.py
@@ -38,6 +38,24 @@ def mock_dependencies():
         }
 
 
+def test_ensures_transcript_monitor_started_when_down(mock_dependencies):
+    """SessionStart auto-starts the Transcript Monitor when it isn't running (#144)."""
+    from macf.hooks.handle_session_start import run
+    with patch('macf.transcript_monitor.daemon.is_running', return_value=False), \
+         patch('macf.transcript_monitor.daemon.start_daemon') as m_start:
+        run("")
+    m_start.assert_called_once()
+
+
+def test_does_not_restart_running_transcript_monitor(mock_dependencies):
+    """If the Transcript Monitor is already up, SessionStart must not start a second (#144)."""
+    from macf.hooks.handle_session_start import run
+    with patch('macf.transcript_monitor.daemon.is_running', return_value=True), \
+         patch('macf.transcript_monitor.daemon.start_daemon') as m_start:
+        run("")
+    m_start.assert_not_called()
+
+
 def test_no_compaction_detected(mock_dependencies):
     """Test hook returns temporal awareness message when no compaction detected."""
     from macf.hooks.handle_session_start import run


### PR DESCRIPTION
## What

Ensures the **Transcript Monitor** (TM) is running on every session, started from the `SessionStart` hook — not only opportunistically when a `mode set` / `task create` happened to spin it up.

## Why

The TM feeds presence detection (USER_IDLE / USER_REMOTE auto-clear). Before this, it started only as a side effect of other commands, so a session that never ran one left presence detection silently blind. Discovered while building USER_REMOTE (#143): the monitor that the whole presence axis depends on had no guaranteed start.

## How

- `hooks/handle_session_start.py`: after the `HOOK_START` log, check `is_running()` and `start_daemon()` if not — idempotent, so restarts and continues don't double-spawn.

## Tests

- `test_handle_session_start.py` (+2): asserts the ensure-running block starts the TM when down and is a no-op when already up. Suite: 19 passed.

Task: #144
