### PR TITLE
fix(cli): source tree/list scope markers from the event log, not the MTMD field

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -4260,12 +4260,15 @@ def cmd_task_list(args: argparse.Namespace) -> int:
             key=lambda t: str(t.id).zfill(10),
         )
 
-    # Load scope state from MTMD scope_status field on tasks (same source as cmd_task_tree).
-    # Without this, format_task's scope indicator block raises NameError (gh-48).
-    scope_state = {}
-    for t in tasks:
-        if t.mtmd and getattr(t.mtmd, 'scope_status', None):
-            scope_state[t.id] = t.mtmd.scope_status
+    # Scope markers are sourced from the EVENT LOG — the single source of truth the
+    # gate uses — not the per-task MTMD scope_status field. That field is a
+    # denormalized cache duplicated across task stores and drifts both ways: markers
+    # vanish where it is unwritten (the event log has the task), and zombie orphans
+    # persist where it is stale (the event log dropped it). get_scope_state() replays
+    # scope events and is store-independent, so the tree always agrees with
+    # `scope check` / `scope show`.
+    from .task.scope import get_scope_state
+    scope_state = get_scope_state()
 
     def format_task(t: MacfTask, indent: int = 0) -> str:
         prefix = "  " * indent
@@ -4291,10 +4294,12 @@ def cmd_task_list(args: argparse.Namespace) -> int:
             status_icon = "◻"
             line = f"{prefix}{status_icon} {_dim_task_ids(subject_with_live_parent(t))}"
 
-        # Scope indicator (👀 for active, ✅ for completed/inactive)
+        # Scope indicator (👀 active, ⏸️ paused, ✅ inactive/completed)
         if scope_state and t.id in scope_state:
             if scope_state[t.id] == "active":
                 line += " 👀"
+            elif scope_state[t.id] == "paused":
+                line += " ⏸️"
             elif scope_state[t.id] == "inactive":
                 line += " ✅"
 
@@ -4472,11 +4477,11 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
         reader = TaskReader()
         all_tasks = reader.read_all_tasks()
 
-        # Load scope state from MTMD scope_status field on tasks
-        scope_state = {}
-        for t in all_tasks:
-            if t.mtmd and getattr(t.mtmd, 'scope_status', None):
-                scope_state[t.id] = t.mtmd.scope_status
+        # Scope markers sourced from the event log (single source of truth), not the
+        # per-task MTMD scope_status field which drifts across stores. See the note
+        # at the other render site.
+        from .task.scope import get_scope_state
+        scope_state = get_scope_state()
 
         # Archive filtering (default: hide archived)
         def is_archived(task):
@@ -4789,6 +4794,8 @@ def cmd_task_tree(args: argparse.Namespace) -> int:
             if scope_state and task.id in scope_state:
                 if scope_state[task.id] == "active":
                     text += " 👀"
+                elif scope_state[task.id] == "paused":
+                    text += " ⏸️"
 
             text += recency_marker(task)
 

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -259,6 +259,37 @@ class TestTaskCreateDelegCommand:
         assert result.returncode != 0
 
 
+class TestTreeScopeMarkersFromEventLog:
+    """The tree's scope markers come from the event-sourced scope state, not the
+    drift-prone per-task MTMD scope_status field."""
+
+    def test_active_from_events_shows_marker_even_when_mtmd_absent(self, isolated_task_env):
+        """The discriminating case: a task active in the EVENT LOG but with no MTMD
+        scope_status must still show 👀. Fails against the old MTMD-sourced render."""
+        import re
+        env = isolated_task_env['env']
+        tid = str(json.loads(subprocess.run(
+            ['macf_tools', 'task', 'create', 'task', 'Scoped', '--plan', 'p', '--json'],
+            capture_output=True, text=True, env=env).stdout)['task_id'])
+
+        # Scope it (writes both the scope_activated event and the MTMD field)...
+        subprocess.run(['macf_tools', 'task', 'scope', 'set', tid],
+                       capture_output=True, text=True, env=env)
+        # ...then force the store drift: strip scope_status from the task file so
+        # ONLY the event log knows the task is scoped.
+        tf = isolated_task_env['session_dir'] / f"{tid}.json"
+        data = json.loads(tf.read_text())
+        data['description'] = re.sub(r'\n?scope_status:[^\n]*', '', data.get('description', ''))
+        tf.write_text(json.dumps(data))
+        assert 'scope_status' not in tf.read_text(), "precondition: MTMD scope_status stripped"
+
+        tree = subprocess.run(['macf_tools', 'task', 'tree'],
+                              capture_output=True, text=True, env=env)
+        # 👀 is produced ONLY by the scope marker (not by any note), so this is a
+        # clean signal that the marker was sourced from the event log.
+        assert '👀' in tree.stdout, "event-active task must show 👀 despite absent MTMD scope_status"
+
+
 class TestTaskGrantUpdateCommand:
     """Test macf_tools task grant-update command."""
 
