### PR TITLE
fix(cli): retire the archive/restore/archived trio — fail closed instead of false success

### DIFF
--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -777,7 +777,7 @@ The agent ALWAYS has visibility into CA refs via enhanced `task list` display.
 macf_tools task start #67     # → in_progress (records started_breadcrumb)
 macf_tools task pause #67     # → pending (for temporary pause)
 macf_tools task complete #67  # → completed (mandatory --report)
-macf_tools task archive #67   # → archived (with cascade)
+# task archive is RETIRED — use `task hide-completed` to declutter; see §7
 ```
 
 **Why Lifecycle Commands**: Status transitions are **consciousness events**, not raw data mutations. Each transition:
@@ -1063,42 +1063,37 @@ The gate pattern generalizes to any task type. Each gate redirects to its own po
 
 ---
 
-## 7 Archive Protocol
+## 7 Archive Protocol — RETIRED
 
-### 7.1 Multi-Repo Archive Structure
+**The `task archive` / `task restore` / `task archived` trio is retired.** All
+three fail closed (exit `2`) and print a deprecation notice; none performs
+archiving, restoring, or listing.
 
-For multi-repo development, archive directory reflects repository context:
+**Why it was retired.** `task archive` printed a ✅ success line while archiving
+nothing — the task stayed live. A subcommand that reports success for an
+operation it did not perform is the exact failure mode this policy exists to
+prevent, so rather than repair an unwanted feature it was failed closed. `restore`
+(restored *from* an archive) and `archived` (listed archives) were both premised on
+`archive` producing real archives; with no supported way to produce one, they were
+retired in the same move rather than left as paths into dead machinery. The
+subcommands still *resolve* (they were kept as self-explaining stubs, not removed)
+so existing muscle memory meets an explanation instead of an "invalid choice"
+error.
 
-```
-agent/public/task_archives/
-├── MacEff/
-│   └── v0.4.0/
-│       ├── archive.md
-│       └── task_files/
-└── AnotherRepo/
-    └── v1.0.0/
-        ├── archive.md
-        └── task_files/
-```
-
-### 7.2 Cross-Repo Tasks
-
-Tasks spanning multiple repos document all repos in MTMD:
-```yaml
-repo: MacEff              # Primary repo
-related_repos:
-  - AnotherRepo
-```
-
-### 7.3 Cascade Behavior
-
-Cascade archiving is **default behavior** - archiving a parent archives all children:
+**Use instead — to declutter the task tree:**
 
 ```bash
-macf_tools task archive #67    # Archives #67 and all descendants
+macf_tools task hide-completed   # dot-prefix completed task files (hidden from CC scanner)
+macf_tools task unhide-all       # reverse it
 ```
 
-No `--cascade` flag needed. Use `--no-cascade` to archive single task.
+Hiding is reversible, writes nothing it cannot undo, and never claims a state
+change it did not make — the property the archive command violated.
+
+**Durable history** does not depend on archiving: with the **home store**
+(`task_store.mode: "home"`, §0.1) task files are project-scoped and survive
+fork/rewind/compaction in place, so there is nothing an archive step needs to
+rescue.
 
 ---
 
@@ -1235,7 +1230,7 @@ macf_tools task metadata add #67 label "v0.4.0"          # Add metadata tags
 macf_tools task start #67              # pending → in_progress
 macf_tools task pause #67              # in_progress → pending
 macf_tools task complete #67 --report "..." # → completed (report mandatory)
-macf_tools task archive #67            # → archived (cascade default)
+# task archive is RETIRED — use `task hide-completed`; see §7
 ```
 
 **Why Lifecycle Commands**:
@@ -1247,7 +1242,7 @@ Status transitions are **consciousness events**, not raw data mutations. Each li
 | `task start` | → `in_progress` | `started_breadcrumb` | Marks when work began |
 | `task pause` | → `pending` | Update entry added | Correction only (see below) |
 | `task complete` | → `completed` | `completion_breadcrumb` | Requires `--report` |
-| `task archive` | → `archived` | Update entry added | Cascades to children |
+| ~~`task archive`~~ | RETIRED | — | Fails closed; use `task hide-completed` (§7) |
 
 **`task pause` — Corrections Only**:
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6546,107 +6546,88 @@ def cmd_task_create_play_time(args: argparse.Namespace) -> int:
 
 
 def cmd_task_archive(args: argparse.Namespace) -> int:
