### PR TITLE
Singleton pre-flight: refuse to fork a live calling card (GH#210)

### DIFF
--- a/framework/policies/base/operations/autonomous_operation.md
+++ b/framework/policies/base/operations/autonomous_operation.md
@@ -1,6 +1,6 @@
 # Autonomous Operation Policy
 
-**Version**: 1.2
+**Version**: 1.3
 **Tier**: CORE
 **Category**: Operations
 **Status**: ACTIVE
@@ -47,6 +47,8 @@ Applies to all Primary Agents (PA) and Subagents (SA) capable of extended autono
 - Which measured observable resolves supervision, and which two must NOT be used?
 - How does behaviour branch on supervised vs unsupervised?
 - When is self-restart permitted vs a self-kill?
+- What makes "it rejoins, it does not fork" true — how is the one-live-supervisor-per-calling-card guarantee enforced, where, and why there?
+- What is the difference between rejoin and fork, and what is the sanctioned rejoin command vs the deliberate-second-instance override?
 
 **4 Mode-Specific Recovery Behavior**
 - How does MANUAL_MODE recovery work?
@@ -332,6 +334,49 @@ Observing supervision is **proprioception** and is always permitted; *driving* t
 restart is a separate, grant-gated write action. Self-restart under supervision is a
 real, safe capability; self-restart without it is the "never kill your own runtime"
 failure — the two arms of this one branch.
+
+#### 3.2.1 The Singleton Guarantee: One Live Supervisor per Calling Card
+
+The supervised row above promises self-restart "rejoins, it does not fork." That
+promise is only as good as its enforcement. The failure it guards against is the
+**fork**: two live supervisors under one calling card, hence two clients writing one
+task store. It has been observed in the wild — a restart kick plus a relaunch minted
+*concurrent* instances instead of rejoining, and unattended twins worked the same
+branch as the attended session. Fork-**join** through the substrate held (the twins
+honoured directives they never heard, by reading the staged task notes; reconciliation
+afterward was mechanical). What did not exist was fork **prevention**.
+
+The two operations are not symmetric and must not be confused:
+
+- **Rejoin (safe, sanctioned)**: `macf_tools auto-restart restart <supervisor-pid>`
+  signals the *existing* supervisor to cycle its child in place. No new supervisor, no
+  new terminal, no new client — the conversation resumes in the same session. This is
+  the self-restart the §3.2 table permits under supervision.
+- **Fork (hazard)**: launching a *second* supervisor for a calling card that already
+  has a live one — via a manual launch, a service-manager unit, or a recovery script.
+  Every one of these is a fork mint if it is not guarded.
+
+**The guarantee, enforced:** a supervisor refuses to be *born* if a live supervisor
+already owns its name. The check lives at the single point every birth path converges
+on — not at any one launcher — because a launcher-level check leaves every *other*
+launch door (notably a service-manager unit invoking the supervisor module directly)
+unguarded, which is the same "rule at one call site" defect this framework names
+elsewhere. Liveness is decided by a **measured process probe** (registry entry marked
+running, *and* the pid alive, *and* the pid still a supervisor), never by the state
+file alone — the same evening that produced the fork also produced `running` entries
+for dead pids and dead entries for live ones. The refusal **names the live instance
+and the sanctioned rejoin command**, so an agent or operator who meets the wall is
+handed the path that gets the work done rather than an unexplained boundary.
+
+**The override:** a deliberate second instance (genuinely separate work) is available
+by passing `--force`, or simply by giving the new supervisor a distinct `--name` —
+distinct names are distinct services and never collide. The guard stops the
+*accidental* fork; it does not remove the operator's authority to run two on purpose.
+
+**Registry hygiene rides along:** listings and lookups apply the same measured
+liveness predicate, so a recycled pid — alive, but no longer a supervisor — is never
+reported as a running instance. A registry that cannot answer "who is alive" turns
+every recovery path into a guess, and a guess at this joint is a fork.
 
 ---
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -8866,7 +8866,8 @@ def _cmd_ar_launch(args):
                               use_tmux=not getattr(args, 'no_tmux', False),
                               session_spec=getattr(args, 'session_id', None),
                               post_start_keys=getattr(args, 'post_start_keys', None),
-                              post_start_delay=getattr(args, 'post_start_delay', 18))
+                              post_start_delay=getattr(args, 'post_start_delay', 18),
+                              force=getattr(args, 'force', False))
 
 def _cmd_ar_list(args=None):
     from .supervisor import list_processes
