### PR TITLE
feat(task-lifecycle): cascade on every start path + guard completing over open children

### DIFF
--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -6908,22 +6908,18 @@ def cmd_task_start(args: argparse.Namespace) -> int:
     # ancestor chain and start any pending ancestor, reporting each so the
     # resumption is visible rather than silent.
     cascaded = []
-    if task.mtmd and getattr(task.mtmd, "parent_id", None):
+    if task.mtmd and getattr(task.mtmd, "parent_id", None) and str(task.mtmd.parent_id).lstrip("#") != "000":
         from .task.create import _run_task_start
-        seen = {str(task_id)}
-        parent_id = task.mtmd.parent_id
-        while parent_id and str(parent_id) not in seen and str(parent_id) != "000":
-            seen.add(str(parent_id))
-            try:
-                pid_int = int(str(parent_id).lstrip("#"))
-            except (ValueError, TypeError):
-                break
-            ancestor = reader.read_task(pid_int)
-            if not ancestor:
-                break
-            if ancestor.status == "pending" and _run_task_start(pid_int):
-                cascaded.append(pid_int)
-            parent_id = ancestor.mtmd.parent_id if ancestor.mtmd else None
+        try:
+            _pid = int(str(task.mtmd.parent_id).lstrip("#"))
+        except (ValueError, TypeError):
+            _pid = None
+        if _pid is not None:
+            ancestor = reader.read_task(_pid)
+            if ancestor and ancestor.status == "pending":
+                # _run_task_start now cascades the full ancestor chain through the
+                # shared chokepoint; collect the started ancestors for the report.
+                _run_task_start(_pid, _cascaded=cascaded)
 
     print(f"✅ Task #{task_id} started")
     print(f"   Breadcrumb: {breadcrumb}")
@@ -7976,6 +7972,30 @@ def cmd_task_complete(args: argparse.Namespace) -> int:
     if task.status == "completed":
         print(f"⚠️  Task #{task_id} is already completed")
         return 1
+
+    # Guard: completing a parent while its children are still open puts a done
+    # parent over unfinished work — an inconsistency the tree reader can't trust.
+    # In AUTO_MODE (or with --force) warn and proceed; otherwise refuse and point
+    # at the fix. Mirror of cascade-start, which guards the start direction.
+    _open_children = [
+        (t.id, t.status) for t in reader.read_all_tasks()
+        if t.mtmd and str(getattr(t.mtmd, "parent_id", "") or "").lstrip("#") == str(task_id)
+        and t.status in ("pending", "in_progress")
+    ]
+    if _open_children:
+        try:
+            from .modes import detect_auto_mode
+            _auto, _ = detect_auto_mode(get_current_session_id())
+        except Exception:
+            _auto = False
+        _listing = ", ".join(f"#{cid}({st})" for cid, st in _open_children[:8])
+        print(f"⚠️  Task #{task_id} has {len(_open_children)} incomplete child task(s): {_listing}")
+        if _auto or getattr(args, "force", False):
+            print("   Completing anyway (AUTO_MODE / --force) — those children remain open.")
+        else:
+            print("   A parent completing over open children misrepresents the tree.")
+            print("   Complete, reparent, or pause the children first — or re-run with --force.")
+            return 1
 
     # Type-specific completion gate: GH_ISSUE
     task_type = getattr(task.mtmd, 'task_type', None) if task.mtmd else None

--- a/macf/src/macf/task/create.py
+++ b/macf/src/macf/task/create.py
@@ -1657,8 +1657,16 @@ def _play_log_skeleton(title: str, goal: str, chain: List[str],
 # Internal helpers for auto-start chain
 # ---------------------------------------------------------------------------
 
-def _run_task_start(task_id: int, session_uuid: Optional[str] = None) -> bool:
+def _run_task_start(task_id: int, session_uuid: Optional[str] = None,
+                    cascade: bool = True, _cascaded: Optional[List[int]] = None) -> bool:
     """Start a task programmatically (mirrors cmd_task_start logic).
+
+    Cascades upstream by default: starting any task starts its pending ancestors
+    too, so the tree never shows work underway on a branch whose parents still read
+    'pending'. Because the cascade lives in this shared chokepoint, EVERY start path
+    inherits it — explicit ``task start``, sprint/play_time auto-start, and this
+    function's own recursion — not only the CLI command. Pass ``_cascaded`` a list
+    to collect the ancestor IDs that were started (for reporting).
 
     Returns True on success, False on failure.
     """
@@ -1698,6 +1706,24 @@ def _run_task_start(task_id: int, session_uuid: Optional[str] = None) -> bool:
         "breadcrumb": breadcrumb,
         "plan_ca_ref": plan_ca_ref,
     })
