### PR TITLE
refactor(scope): retire the MTMD scope_status field — scope is event-sourced only

### DIFF
--- a/macf/src/macf/task/models.py
+++ b/macf/src/macf/task/models.py
@@ -103,8 +103,7 @@ class MacfTaskMetaData:
     archived: bool = False
     archived_at: Optional[str] = None
 
-    # Optional - scope tracking (set by scope system, nullable)
-    scope_status: Optional[str] = None  # None | "active" | "inactive"
+    # (scope_status field RETIRED — scope is event-sourced via get_scope_state)
 
     # Optional - custom fields
     custom: Dict[str, Any] = field(default_factory=dict)
@@ -170,7 +169,6 @@ class MacfTaskMetaData:
             updates=updates,
             archived=data.get("archived", False),
             archived_at=data.get("archived_at"),
-            scope_status=data.get("scope_status"),
             custom=data.get("custom", {}),
         )
 
@@ -271,8 +269,6 @@ class MacfTaskMetaData:
             data["archived"] = self.archived
         if self.archived_at:
             data["archived_at"] = self.archived_at
-        if self.scope_status:
-            data["scope_status"] = self.scope_status
         if self.custom:
             data["custom"] = self.custom
 

--- a/macf/src/macf/task/scope.py
+++ b/macf/src/macf/task/scope.py
@@ -34,27 +34,16 @@ from ..agent_events_log import append_event, read_events
 
 
 def _update_task_scope_status(task_id: str, scope_status: Optional[str]) -> bool:
-    """Update a task's MTMD scope_status field.
+    """RETIRED — no-op.
 
-    Args:
-        task_id: Task ID to update
-        scope_status: "active", "inactive", or None (clear)
-
-    Returns:
-        True if successful
+    Scope state is sourced exclusively from the event log (get_scope_state), the
+    single source of truth the gate, tree, and list all read. The per-task MTMD
+    scope_status field it used to write was a denormalized cache that drifted across
+    task stores; the field is gone. This stays as a no-op so the existing
+    scope-mutation call sites need no change (they still append the authoritative
+    events).
     """
-    import copy
-    from .reader import TaskReader, update_task_file
-
-    reader = TaskReader()
-    task = reader.read_task(task_id)
-    if not task or not task.mtmd:
-        return False
-
-    new_mtmd = copy.deepcopy(task.mtmd)
-    new_mtmd.scope_status = scope_status
-    new_description = task.description_with_updated_mtmd(new_mtmd)
-    return update_task_file(task_id, {"description": new_description})
+    return True
 
 
 def set_scope(task_ids: List[str], parent_expanded: bool = False,
@@ -257,15 +246,11 @@ def find_orphaned_scope_tasks() -> Dict[str, str]:
     Returns:
         Dict of {task_id: mtmd_scope_status} for statuses 'active'/'paused'.
     """
-    from .reader import TaskReader
-
-    event_scope = get_scope_state()
-    orphans: Dict[str, str] = {}
-    for task in TaskReader().read_all_tasks():
-        mtmd_status = task.mtmd.scope_status if task.mtmd else None
-        if mtmd_status in ("active", "paused") and str(task.id) not in event_scope:
-            orphans[str(task.id)] = mtmd_status
-    return orphans
+    # RETIRED: always empty. Orphans were tasks whose MTMD scope_status disagreed
+    # with the event log. With the scope_status field retired (scope is event-sourced
+    # only), that disagreement is structurally impossible — there are no orphans to
+    # find or heal. Kept as a stub so clear/pause/remove need no change.
+    return {}
 
 
 def pause_scoped_tasks(task_ids: List[str], justification: str, session_id: str = "") -> dict:

--- a/macf/tests/test_scope_and_stop.py
+++ b/macf/tests/test_scope_and_stop.py
@@ -313,91 +313,37 @@ class TestScopeAddRemovePrimitives:
         assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])
 
 
-class TestScopeOrphanHealing:
-    """Stale MTMD scope_status with lost event history.
+class TestScopeStatusFieldRetired:
+    """The per-task MTMD scope_status field is retired; scope is event-sourced only.
 