@@ -10272,6 +10273,12 @@ def _build_parser() -> argparse.ArgumentParser:
                            help="terminal app (default: auto-detect)")
     ar_launch.add_argument("--no-tmux", action="store_true",
                            help="do not back the session with tmux (disables send-keys)")
+    ar_launch.add_argument("--force", action="store_true",
+                           help="override the singleton pre-flight: start even if a live "
+                                "supervisor already owns this --name. Without this, launching "
+                                "a second supervisor for a name that already has one is refused "
+                                "as a fork (GH#210); the sanctioned in-place restart is "
+                                "'auto-restart restart <pid>'.")
     ar_launch.add_argument("--post-start-keys", default=None, metavar="KEYS",
                            help="tmux keys to send after every child spawn (initial and each "
                                 "restart), e.g. 'Enter' to dismiss a workspace-trust dialog that "

--- a/macf/src/macf/supervisor.py
+++ b/macf/src/macf/supervisor.py
@@ -317,12 +317,16 @@ def is_live_supervisor(data: dict) -> bool:
     return _is_supervisor_process(pid)
 
 
-def _find_supervisor(target: str) -> dict | None:
-    """Find a RUNNING supervisor registry entry by supervisor PID or by name.
-    On multiple name matches, returns the most recently created."""
+def _iter_live_supervisors():
+    """Yield the registry data of every supervisor that is actually running now.
+
+    The single registry scan that every "who is live?" question routes through,
+    so ``is_live_supervisor`` — the process-liveness predicate, never the state
+    file alone — is applied in exactly one place and cannot come to mean two
+    different things in two callers.
+    """
     if not REGISTRY_DIR.exists():
-        return None
-    matches = []
+        return
     for entry in REGISTRY_DIR.glob("*.json"):
         if entry.name == "supervisor_crash.log":
             continue
@@ -330,11 +334,43 @@ def _find_supervisor(target: str) -> dict | None:
             data = json.loads(entry.read_text())
         except (json.JSONDecodeError, OSError):
             continue
-        if not is_live_supervisor(data):
-            continue
-        sup_pid = data.get("supervisor_pid", 0)
-        if target == str(sup_pid) or target == data.get("name"):
-            matches.append(data)
+        if is_live_supervisor(data):
+            yield data
+
+
+def _find_supervisor(target: str) -> dict | None:
+    """Find a RUNNING supervisor registry entry by supervisor PID or by name.
+    On multiple name matches, returns the most recently created."""
+    matches = [
+        data for data in _iter_live_supervisors()
+        if target == str(data.get("supervisor_pid", 0)) or target == data.get("name")
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda d: d.get("created", 0))
+
+
+def find_live_supervisor_by_name(name: str, exclude_pid: int = 0) -> dict | None:
+    """The live supervisor already owning this calling card, or None.
+
+    The singleton guard's eyes (task #113 / GH#210). "Owning" is keyed on the
+    supervisor *name* — the calling card — because the fork the FORK INCIDENT
+    documented was three ``claude -c`` clients under one name, and two live
+    supervisors sharing a name is precisely the state in which two clients write
+    one task store. Distinct names are distinct services (``claude`` vs
+    ``manny``) and never collide here.
+
+    ``exclude_pid`` skips the caller's own entry so a supervisor calling this to
+    check for a *pre-existing* twin never matches itself. Liveness is decided by
+    ``is_live_supervisor`` (status running + pid alive + pid still a supervisor),
+    never by the state file alone: the same evening produced ``running`` entries
+    for dead pids and dead entries for live ones. On multiple matches returns the
+    most recently created.
+    """
+    matches = [
+        data for data in _iter_live_supervisors()
+        if data.get("name") == name and data.get("supervisor_pid", 0) != exclude_pid
+    ]
     if not matches:
         return None
     return max(matches, key=lambda d: d.get("created", 0))
@@ -388,7 +424,8 @@ def launch_in_terminal(cmd_args: list, name: str = "",
                        use_tmux: bool = True,
                        session_spec: str = None,
                        post_start_keys: str = None,
-                       post_start_delay: int = 18) -> int:
+                       post_start_delay: int = 18,
+                       force: bool = False) -> int:
     """Launch a supervised process in a new terminal window.
 
     Args:
@@ -420,6 +457,17 @@ def launch_in_terminal(cmd_args: list, name: str = "",
 
     if not name:
         name = os.path.basename(cmd_args[0])
+
+    # Singleton pre-flight, early copy (task #113 / GH#210). run_loop holds the
+    # authoritative guard — it is the confluence a systemd-launched supervisor
+    # also passes through — but refusing HERE too, before a terminal window is
+    # ever opened, spares the interactive user an orphaned terminal that would
+    # only flash the same refusal and vanish. Same predicate, friendlier moment.
+    if not force:
+        existing = find_live_supervisor_by_name(name)
+        if existing:
+            _refuse_duplicate(name, existing, where="launch_in_terminal")
+            return 1
 
     # Optionally pin a session id. When set, the supervised command (e.g. a
     # wrapper around `claude`) forwards it via `claude --session-id
@@ -455,6 +503,11 @@ def launch_in_terminal(cmd_args: list, name: str = "",
     if post_start_keys:
         supervisor_cmd += ["--post-start-keys", post_start_keys,
                            "--post-start-delay", str(post_start_delay)]
+    # Propagate the override: without it the terminal-hosted supervisor would
+    # re-run the pre-flight and refuse, so a --force that stopped at this layer
+    # would be silently ineffective.
+    if force:
+        supervisor_cmd += ["--force"]
     supervisor_cmd += ["--"] + cmd_args
 
     # When tmux-backed, the terminal hosts `tmux new-session` which runs the
@@ -590,9 +643,38 @@ def _send_post_start_keys(tmux_session: str, keys: str, delay: int) -> None:
         print(f"[auto-restart] post-start keys failed (non-fatal): {e}", file=sys.stderr)
 
 
+def _refuse_duplicate(name: str, existing: dict, *, where: str) -> None:
+    """Print the singleton refusal and fire the Telegram notice.
+
+    Shared by both guard sites so the refusal — which names the live instance
+    and the sanctioned rejoin path — reads identically whether it fires early in
+    ``launch_in_terminal`` or authoritatively in ``run_loop``.
+    """
+    other_pid = existing.get("supervisor_pid")
+    other_restarts = existing.get("restart_count", 0)
+    other_session = existing.get("tmux_session") or "n/a"
+    print(f"\n[auto-restart] REFUSING TO START: a live supervisor for "
+          f"'{name}' already exists (pid {other_pid}, {other_restarts} restart(s), "
+          f"tmux session {other_session}).", file=sys.stderr)
+    print("[auto-restart] Starting another would MINT A FORK — two clients "
+          "writing one calling card, the failure GH#210 exists to prevent.",
+          file=sys.stderr)
+    print(f"[auto-restart] To restart that instance IN PLACE (rejoin, not fork):"
+          f"\n                 macf_tools auto-restart restart {other_pid}",
+          file=sys.stderr)
+    print("[auto-restart] To run a genuinely separate service, give it a distinct "
+          "--name. To override this guard deliberately, pass --force.",
+          file=sys.stderr)
+    _notify_telegram(
+        f"Name: {name}\nLive instance: pid {other_pid}\n"
+        f"Rejoin: auto-restart restart {other_pid}",
+        prefix="\U0001f6d1 Supervisor Refused (would fork)")
+
+
 def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
              tmux_session: str = None, session_id: str = None,
-             post_start_keys: str = None, post_start_delay: int = 18):
+             post_start_keys: str = None, post_start_delay: int = 18,
+             force: bool = False):
     """Run the supervisor loop (called inside the new terminal).
 
     This is the actual supervisor process — manages the child.
