### PR TITLE
feat(modes): behavioral-reinforcement message on every mode transition (#149, idea #091)

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -3322,6 +3322,10 @@ def cmd_mode_set_work(args: argparse.Namespace) -> int:
     info = WORK_MODES[mode]
     append_event("work_mode_change", {"mode": mode})
     print(f"✅ Work mode set: {info['emoji']} {mode}")
+    from .modes.transition_messages import transition_reinforcement
+    _reinforce = transition_reinforcement(mode)
+    if _reinforce:
+        print(f"   {_reinforce}")
 
     # PLAY_TIME transition recording
     try:
@@ -3656,6 +3660,10 @@ def cmd_mode_set(args: argparse.Namespace) -> int:
 
         if success:
             print(f"✅ {message}")
+            from .modes.transition_messages import transition_reinforcement
+            _reinforce = transition_reinforcement(mode)
+            if _reinforce:
+                print(f"   {_reinforce}")
 
             from .utils.claude_settings import (
                 set_autocompact_enabled, set_permission_mode,

--- a/macf/src/macf/modes/transition_messages.py
+++ b/macf/src/macf/modes/transition_messages.py
@@ -1,0 +1,76 @@
+"""Behavioral-reinforcement messages printed on mode transitions (idea #091).
+
+A mode change alters what the agent should and should not do. Printing a short
+"here is what this mode means for you" line at every transition keeps behavior
+aligned with the mode rather than relying on the agent to remember across a long
+session. The USER_REMOTE switch message is the exemplar this generalizes: every
+operational and work-mode transition should carry the same kind of reinforcement.
+
+Operator directive (Telegram, c_14): "helpful behavior reinforcement messages
+should be put at every mode transition."
+"""
+
+# Operational-mode reinforcement. USER_REMOTE prints its own richer switch
+# message at the transition site (the exemplar); the entry here is the one-line
+# form for echo/consistency.
+OPERATIONAL_REINFORCEMENT = {
+    "AUTO_MODE": (
+        "🤖 AUTO_MODE — operate autonomously within your scoped work. Valid stops: "
+        "scope complete, blocked needing operator input, wind-down at low context, "
+        "or an unrecoverable error. Do local work freely; outward or irreversible "
+        "actions (push, PR, merge, deletes) still prompt — batch them for the gate."
+    ),
+    "MANUAL_MODE": (
+        "✋ MANUAL_MODE — await operator direction. Do not self-scope new work; "
+        "report and stop at decision points."
+    ),
+    "USER_REMOTE": (
+        "📡 USER_REMOTE — operator on a remote channel, CLI unattended. Never use "
+        "tools that block on CLI input (AskUserQuestion, Ask-list commands) — they "
+        "hang the session. Talk via the remote channel; hold pushes."
+    ),
+}
+
+# Work-mode reinforcement — what the mode obligates the agent to do.
+WORK_REINFORCEMENT = {
+    "DISCOVER": (
+        "🔍 DISCOVER — explore and map the territory before committing to a build; "
+        "capture what you find so the exploration isn't lost."
+    ),
+    "EXPERIMENT": (
+        "🧪 EXPERIMENT — form a testable hypothesis and design its control BEFORE "
+        "building; a prototype without a hypothesis is just a build."
+    ),
+    "BUILD": (
+        "🔨 BUILD — implement against a validated hypothesis; prototypes live inside "
+        "the experiment CA, not scattered across the tree."
+    ),
+    "CURATE": (
+        "📋 CURATE — preserve knowledge: learnings, ideas, indexes, cross-references. "
+        "Perishable insight first."
+    ),
+    "CONSOLIDATE": (
+        "✍️ CONSOLIDATE — synthesize scattered findings into coherent artifacts; "
+        "connect them into the knowledge web."
+    ),
+    "SPRINT": (
+        "🏃 SPRINT — work the scoped set to completion; the Markov recommender is "
+        "silent. Complete each task the moment its work finishes."
+    ),
+}
+
+
+def transition_reinforcement(mode: str) -> str:
+    """Return the behavioral-reinforcement line for a mode transition.
+
+    Args:
+        mode: the mode being transitioned INTO (e.g. "AUTO_MODE", "BUILD").
+
+    Returns:
+        A short reinforcement string, or "" for an unknown mode (callers print
+        nothing rather than a blank line).
+    """
+    if not mode:
+        return ""
+    key = mode.upper()
+    return OPERATIONAL_REINFORCEMENT.get(key) or WORK_REINFORCEMENT.get(key, "")

--- a/macf/tests/test_transition_messages.py
+++ b/macf/tests/test_transition_messages.py
@@ -1,0 +1,39 @@
+"""Tests for mode-transition reinforcement messages (idea #091)."""
+
+from macf.modes.transition_messages import (
+    transition_reinforcement,
+    OPERATIONAL_REINFORCEMENT,
+    WORK_REINFORCEMENT,
+)
+
+
+def test_every_operational_mode_has_reinforcement():
+    for mode in ("AUTO_MODE", "MANUAL_MODE", "USER_REMOTE"):
+        assert transition_reinforcement(mode), f"no reinforcement for {mode}"
+
+
+def test_every_work_mode_has_reinforcement():
+    for mode in ("DISCOVER", "EXPERIMENT", "BUILD", "CURATE", "CONSOLIDATE", "SPRINT"):
+        assert transition_reinforcement(mode), f"no reinforcement for {mode}"
+
+
+def test_case_insensitive():
+    assert transition_reinforcement("build") == transition_reinforcement("BUILD")
+
+
+def test_unknown_or_empty_mode_returns_empty_string():
+    # Callers print nothing (not a blank line) for these.
+    assert transition_reinforcement("NOT_A_MODE") == ""
+    assert transition_reinforcement("") == ""
+    assert transition_reinforcement(None) == ""
+
+
+def test_user_remote_message_names_the_hazard():
+    msg = transition_reinforcement("USER_REMOTE")
+    assert "hang" in msg.lower()
+    assert "AskUserQuestion" in msg
+
+
+def test_auto_mode_message_names_valid_stops():
+    msg = transition_reinforcement("AUTO_MODE").lower()
+    assert "scope" in msg and "stop" in msg


### PR DESCRIPTION
## What

Emits a short **behavioral-reinforcement message on every mode transition** — both operational (`mode set`) and work-mode (`mode set-work`) changes.

## Why

Operator directive (c_14): *"helpful behavior reinforcement messages should be put at every mode transition."* A mode change silently altering what the agent should/shouldn't do is a missed teaching moment; the transition is exactly when a one-line reminder of the new mode's discipline lands with most effect.

## How

- New `modes/transition_messages.py`: `OPERATIONAL_REINFORCEMENT` + `WORK_REINFORCEMENT` dicts keyed by mode, and `transition_reinforcement(mode)` returning the message (or empty for unknown modes).
- Wired into both `cmd_mode_set` and `cmd_mode_set_work` in `cli.py`, alongside the existing per-mode handling (coexists with the USER_REMOTE branch from #223 — verified: both the reinforcement call and the USER_REMOTE/USER_PRESENT block are present and independent).

## Tests

- `test_transition_messages.py` (6): message presence per mode, empty for unknown, both dict families covered.
- Full suite on this branch: **1470 passed** (2 pre-existing `test_time_cli` env failures unrelated, present on `main`).

Task: #149 (idea #091)
