### PR TITLE
feat(cli): task start cascades pending ancestors and reports it

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6895,8 +6895,35 @@ def cmd_task_start(args: argparse.Namespace) -> int:
                 })
                 injected_policies.append(policy_name)
 
+    # Cascade upstream (#115 / GH#212): a phase in_progress under an ancestor
+    # still 'pending' makes the tree misreport where work stands — orientation
+    # reads the MISSION as "nobody is working this", the wrong direction. Walk the
+    # ancestor chain and start any pending ancestor, reporting each so the
+    # resumption is visible rather than silent.
+    cascaded = []
+    if task.mtmd and getattr(task.mtmd, "parent_id", None):
+        from .task.create import _run_task_start
+        seen = {str(task_id)}
+        parent_id = task.mtmd.parent_id
+        while parent_id and str(parent_id) not in seen and str(parent_id) != "000":
+            seen.add(str(parent_id))
+            try:
+                pid_int = int(str(parent_id).lstrip("#"))
+            except (ValueError, TypeError):
+                break
+            ancestor = reader.read_task(pid_int)
+            if not ancestor:
+                break
+            if ancestor.status == "pending" and _run_task_start(pid_int):
+                cascaded.append(pid_int)
+            parent_id = ancestor.mtmd.parent_id if ancestor.mtmd else None
+
     print(f"✅ Task #{task_id} started")
     print(f"   Breadcrumb: {breadcrumb}")
+    if cascaded:
+        print(f"   ⬆️  Cascade-started {len(cascaded)} pending ancestor(s): "
+              + ", ".join(f"#{c}" for c in cascaded))
+        print("      (a phase cannot truly be underway while an ancestor reads 'pending')")
     if injected_policies:
         print(f"   Auto-injected policies: {injected_policies}")
     if stale:

--- a/macf/tests/test_task_start_cascade.py
+++ b/macf/tests/test_task_start_cascade.py
@@ -1,0 +1,44 @@
+"""`task start` cascades pending ancestors and reports it (#115 / GH#212).
+
+A phase in_progress under a MISSION still 'pending' makes the tree misreport
+where work stands. Starting a child must start any pending ancestor and say so.
+Driven through the real CLI against an isolated task store.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+
+def _cli(store, *args):
+    env = dict(os.environ, MACF_TASK_STORE_DIR=str(store))
+    return subprocess.run(["macf_tools", *args], capture_output=True, text=True, env=env)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return tmp_path
+
+
+def test_start_cascades_and_reports_pending_ancestor(store):
+    _cli(store, "task", "create", "task", "Parent umbrella", "--plan", "parent")
+    _cli(store, "task", "create", "phase", "--parent", "1", "Child phase", "--plan", "child")
+
+    started = _cli(store, "task", "start", "2")
+    assert "Cascade-started" in started.stdout, started.stdout
+    assert "#1" in started.stdout
+
+    # Ground truth: the ancestor is actually in_progress now, not just reported.
+    assert "in_progress" in _cli(store, "task", "get", "1").stdout
+
+
+def test_no_cascade_when_ancestor_already_started(store):
+    # Negative control: nothing to cascade means nothing is reported (and the
+    # command doesn't spuriously restart an already-active ancestor).
+    _cli(store, "task", "create", "task", "Parent umbrella", "--plan", "parent")
+    _cli(store, "task", "start", "1")
+    _cli(store, "task", "create", "phase", "--parent", "1", "Child phase", "--plan", "child")
+
+    started = _cli(store, "task", "start", "2")
+    assert "Cascade-started" not in started.stdout, started.stdout


### PR DESCRIPTION
## What

`task start` now **cascades**: starting a child of an unstarted parent walks the parent chain up to the root, starts every pending ancestor, and reports what it did.

## Why

Starting a leaf while its parents sit `pending` produced a tree that claimed no work was underway on the branch the work was actually on — the same "tree doesn't reflect reality" failure this policy keeps fighting. Cascading makes starting a leaf tell the truth about the whole lineage.

## How

- `cmd_task_start` (cli.py): walks `parent_id` up to the root sentinel, runs the start path on each pending ancestor, and prints an `⬆️ Cascade-started` summary. Idempotent — ancestors already `in_progress`/`completed` are skipped.

## Tests

`test_task_start_cascade.py` (2, subprocess): cascade starts pending ancestors; already-started ancestors are untouched. Broader `test_task_cli.py` still green (69 passed). Full suite on CI.

Closes #212