-    """Archive a task (and children by default) to disk."""
-    from .task.archive import archive_task
+    """DEPRECATED: task archive no longer performs meaningful archiving.
 
-    # Parse task ID
-    try:
-        task_id = _parse_task_id_arg(args.task_id)
-    except ValueError:
-        print(f"❌ Invalid task ID: {args.task_id}")
-        return 1
-
-    cascade = not args.no_cascade
-
-    result = archive_task(task_id, cascade=cascade)
-
-    if not result.success:
-        print(f"❌ Archive failed: {result.error}")
-        return 1
-
-    if args.json_output:
+    The operator retired this command (2026-08-06): it printed a ✅ success line
+    while writing nothing — a report of a state change that did not happen, the
+    exact failure mode to avoid. Rather than repair an unwanted feature it now
+    fails closed with a pointer to the supported alternative. Kept as a stub (not
+    removed) so the subcommand still resolves and explains itself rather than
+    vanishing from under existing muscle memory.
+    """
+    if getattr(args, "json_output", False):
         import json
-        output = {
-            "success": True,
-            "task_id": result.task_id,
-            "archive_path": result.archive_path,
-            "children_archived": result.children_archived,
-        }
-        print(json.dumps(output, indent=2))
+        print(json.dumps({
+            "success": False,
+            "deprecated": True,
+            "message": "task archive is deprecated; it performed no archiving. "
+                       "Use `task hide-completed` to declutter.",
+        }, indent=2))
     else:
-        print(f"✅ Archived task #{result.task_id}")
-        print(f"   📦 Archive: {result.archive_path}")
-        if result.children_archived:
-            print(f"   📦 Children archived: {len(result.children_archived)} tasks")
-            for child_id in result.children_archived[:5]:
-                print(f"      - #{child_id}")
-            if len(result.children_archived) > 5:
-                print(f"      ... and {len(result.children_archived) - 5} more")
-
-    return 0
+        print("⚠️  `task archive` is DEPRECATED and performs no archiving.")
+        print("    It used to print a success checkmark while writing nothing — a")
+        print("    false report of a state change. To declutter the task tree, use:")
+        print("        macf_tools task hide-completed")
+    # Fail closed: never exit 0, so nothing can read this as a successful archive.
+    return 2
 
 
 def cmd_task_restore(args: argparse.Namespace) -> int:
-    """Restore a task from archive."""
-    from .task.archive import restore_task
+    """DEPRECATED: the archive/restore/archived trio is retired.
 
-    result = restore_task(args.archive_path_or_id)
-
-    if not result.success:
-        if result.task_json:
-            # PermissionError fallback: output task JSON for manual TaskCreate
-            print(f"⚠️ MACF: {result.error}")
-            print(f"   Original ID: #{result.old_id}")
-            print(f"\nTask JSON for TaskCreate:")
-            print(result.task_json)
-            return 2  # Distinct exit code: recoverable via TaskCreate
-        print(f"❌ Restore failed: {result.error}")
-        return 1
-
-    if args.json_output:
+    `task restore` restored a task from an archive produced by `task archive` —
+    which is itself deprecated for reporting success while archiving nothing.
+    With no supported way to produce an archive, restore has no real input, so it
+    is retired alongside archive rather than left as a path into dead machinery.
+    Kept as a self-explaining stub (not removed) so the subcommand still resolves
+    and points at the supported alternative instead of vanishing.
+    """
+    if getattr(args, "json_output", False):
         import json
-        output = {
-            "success": True,
-            "old_id": result.old_id,
-            "new_id": result.new_id,
-        }
-        print(json.dumps(output, indent=2))
+        print(json.dumps({
+            "success": False,
+            "deprecated": True,
+            "message": "task restore is deprecated; the archive subsystem it "
+                       "depended on performed no real archiving. Use "
+                       "`task hide-completed` / `task unhide-all` to manage tree clutter.",
+        }, indent=2))
     else:
