### PR TITLE
test(knowledge-web): lock idea status as a queryable node property

### DIFF
--- a/macf/tests/test_query_idea_status.py
+++ b/macf/tests/test_query_idea_status.py
@@ -1,0 +1,23 @@
+"""Idea status is a queryable node property so retrieval can tell a proposal
+from a finding (#121). This locks the property (satisfied via #216's extraction)
+so it cannot silently regress."""
+from macf.knowledge_web import query_knowledge_web
+
+
+def test_query_result_carries_idea_status():
+    kg = {
+        "ideas": {
+            1: {"title": "A proposal", "status": "captured", "category": "tooling"},
+            2: {"title": "A finding", "status": "promoted", "category": "tooling"},
+        },
+        "ca_nodes": {},
+        "wiki_index": {"topic": {1, 2}},
+        "edges": {1: {2}, 2: {1}},
+        "stats": {},
+    }
+    result = query_knowledge_web("topic", kg)
+    nodes = list(result.get("nodes", [])) + list(result.get("neighbors", []))
+    by_id = {n["id"]: n for n in nodes}
+    # The proposal-vs-finding weighting must be present per idea node.
+    assert by_id["1"]["status"] == "captured"
+    assert by_id["2"]["status"] == "promoted"


### PR DESCRIPTION
## What

Locks **idea status as a queryable node property** in the knowledge web — a regression test so retrieval can always distinguish a proposal from a finding.

## Why

The knowledge-web query returns nodes with their properties; idea `status` (e.g. proposal vs finding) must be exposed as a node property, not buried, so a query can tell which is which. The behavior was satisfied by earlier knowledge-web work but had no test pinning it — this adds the lock so a regression fails the suite instead of silently degrading retrieval.

## Tests

`test_query_idea_status.py` (1): querying surfaces idea `status` as a node property (the result key is `nodes`). Passed against current main. Full suite on CI.