@@ -983,20 +1014,33 @@ class TestTaskListCommand:
         assert 'Test task 100' in result.stdout
 
     def test_task_list_shows_scope_indicator_for_active_scope(self, isolated_task_env):
-        """Positive test: active scope shows 👀 indicator (the feature gh-48's bug gated)."""
-        self._write_task(isolated_task_env['session_dir'], 101, scope_status='active')
-        result = subprocess.run(
-            ['macf_tools', 'task', 'list'],
-            capture_output=True, text=True, env=isolated_task_env['env'])
+        """Positive test: a task active in the event-sourced scope shows 👀.
+
+        Scope is established through the event log (`scope set`) — the single source
+        of truth the list now reads — not by writing the MTMD scope_status field."""
+        env = isolated_task_env['env']
+        self._write_task(isolated_task_env['session_dir'], 101)
+        subprocess.run(['macf_tools', 'task', 'scope', 'set', '101'],
+                       capture_output=True, text=True, env=env)
+        result = subprocess.run(['macf_tools', 'task', 'list'],
+                                capture_output=True, text=True, env=env)
         assert result.returncode == 0, f'stderr: {result.stderr}'
         assert '👀' in result.stdout
 
     def test_task_list_shows_scope_indicator_for_inactive_scope(self, isolated_task_env):
-        """Inactive scope shows ✅ indicator."""
-        self._write_task(isolated_task_env['session_dir'], 102, scope_status='inactive')
-        result = subprocess.run(
-            ['macf_tools', 'task', 'list'],
-            capture_output=True, text=True, env=isolated_task_env['env'])
+        """A task completed while scoped shows ✅ (inactive) — event-sourced.
+
+        Two tasks are scoped and one completed; the other stays active so the scope
+        is not auto-cleared, leaving the completed one as inactive-in-scope."""
+        env = isolated_task_env['env']
+        self._write_task(isolated_task_env['session_dir'], 102)
+        self._write_task(isolated_task_env['session_dir'], 103)
+        subprocess.run(['macf_tools', 'task', 'scope', 'set', '102', '103'],
+                       capture_output=True, text=True, env=env)
+        subprocess.run(['macf_tools', 'task', 'complete', '102', '--report', 'done'],
+                       capture_output=True, text=True, env=env)
+        result = subprocess.run(['macf_tools', 'task', 'list', '--all'],
+                                capture_output=True, text=True, env=env)
         assert result.returncode == 0, f'stderr: {result.stderr}'
         assert '✅' in result.stdout
 


### PR DESCRIPTION
The task tree and list rendered their scope markers (👀/✅) from a denormalized
per-task MTMD scope_status field — a second copy of scope state, duplicated across
task stores, that drifts from the event log both ways: markers VANISH where the
field is unwritten (the gate's event log has the task) and ZOMBIE ORPHANS persist
where it is stale (the event log dropped it). The event log (get_scope_state) is the
single source of truth the gate already uses, and it is store-independent.

Both render sites now read get_scope_state(); paused scope renders ⏸️ to match
`scope show`, so the tree/list always agree with `scope check`.

- cli.py: cmd_task_list + cmd_task_tree source scope_state from get_scope_state();
  paused → ⏸️ added at both marker sites.
- tests: a discriminating regression (a task active in the event log but with no MTMD
  scope_status must still show 👀 — proven to fail without the fix); the two
  list-indicator tests now establish scope through the event log rather than writing
  the obsolete MTMD field.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