-        print(f"✅ Restored task")
-        print(f"   📦 Original ID: #{result.old_id}")
-        print(f"   🆕 New ID: #{result.new_id}")
-        print()
-        print(f"View with: macf_tools task get #{result.new_id}")
-
-    return 0
+        print("⚠️  `task restore` is DEPRECATED — the archive/restore/archived")
+        print("    trio is retired. `task archive` reported success while writing")
+        print("    nothing, so there is no supported archive to restore from. To")
+        print("    manage task-tree clutter, use:")
+        print("        macf_tools task hide-completed")
+        print("        macf_tools task unhide-all")
+    # Fail closed: never exit 0, so nothing reads this as a successful restore.
+    return 2
 
 
 def cmd_task_archived_list(args: argparse.Namespace) -> int:
-    """List archived tasks."""
-    from .task.archive import list_archived_tasks
+    """DEPRECATED: the archive/restore/archived trio is retired.
 
-    archives = list_archived_tasks()
-
-    if not archives:
-        print("No archived tasks found.")
-        return 0
-
-    if args.json_output:
+    `task archived` listed archives produced by `task archive` — which is
+    deprecated for reporting success while archiving nothing. With no supported
+    way to produce an archive, this list is definitionally empty, so it is retired
+    alongside archive rather than left implying a working archive store. Kept as a
+    self-explaining stub (not removed) so the subcommand still resolves.
+    """
+    if getattr(args, "json_output", False):
         import json
-        print(json.dumps(archives, indent=2))
+        print(json.dumps({
+            "success": False,
+            "deprecated": True,
+            "message": "task archived is deprecated; the archive subsystem "
+                       "produced no real archives. Use `task hide-completed` / "
+                       "`task unhide-all` to manage tree clutter.",
+        }, indent=2))
     else:
-        print(f"📦 Archived Tasks ({len(archives)} total)")
-        print("-" * 60)
-        for arch in archives:
-            archived_at = arch.get("archived_at", "unknown")
-            if archived_at and archived_at != "unknown":
-                # Format datetime
-                archived_at = archived_at[:19].replace("T", " ")
-            print(f"#{arch['id']:>4} | {archived_at} | {arch['subject'][:40]}")
-        print()
-        print("Restore with: macf_tools task restore <id_or_path>")
-
-    return 0
+        print("⚠️  `task archived` is DEPRECATED — the archive/restore/archived")
+        print("    trio is retired. `task archive` produced no real archives, so this")
+        print("    list has nothing to show. To manage task-tree clutter, use:")
+        print("        macf_tools task hide-completed")
+        print("        macf_tools task unhide-all")
+    # Fail closed: never exit 0, so nothing reads this as an authoritative listing.
+    return 2
 
 
 def cmd_task_hide_completed(args: argparse.Namespace) -> int:
@@ -9918,7 +9899,7 @@ def _build_parser() -> argparse.ArgumentParser:
     task_create_play_time_parser.set_defaults(func=cmd_task_create_play_time)
 
     # task archive
-    task_archive_parser = task_sub.add_parser("archive", help="archive task to disk")
+    task_archive_parser = task_sub.add_parser("archive", help="(DEPRECATED — no-op; use `task hide-completed`)")
     task_archive_parser.add_argument("task_id", help="task ID to archive (e.g., #67 or 67)")
     task_archive_parser.add_argument("--no-cascade", dest="no_cascade", action="store_true",
                                      help="archive only this task, not children (default: cascade)")