+
+    if _cascaded is not None:
+        _cascaded.append(int(task_id))
+
+    # Cascade upstream through the shared chokepoint (terminates at the root
+    # sentinel or the first already-in_progress ancestor, whose call returns early).
+    if cascade and task.mtmd:
+        parent_id = getattr(task.mtmd, "parent_id", None)
+        if parent_id and str(parent_id).lstrip("#") not in ("000", "0", ""):
+            try:
+                pid_int = int(str(parent_id).lstrip("#"))
+            except (ValueError, TypeError):
+                pid_int = None
+            if pid_int is not None:
+                parent = reader.read_task(pid_int)
+                if parent and parent.status == "pending":
+                    _run_task_start(pid_int, session_uuid=session_uuid,
+                                    cascade=True, _cascaded=_cascaded)
     return True
 
 

--- a/macf/tests/test_task_complete_child_guard.py
+++ b/macf/tests/test_task_complete_child_guard.py
@@ -1,0 +1,46 @@
+"""Completing a parent with incomplete children is guarded (idea #095).
+
+A done parent over unfinished children misrepresents the tree. Outside AUTO_MODE the
+completion is refused (re-run with --force to override); a leaf task completes
+without any warning. Driven through the real CLI against an isolated task store.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+
+def _cli(store, *args):
+    env = dict(os.environ, MACF_TASK_STORE_DIR=str(store))
+    return subprocess.run(["macf_tools", *args], capture_output=True, text=True, env=env)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return tmp_path
+
+
+def test_complete_parent_with_open_child_is_refused(store):
+    _cli(store, "task", "create", "task", "Parent", "--plan", "p")
+    _cli(store, "task", "create", "task", "Child", "--parent", "1", "--plan", "c")
+    r = _cli(store, "task", "complete", "1", "--report", "done")
+    assert r.returncode != 0, r.stdout
+    assert "incomplete child" in r.stdout.lower(), r.stdout
+    # Ground truth: the parent was NOT completed.
+    assert "completed" not in _cli(store, "task", "get", "1").stdout.lower()
+
+
+def test_force_completes_parent_over_open_child_but_still_warns(store):
+    _cli(store, "task", "create", "task", "Parent", "--plan", "p")
+    _cli(store, "task", "create", "task", "Child", "--parent", "1", "--plan", "c")
+    r = _cli(store, "task", "complete", "1", "--report", "done", "--force")
+    assert r.returncode == 0, r.stdout
+    assert "incomplete child" in r.stdout.lower(), r.stdout  # warned, but proceeded
+
+
+def test_leaf_task_completes_with_no_child_warning(store):
+    _cli(store, "task", "create", "task", "Solo", "--plan", "p")
+    r = _cli(store, "task", "complete", "1", "--report", "done")
+    assert r.returncode == 0, r.stdout
+    assert "incomplete child" not in r.stdout.lower()

--- a/macf/tests/test_task_start_cascade.py
+++ b/macf/tests/test_task_start_cascade.py
@@ -42,3 +42,16 @@ def test_no_cascade_when_ancestor_already_started(store):
 
     started = _cli(store, "task", "start", "2")
     assert "Cascade-started" not in started.stdout, started.stdout
+
+
+def test_sprint_auto_start_cascades_pending_parent(store):
+    """#156: the cascade lives in the shared start chokepoint (_run_task_start), so
+    creating a SPRINT under a pending parent auto-starts (cascades) the parent — the
+    cascade is no longer confined to the explicit `task start` command. Proven to
+    fail before the fix (the sprint auto-start bypassed the CLI-only cascade)."""
+    _cli(store, "task", "create", "task", "Parent umbrella", "--plan", "parent")
+    created = _cli(store, "task", "create", "sprint", "Child sprint",
+                   "--parent", "1", "--children", "A", "B")
+    assert "Auto-started in SPRINT mode" in created.stdout, created.stdout
+    # Ground truth: the pending parent is now in_progress via the chokepoint cascade.
+    assert "in_progress" in _cli(store, "task", "get", "1").stdout


### PR DESCRIPTION
Two sides of the same parent/child consistency:

- Parent cascade lived only in `cmd_task_start`, so sprint/play_time auto-start (and
  any _run_task_start caller) bypassed it — creating a sprint under a pending parent
  left the parent 'pending' while its child ran. Moved the cascade into the shared
  `_run_task_start` chokepoint (recursive; terminates at root or the first
  already-started ancestor); the CLI command now leverages it and still reports the
  cascaded ancestors.
- Completing a parent while its children are still open put a done parent over
  unfinished work with no warning. `task complete` now refuses outside AUTO_MODE
  (warns-and-proceeds in AUTO_MODE or with --force), listing the open children.

- create.py: _run_task_start gains a cascade flag + an ancestor collector.
- cli.py: cmd_task_start uses the chokepoint cascade; cmd_task_complete guards
  parent-over-open-children.
- tests: sprint auto-start cascades the pending parent (proven to fail without the
  fix); complete-parent refused / --force / leaf-clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