-    The bug: task files keep scope_status="active" from a legacy session while
-    the event log carries no scope membership -- the tree renders 👀 but every
-    scope command reports not_in_scope. Orphans must be detectable, and
-    pause/remove/clear must heal them.
+    Replaces the former orphan-healing suite: orphans were tasks whose MTMD
+    scope_status disagreed with the event log, and that disagreement is now
+    structurally impossible.
     """
 
-    @pytest.fixture
-    def home_with_orphan(self, tmp_path, monkeypatch):
-        from macf.utils.paths import find_agent_home
-        monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
-        monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
-        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
-        find_agent_home.cache_clear()
-        maceff = tmp_path / ".maceff"
-        maceff.mkdir()
-        (maceff / "config.json").write_text(json.dumps(
-            {"task_store": {"mode": "home", "path": "agent/public/tasks"}}))
-        (maceff / "agent_events_log.jsonl").touch()
-        store = tmp_path / "agent" / "public" / "tasks"
-        store.mkdir(parents=True)
-        desc = (
-            '<macf_task_metadata version="1.0">\n'
-            "creation_breadcrumb: s_test/c_1/p_x/t_1\n"
-            "created_cycle: 1\n"
-            "created_by: PA\n"
-            "scope_status: active\n"
-            "</macf_task_metadata>"
-        )
-        (store / "99.json").write_text(json.dumps({
-            "id": "99",
-            "subject": "#99 orphan task",
-            "description": desc,
-            "status": "pending",
-        }))
-        yield tmp_path
-        find_agent_home.cache_clear()
-
-    def test_orphan_detected_but_absent_from_event_state(self, home_with_orphan):
-        from macf.task.scope import get_scope_state, find_orphaned_scope_tasks
-        assert get_scope_state() == {}
-        assert find_orphaned_scope_tasks() == {"99": "active"}
-
-    def test_remove_heals_orphan(self, home_with_orphan):
-        from macf.task.reader import TaskReader
-        from macf.task.scope import remove_from_scope, find_orphaned_scope_tasks
-        result = remove_from_scope(["99"])
-        assert result["success"]
-        assert result["removed_ids"] == ["99"]
-        assert result["healed_ids"] == ["99"]
+    def test_find_orphaned_scope_tasks_is_always_empty(self, isolated_events):
+        from macf.task.scope import set_scope, find_orphaned_scope_tasks
+        set_scope(["1", "2", "3"])
+        # Even with an active event-sourced scope, there is no drift-prone field to
+        # go stale, so there are never any orphans to find.
         assert find_orphaned_scope_tasks() == {}
-        task = TaskReader().read_task("99")
-        assert task.mtmd.scope_status is None
 
-    def test_pause_heals_orphan_and_event_state_adopts(self, home_with_orphan):
-        from macf.task.reader import TaskReader
+    def test_model_metadata_no_longer_carries_scope_status(self):
+        import dataclasses
+        from macf.task.models import MacfTaskMetaData
+        names = {f.name for f in dataclasses.fields(MacfTaskMetaData)}
+        assert "scope_status" not in names
+
+    def test_scope_mutations_still_work_event_sourced(self, isolated_events):
         from macf.task.scope import (
-            pause_scoped_tasks, get_scope_state, find_orphaned_scope_tasks,
+            set_scope, pause_scoped_tasks, complete_scoped_task,
+            remove_from_scope, get_scope_check,
         )
-        result = pause_scoped_tasks(["99"], justification="stale scoping from a legacy sprint")
-        assert result["success"]
-        assert result["paused_ids"] == ["99"]
-        assert result["healed_ids"] == ["99"]
-        # Event replay adopts the previously-unknown tid as paused
-        assert get_scope_state() == {"99": "paused"}
-        assert find_orphaned_scope_tasks() == {}
-        task = TaskReader().read_task("99")
-        assert task.mtmd.scope_status == "paused"
-
-    def test_clear_sweeps_orphans(self, home_with_orphan):
-        from macf.task.reader import TaskReader
-        from macf.task.scope import clear_scope, find_orphaned_scope_tasks
-        result = clear_scope()
-        assert result["success"]
-        assert result["orphans_swept"] == ["99"]
-        assert find_orphaned_scope_tasks() == {}
-        task = TaskReader().read_task("99")
-        assert task.mtmd.scope_status is None
-
-    def test_unscoped_unknown_task_still_skipped(self, home_with_orphan):
-        # A task with NO stale MTMD must still be refused (no accidental adoption)
-        from macf.task.scope import pause_scoped_tasks, remove_from_scope
-        result = pause_scoped_tasks(["555"], justification="reason")
-        assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])
-        result = remove_from_scope(["555"])
-        assert any(s["reason"] == "not_in_scope" for s in result["skipped_ids"])
+        set_scope(["10", "11", "12"])
+        pause_scoped_tasks(["10"], justification="external blocker")
+        complete_scoped_task("11")
+        remove_from_scope(["12"])
+        check = get_scope_check()
+        assert check["active_count"] == 0    # 12 removed, 11 inactive, 10 paused
+        assert check["paused_count"] == 1
+        assert check["inactive_count"] == 1


### PR DESCRIPTION
Following the tree/list markers moving to the event log, the per-task MTMD
scope_status field is dead weight: a denormalized cache duplicated across task stores
that drifted both ways (vanishing markers, zombie orphans). Scope state now comes
exclusively from the event log (get_scope_state), the single source of truth the
gate, tree, and list already read.

- models.py: MacfTaskMetaData drops the scope_status field (existing files' stale
  values become inert on read/write).
- scope.py: _update_task_scope_status and find_orphaned_scope_tasks are neutered to
  inert stubs (no-op write / always-empty). Orphans — tasks whose MTMD disagreed
  with the event log — are now structurally impossible, so their heal machinery has
  nothing to do. The mutation call sites are left calling the no-op to keep this
  change low-risk; they still append the authoritative scope events.
- tests: the orphan-healing suite is replaced with retirement-contract tests
  (find_orphaned always empty; the field is gone from the model; scope mutations
  still work event-sourced).

The scope-show orphan warning remains but is now unreachable (find_orphaned returns
empty); it and the no-op call sites are safe to delete in a follow-up micro-cleanup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