@@ -627,6 +709,23 @@ def run_loop(cmd_args: list, name: str = "", restart_delay: int = 5,
         _notify_telegram(f"Name: {name}\n{problem}",
                          prefix="\U0001f6d1 Supervisor Refused")
         return 1
+
+    # Singleton pre-flight (task #113 / GH#210). Refuse to become a SECOND live
+    # supervisor for a calling card that already has one. This guard lives HERE,
+    # in run_loop, because run_loop is the confluence every supervisor birth
+    # passes through — `launch_in_terminal`, a systemd unit invoking this module
+    # directly, a manual launch. A guard placed only at `launch_in_terminal`
+    # would leave the systemd door open, and the fork the FORK INCIDENT
+    # documented (three `claude -c` clients under one name) mints through
+    # whichever door is unguarded. Checked by process liveness, never by state
+    # file: this same evening produced 'running' entries for dead pids and dead
+    # entries for live ones. --force is the deliberate override for a human who
+    # genuinely wants a second instance.
+    if not force:
+        existing = find_live_supervisor_by_name(name, exclude_pid=pid)
+        if existing:
+            _refuse_duplicate(name, existing, where="run_loop")
+            return 1
 
     # Export the pinned session id so the child (run via $SHELL -ic, which
     # inherits this environment) can pass it to `claude --session-id`.
@@ -841,7 +940,13 @@ def list_processes(show_all: bool = False):
         print("No managed processes.")
         return
 
-    # Categorize entries
+    # Categorize entries. "Active" means an entry that is genuinely a live
+    # supervisor — status running AND pid alive AND the pid still a supervisor
+    # (is_live_supervisor), not merely an alive pid. The weaker os.kill check
+    # marked a recycled pid — now running something unrelated — as a live
+    # supervisor, so a dead supervisor's number could show as "running" once the
+    # OS handed it out again (task #113 / GH#210 registry hygiene). _alive is
+    # still recorded for the status-line normalization below.
     active = []
     stale = []
     for entry in entries:
@@ -849,10 +954,9 @@ def list_processes(show_all: bool = False):
             continue
         data = json.loads(entry.read_text())
         pid = data.get("supervisor_pid", 0)
-        alive = _is_alive(pid)
-        data["_alive"] = alive
+        data["_alive"] = _is_alive(pid)
         data["_path"] = entry
-        if alive:
+        if is_live_supervisor(data):
             active.append(data)
         else:
             stale.append(data)
@@ -1005,6 +1109,9 @@ if __name__ == "__main__":
         parser.add_argument("--session-id", default=None)
         parser.add_argument("--post-start-keys", default=None)
         parser.add_argument("--post-start-delay", type=int, default=18)
+        parser.add_argument("--force", action="store_true",
+                            help="override the singleton pre-flight and start even if "
+                                 "a live supervisor already owns this name (GH#210)")
 
         args = parser.parse_args(supervisor_argv)
 
@@ -1016,7 +1123,8 @@ if __name__ == "__main__":
             sys.exit(run_loop(cmd, name=args.name, restart_delay=args.delay,
                               tmux_session=args.tmux_session, session_id=args.session_id,
                               post_start_keys=args.post_start_keys,
-                              post_start_delay=args.post_start_delay) or 0)
+                              post_start_delay=args.post_start_delay,
+                              force=args.force) or 0)
 
     except Exception as e:
         # Top-level supervisor crash handler — bare Exception is intentional:

--- a/macf/tests/test_supervisor_singleton.py
+++ b/macf/tests/test_supervisor_singleton.py
@@ -1,0 +1,165 @@
+"""Singleton pre-flight — fork prevention for supervisor birth (cversek/MacEff#210).
+
+The FORK INCIDENT: a restart kick + supervisor relaunch minted CONCURRENT
+instances instead of rejoining — three `claude -c` clients under one calling
+card, two of them unattended, all writing one task store. The fork mints through
+whichever launch door is unguarded, and there are three (launch_in_terminal, a
+systemd unit invoking the module directly, a manual launch). They converge at
+run_loop, so run_loop is where the guard has to live.
+
+The seams `_is_alive` (os.kill) and `_is_supervisor_process` (ps) are the two
+places "the registry says running" meets "the process table agrees"; every test
+here monkeypatches them so liveness is deterministic rather than dependent on
+real pids.
+"""
+import importlib
+
+
+def _reload_supervisor(monkeypatch, tmp_path):
+    """Reload the module with a private, empty registry dir (REGISTRY_DIR is
+    resolved at import time from XDG_RUNTIME_DIR)."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    import macf.supervisor as s
+    return importlib.reload(s)
+
+
+def _make_live(monkeypatch, s):
+    """Make every registered entry read as a genuinely live supervisor."""
+    monkeypatch.setattr(s, "_is_alive", lambda pid: True)
+    monkeypatch.setattr(s, "_is_supervisor_process", lambda pid: True)
+    monkeypatch.setattr(s, "_notify_telegram", lambda *a, **k: None)
+
+
+def _register(s, pid, name, **extra):
+    data = {"supervisor_pid": pid, "name": name, "status": "running",
+            "created": float(pid), "restart_count": 0}
+    data.update(extra)
+    s._write_registry(pid, data)
+
+
+# ---- find_live_supervisor_by_name (the guard's eyes) ----------------------
+
+def test_finds_live_supervisor_by_name(monkeypatch, tmp_path):
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 111, "claude")
+    assert s.find_live_supervisor_by_name("claude")["supervisor_pid"] == 111
+
+
+def test_name_scoped_distinct_names_never_collide(monkeypatch, tmp_path):
+    """A different --name is a different service, not a fork."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 111, "claude")
+    assert s.find_live_supervisor_by_name("manny") is None
+
+
+def test_excludes_self(monkeypatch, tmp_path):
+    """A supervisor checking for a *pre-existing* twin must not match itself."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 222, "claude")
+    assert s.find_live_supervisor_by_name("claude", exclude_pid=222) is None
+
+
+def test_ignores_dead_pid(monkeypatch, tmp_path):
+    """A 'running' entry whose pid is dead is not a live supervisor."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    monkeypatch.setattr(s, "_is_alive", lambda pid: False)
+    monkeypatch.setattr(s, "_is_supervisor_process", lambda pid: True)
+    _register(s, 333, "claude")
+    assert s.find_live_supervisor_by_name("claude") is None
+
+
+def test_ignores_recycled_pid(monkeypatch, tmp_path):
+    """Alive pid but no longer a supervisor (recycled) → not live."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    monkeypatch.setattr(s, "_is_alive", lambda pid: True)
+    monkeypatch.setattr(s, "_is_supervisor_process", lambda pid: False)
+    _register(s, 444, "claude")
+    assert s.find_live_supervisor_by_name("claude") is None
+
+
+def test_returns_most_recent_on_multiple(monkeypatch, tmp_path):
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 10, "claude", created=1.0)
+    _register(s, 20, "claude", created=2.0)
+    assert s.find_live_supervisor_by_name("claude")["supervisor_pid"] == 20
+
+
+# ---- run_loop: the authoritative chokepoint -------------------------------
+
+def test_run_loop_refuses_when_name_already_live(monkeypatch, tmp_path, capsys):
+    """run_loop is the door systemd also passes through; it must refuse to
+    become a second live supervisor and return non-zero WITHOUT registering."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 99999, "claude", restart_count=3, tmux_session="claude_abc")
+
+    rc = s.run_loop(["true"], name="claude", force=False)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "REFUSING TO START" in err
+    assert "99999" in err
+    assert "auto-restart restart 99999" in err  # names the sanctioned rejoin
+    assert "--force" in err                       # names the override
+    # No second supervisor for the name was registered.
+    assert s.find_live_supervisor_by_name("claude")["supervisor_pid"] == 99999
+
+
+def test_run_loop_refusal_returns_nonzero_for_systemd(monkeypatch, tmp_path, capsys):
+    """The non-zero return is what stops a systemd unit reporting active with a
+    fork underneath — mirrors the _unlaunchable_reason contract."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 7777, "claude")
+    assert s.run_loop(["true"], name="claude") == 1
+
+
+# ---- launch_in_terminal: friendly early refusal ---------------------------
+
+def test_launch_in_terminal_refuses_before_opening_terminal(monkeypatch, tmp_path, capsys):
+    """The early copy of the guard must refuse before any terminal is opened,
+    so the interactive user never gets an orphan window."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    opened = []
+    monkeypatch.setattr(s.subprocess, "Popen", lambda *a, **k: opened.append(a))
+    _register(s, 4242, "claude")
+
+    rc = s.launch_in_terminal(["claude", "-c"], name="claude", force=False)
+
+    assert rc == 1
+    assert opened == []  # no terminal emulator was spawned
+    assert "REFUSING TO START" in capsys.readouterr().err
+
+
+# ---- registry hygiene: liveness-checked list output -----------------------
+
+def test_list_processes_cleans_recycled_pid_entry(monkeypatch, tmp_path, capsys):
+    """A 'running' entry whose pid is alive but no longer a supervisor must be
+    treated as stale, not listed as running (GH#210 registry hygiene)."""
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    monkeypatch.setattr(s, "_is_alive", lambda pid: True)
+    monkeypatch.setattr(s, "_is_supervisor_process", lambda pid: False)
+    _register(s, 5555, "claude")
+
+    s.list_processes(show_all=False)
+
+    out = capsys.readouterr().out
+    assert "No running processes" in out
+    assert not s._registry_file(5555).exists()  # cleaned
+
+
+def test_list_processes_shows_genuine_live_supervisor(monkeypatch, tmp_path, capsys):
+    s = _reload_supervisor(monkeypatch, tmp_path)
+    _make_live(monkeypatch, s)
+    _register(s, 6060, "claude", command=["claude", "-c"])
+
+    s.list_processes(show_all=False)
+
+    out = capsys.readouterr().out
+    assert "6060" in out
+    assert "claude" in out