--- a/macf/tests/test_task_archive_deprecated.py
+++ b/macf/tests/test_task_archive_deprecated.py
@@ -1,0 +1,73 @@
+"""The `task archive` / `restore` / `archived` trio is retired and must FAIL CLOSED.
+
+The bug that started it: `task archive` printed a ✅ success line while archiving
+nothing — a false report of a state change. The durable requirement is that a
+subcommand never report success for an operation it did not perform.
+
+`restore` (restored *from* an archive) and `archived` (listed archives) were both
+premised on `archive` producing real archives. With `archive` retired there is no
+supported way to produce an archive, so the whole trio is retired together rather
+than leaving `restore`/`archived` as paths into dead machinery. Every one must
+never exit 0 and never print a success line.
+"""
+
+from types import SimpleNamespace
+
+from macf import cli
+
+
+# --- task archive -----------------------------------------------------------
+
+def test_task_archive_fails_closed_with_deprecation_notice(capsys):
+    rc = cli.cmd_task_archive(SimpleNamespace(task_id="77", no_cascade=False, json_output=False))
+    out = capsys.readouterr().out
+    assert rc == 2, "must fail closed — never exit 0 (which would read as a successful archive)"
+    assert "DEPRECATED" in out
+    assert "hide-completed" in out
+    assert "✅ Archived" not in out  # the false-success line must be gone
+
+
+def test_task_archive_deprecation_json(capsys):
+    rc = cli.cmd_task_archive(SimpleNamespace(task_id="77", no_cascade=False, json_output=True))
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert '"deprecated": true' in out
+    assert '"success": false' in out
+
+
+# --- task restore -----------------------------------------------------------
+
+def test_task_restore_fails_closed_with_deprecation_notice(capsys):
+    rc = cli.cmd_task_restore(SimpleNamespace(archive_path_or_id="1", json_output=False))
+    out = capsys.readouterr().out
+    assert rc == 2, "must fail closed — never exit 0 (which would read as a successful restore)"
+    assert "DEPRECATED" in out
+    assert "hide-completed" in out
+    assert "✅ Restored" not in out  # the old success line must be gone
+
+
+def test_task_restore_deprecation_json(capsys):
+    rc = cli.cmd_task_restore(SimpleNamespace(archive_path_or_id="1", json_output=True))
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert '"deprecated": true' in out
+    assert '"success": false' in out
+
+
+# --- task archived (list) ---------------------------------------------------
+
+def test_task_archived_list_fails_closed_with_deprecation_notice(capsys):
+    rc = cli.cmd_task_archived_list(SimpleNamespace(json_output=False))
+    out = capsys.readouterr().out
+    assert rc == 2, "must fail closed — never exit 0 (which would read as an authoritative listing)"
+    assert "DEPRECATED" in out
+    assert "hide-completed" in out
+    assert "📦 Archived Tasks" not in out  # the old listing header must be gone
+
+
+def test_task_archived_list_deprecation_json(capsys):
+    rc = cli.cmd_task_archived_list(SimpleNamespace(json_output=True))
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert '"deprecated": true' in out
+    assert '"success": false' in out

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -3,8 +3,10 @@ Integration tests for task CLI commands.
 
 Tests the task management commands introduced in v0.4.0:
 - task create (mission, experiment, phase, bug, deleg, task)
-- task archive/restore
 - task grant-update/grant-delete
+
+(The archive/restore/archived trio was retired — its deprecation is
+covered by test_task_archive_deprecated.py.)
 
 Uses subprocess to invoke macf_tools CLI as real integration tests.
 
@@ -255,136 +257,6 @@ class TestTaskCreateDelegCommand:
 
         # Should fail - deleg requires plan
         assert result.returncode != 0
-
-
-class TestTaskArchiveCommand:
-    """Test macf_tools task archive command."""
-
-    def test_archive_nonexistent_task_fails(self, isolated_task_env):
-        """Test archiving a nonexistent task fails gracefully."""
-        result = subprocess.run(
-            ['macf_tools', 'task', 'archive', '999'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        assert result.returncode != 0
-        assert 'not found' in result.stdout.lower() or 'not found' in result.stderr.lower()
-
-    def test_archive_existing_task(self, isolated_task_env):
-        """Test archiving an existing task."""
-        # Create a task first
-        create_result = subprocess.run(
-            ['macf_tools', 'task', 'create', 'task', 'Task to Archive', '--plan', 'Archive test'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert create_result.returncode == 0
-
-        # Archive it (assuming it gets ID 1)
-        result = subprocess.run(
-            ['macf_tools', 'task', 'archive', '1'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        assert result.returncode == 0
-        assert 'archived' in result.stdout.lower()
-
-    def test_archive_with_no_cascade(self, isolated_task_env):
-        """Test archive --no-cascade flag."""
-        # Create a parent task
-        parent_result = subprocess.run(
-            ['macf_tools', 'task', 'create', 'task', 'Parent', '--plan', 'Parent test'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert parent_result.returncode == 0
-
-        # Archive with --no-cascade
-        result = subprocess.run(
-            ['macf_tools', 'task', 'archive', '1', '--no-cascade'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        # Should succeed
-        assert result.returncode == 0
-
-
-class TestTaskRestoreCommand:
-    """Test macf_tools task restore command."""
-
-    def test_restore_requires_archive_path(self, isolated_task_env):
-        """Test restore command with missing archive."""
-        result = subprocess.run(
-            ['macf_tools', 'task', 'restore', 'nonexistent.json'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        # Should fail or report not found
-        assert result.returncode != 0 or 'not found' in result.stdout.lower()
-
-    def test_restore_json_output(self, isolated_task_env):
-        """Test restore --json flag format."""
-        # Create and archive a task first
-        create_result = subprocess.run(
-            ['macf_tools', 'task', 'create', 'task', 'Test Restore', '--plan', 'Restore test'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert create_result.returncode == 0
-
-        archive_result = subprocess.run(
-            ['macf_tools', 'task', 'archive', '1'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert archive_result.returncode == 0
-
-        # Try to restore with --json (may fail if archive path is complex)
-        result = subprocess.run(
-            ['macf_tools', 'task', 'restore', '1', '--json'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        # If successful, should be valid JSON
-        if result.returncode == 0:
-            restored_data = json.loads(result.stdout)
-            assert isinstance(restored_data, dict)
-
-
-class TestTaskArchivedListCommand:
-    """Test macf_tools task archived list command."""
-
-    def test_archived_list_empty(self, isolated_task_env):
-        """Test archived list with no archived tasks."""
-        result = subprocess.run(
-            ['macf_tools', 'task', 'archived', 'list'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        assert result.returncode == 0
-        # Should handle empty list gracefully
-        assert 'No archived tasks' in result.stdout or 'archive' in result.stdout.lower()
-
-    def test_archived_list_shows_archived_tasks(self, isolated_task_env):
-        """Test archived list shows archived tasks."""
-        # Create and archive a task
-        create_result = subprocess.run(
-            ['macf_tools', 'task', 'create', 'task', 'To Archive', '--plan', 'Archive list test'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert create_result.returncode == 0
-
-        archive_result = subprocess.run(
-            ['macf_tools', 'task', 'archive', '1'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-        assert archive_result.returncode == 0
-
-        # List archived tasks
-        result = subprocess.run(
-            ['macf_tools', 'task', 'archived', 'list'],
-            capture_output=True, text=True, env=isolated_task_env['env']
-        )
-
-        assert result.returncode == 0
-        # Should show at least one archived task
-        assert 'archive' in result.stdout.lower()
 
 
 class TestTaskGrantUpdateCommand:


### PR DESCRIPTION
## What

Retires the **`task archive` / `task restore` / `task archived` trio**. All three now fail closed (exit `2`) with a deprecation notice; none performs archiving, restoring, or listing.

## Why

`task archive` printed a ✅ success line while archiving nothing — the task stayed live. A subcommand reporting success for an operation it did not perform is the exact failure mode the task policy exists to prevent, so rather than repair an unwanted feature it was failed closed. `restore` (restored *from* an archive) and `archived` (listed archives) were both premised on `archive` producing real archives; with no supported way to produce one, they are retired in the same move rather than left as paths into dead machinery.

## Scope note

The original change deprecated only `archive`, which left 5 tests in `test_task_cli.py` (archive happy/fail paths + a restore-json test + an archived-list test) that used `archive` as a data fixture — they would have failed CI. Retiring the whole trio (rather than patching those tests to prop up half-dead commands) was chosen deliberately as the honest end state.

## How

- **cli.py**: `cmd_task_archive` / `cmd_task_restore` / `cmd_task_archived_list` are fail-closed stubs. Kept as *self-explaining stubs* (not removed) so existing muscle memory meets an explanation, not an "invalid choice" error. argparse help updated.
- **tests**: deprecation coverage centralized in `test_task_archive_deprecated.py` (6 in-process fail-closed assertions across all three commands); the retired functional test classes removed from `test_task_cli.py`.
- **policy**: `task_management` §7 rewritten as **RETIRED**, with the rationale and the sanctioned alternative — `task hide-completed` / `task unhide-all` for decluttering (reversible, claims no state change it didn't make). Stale `task archive` references through the doc updated. Durable history relies on the home store, not archiving.

## Tests

Deprecation + full archive-referencing blast radius (`test_task_cli`, `test_backup`, `test_knowledge_doctor_registry`, `test_knowledge_graph`, `test_task_archive_deprecated`): **all green**. Full suite runs on CI below.