### PR DESCRIPTION
Closes #210.

## Problem

A restart kick plus a supervisor relaunch could mint **concurrent** supervisors under one calling card — two clients writing one task store — instead of rejoining the live one. Fork-*join* through the substrate held (twins honoured directives via staged task notes; reconciliation was mechanical), but fork *prevention* did not exist. Every recovery path — manual launch, service-manager unit, recovery script — was a fork mint.

## Fix

Enforce **one live supervisor per name** at the birth chokepoint.

- **`run_loop` is the guard site**, not `launch_in_terminal`. A service-manager unit invokes the supervisor module directly, bypassing `launch_in_terminal`; every supervisor *birth* converges at `run_loop`, so that is the one place no launch path routes around. (A launcher-level check is the "rule at one call site" defect.)
- Refusal is decided by a **measured process probe** (`is_live_supervisor`: registry running + pid alive + pid still a supervisor), never the state file alone — the same incident produced `running` entries for dead pids and dead entries for live ones.
- The refusal **names the live instance and the sanctioned in-place rejoin** (`auto-restart restart <pid>`), so whoever meets the wall is handed the path that gets the work done.
- **`--force`** (or simply a distinct `--name`) is the deliberate override for a genuine second instance.
- **Registry hygiene**: `list_processes` applies the same predicate, so a recycled pid is never reported as running.

## Policy (ships with the capability)

`autonomous_operation` §3.2.1 (v1.2→1.3) documents the singleton guarantee, the rejoin-vs-fork distinction, the sanctioned command, and the override — making §3.2's promise *"it rejoins, it does not fork"* enforced rather than aspirational.

## Verification

- 11 new unit tests (`test_supervisor_singleton.py`) + full supervisor and CLI suites green.
- **Live end-to-end**: a duplicate-launch attempt against a real running supervisor refused *before opening a terminal*, named the live pid, handed over the rejoin command, and exited non-zero — no fork minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)