### PR TITLE
Retire the per-prompt policy-recommendation injection (GH#211)

### DIFF
--- a/framework/policies/base/policy_awareness.md
+++ b/framework/policies/base/policy_awareness.md
@@ -3,7 +3,7 @@
 ## Meta-Policy: Policy Classification
 - **Tier**: MANDATORY
 - **Category**: Framework Foundation
-- **Version**: 1.0.0
+- **Version**: 1.1.0
 - **Dependencies**: None (Bootstrap Policy)
 - **Authority**: MacEff Framework
 - **Status**: ACTIVE
@@ -54,6 +54,12 @@ You don't need to read everything. You need to recognize WHEN you need something
 - How do I engage with injected nav guides?
 - What core policies are always available?
 - What if the policy doesn't answer my question?
+
+2.5 When to Consult the Corpus (the pull obligation)
+- Discovery is pull, not push — so when am I expected to consult?
+- What are the recognised-demand moments?
+- Which commands are the on-demand path (keyword vs semantic)?
+- Why is there no per-prompt recommendation injection?
 
 3 CEP Navigation Guide Protocol
 - What's the reading protocol?
@@ -203,6 +209,57 @@ When you start a task via `macf_tools task start`, the Task System automatically
 
 **Participatory governance**: Policies exist to help you do excellent work. When they don't answer your question, that's valuable feedback — report the gap so the policy can evolve. You have both the obligation to follow policies and the right to improve them.
 
+### 2.5 When to Consult the Corpus (the pull obligation)
+
+Discovery in MacEff is **pull, not push**. The corpus is not fired into your
+context every turn; you reach for it when you recognise you need it. That makes
+*recognising the need* the discipline — and because the need is easy to skip
+past under momentum, this section names the moments the framework expects a
+consultation, so "nobody pushed it at me" is never a reason it was missed.
+
+**Recognised-demand moments — consult before proceeding:**
+
+- **Task and phase orientation.** Starting a task or a roadmap phase is the
+  canonical pull moment; `task start` already surfaces CEP nav guides (§2.4),
+  and you extend that with `policy read` for anything the guides point at.
+- **Before shipping a fix or a capability.** A change that alters what an agent
+  or operator may do is governed — read the policy that governs it before you
+  land it (this is the discipline behind *policy ships with the capability*).
+- **When a bug resists the first hypothesis.** A second failed attempt is a
+  signal to check whether a policy or learning already describes the class of
+  problem, rather than theorising further.
+- **On entering an unfamiliar domain.** Before working in a subsystem you have
+  not touched, orient in its governing policy and its learnings index.
+
+These are moments where *the demand is recognised*, which is exactly when pull
+works. Binding policy engagement to them is the pattern the framework uses
+everywhere; it does not need a per-turn injection to function.
+
+**The on-demand path (both layers stay available):**
+
+```bash
+macf_tools policy list                 # what exists
+macf_tools policy navigate <name>      # its CEP question-map (framing before content)
+macf_tools policy read <name>          # the policy itself
+macf_tools policy search <keyword>     # curated keyword search over the manifest — always available, no optional deps
+macf_tools policy recommend "<query>"  # semantic hybrid search — richer, requires the optional search index
+```
+
+`policy search` is the **always-available keyword fallback**; `policy recommend`
+is the **semantic** path and depends on the optional search index — when that
+index or its dependencies are absent it now says so at the point of use (with
+the install/build hint) rather than returning empty. A recommender you invoke
+when you want one is a tool; use it at the moments above.
+
+**Why no per-prompt recommendation injection (GH#211):** push floods, and what
+floods gets skimmed. An injection nobody reads still *looks* like policy
+awareness, which is worse than no injection at all — for the same reason an
+ignored gate is worse than no gate. A per-turn recommender also drew from a
+snapshot index that nothing rebuilds automatically, and on at least one host it
+had silently degraded to a no-op that nobody noticed *because* nothing depended
+on it. Retiring the push and investing in on-demand search that degrades loudly
+is the pull model applied to its own tooling.
+
 ## 3. CEP Navigation Guide Protocol
 
 ### 3.1 Mandatory Reading Protocol
@@ -312,7 +369,10 @@ cat /opt/maceff/framework/policies/current/manifest.json | jq '.mandatory_polici
 3. `context_management.md` (time/token awareness, compaction)
 4. `delegation_guidelines.md` (when/how to delegate)
 
-**Load On-Demand**: Everything else via CEP triggers
+**Load On-Demand**: Everything else via CEP triggers and the recognised-demand
+moments in §2.5 (task/phase orientation, before shipping a fix, when a bug
+resists the first hypothesis, entering an unfamiliar domain), using
+`macf_tools policy search`/`recommend`.
 
 ### 5.3 Navigation Commands
 

--- a/macf/src/macf/hooks/handle_user_prompt_submit.py
+++ b/macf/src/macf/hooks/handle_user_prompt_submit.py
@@ -33,9 +33,6 @@ from macf.observability import Warning, emit_warning
 # EXPERIMENT: Memory injection script path (Cycle 337)
 MEMORY_RECALL_SCRIPT = Path(__file__).parent.parent.parent / "agent/public/experiments/2026-01-15_140000_001_Claude-Mem_Associative_Injection/artifacts/memory-recall.py"
 
-# NOTE: recommend module imported lazily inside get_policy_injection() (heavy deps ~3s)
-
-
 def get_memory_injection(prompt: str) -> str:
     """
     Query claude-mem for associative memories relevant to the prompt.
@@ -67,72 +64,6 @@ def get_memory_injection(prompt: str) -> str:
         pass  # Fail silently - don't block session
 
     return ""
-
-
-def get_policy_injection(prompt: str) -> str:
-    """
-    Query policy index for relevant policy recommendations.
-
-    Fast path: Socket client to warm search service (45ms)
-    Fallback: Direct import of recommend module (4000ms on first call)
-
-    Logs warnings when fallback is used - not silent failures.
-    Returns empty string on any failure (graceful degradation).
-    """
-    if len(prompt) < 10:  # Skip very short prompts
-        return ""
-
-    # Fast path: Try socket client first (stdlib only, no heavy imports)
-    try:
-        from macf.search_service.client import get_policy_injection as client_get_injection
-        result = client_get_injection(prompt)
-        if result:  # Service returned a result
-            return result
-        # Empty result means service unavailable - fall through with warning
-    except ImportError as e:
-        # Client module not available - log and fall through
-        emit_warning(Warning(source="user_prompt_submit", kind="search_service_unavailable", detail=f"search_service.client not available: {e}"))
-    except Exception as e:
-        # Unexpected error - log with traceback
-        emit_warning(Warning(source="user_prompt_submit", kind="search_service_unavailable", detail=f"search_service.client error: {e}"))
-        log_hook_event({
-            "hook_name": "user_prompt_submit",
-            "event_type": "WARNING",
-            "warning": "search_service_client_failed",
-            "error": str(e),
-            "error_type": type(e).__name__,
-            "traceback": traceback.format_exc(),
-            "fallback": "direct_recommend_import"
-        })
-
-    # Slow path fallback: Direct import (4s on first call)
-    # Log that we're using fallback so user knows service isn't running
-    emit_warning(Warning(source="user_prompt_submit", kind="search_service_unavailable", detail="Search service unavailable, using slow fallback (4s)"))
-    log_hook_event({
-        "hook_name": "user_prompt_submit",
-        "event_type": "WARNING",
-        "warning": "search_service_fallback",
-        "message": "Using direct recommend import (slow path ~4s)",
-        "hint": "Start search service: macf_tools search-service start"
-    })
-
-    try:
-        from macf.utils.recommend import get_recommendations
-        formatted, _ = get_recommendations(prompt)
-        return formatted
-    except ImportError:
-        return ""  # recommend module not available
-    except Exception as e:
-        # Log fallback error too
-        log_hook_event({
-            "hook_name": "user_prompt_submit",
-            "event_type": "ERROR",
-            "error": str(e),
-            "error_type": type(e).__name__,
-            "traceback": traceback.format_exc(),
-            "context": "direct_recommend_fallback_failed"
-        })
-        return ""  # Fail gracefully - don't block session
 
 
 def record_user_activity_from_payload(prompt: str) -> bool:
@@ -327,8 +258,13 @@ Breadcrumb: {breadcrumb}"""
         # Note: prompt already extracted above for prompt_preview
         memory_injection = ""  # get_memory_injection(prompt)
 
-        # EXPERIMENT: Get policy recommendation injection (Cycle 338)
-        policy_injection = get_policy_injection(prompt)
+        # Per-prompt policy-recommendation injection removed (GH#211). Policy
+        # discovery in MacEff is pull, not push: agents consult the corpus on
+        # recognised demand (task/phase orientation, before shipping a fix, when
+        # a bug resists the first hypothesis) via `macf_tools policy
+        # search`/`recommend`, and task-start still auto-surfaces CEP nav guides.
+        # A recommender fired into every turn was stale noise with a maintenance
+        # burden; see policy_awareness §2.5.
 
         # Format footer
         footer = format_macf_footer()
@@ -340,7 +276,6 @@ Breadcrumb: {breadcrumb}"""
             voice_transcript if voice_transcript else "",  # Voice auto-transcription
             boundary_guidance if boundary_guidance else "",
             memory_injection if memory_injection else "",  # EXPERIMENT: associative memories
-            policy_injection if policy_injection else "",  # EXPERIMENT: policy recommendations
             footer
         ]
         plain_content = chr(10).join([s for s in sections if s])

--- a/macf/src/macf/utils/recommend.py
+++ b/macf/src/macf/utils/recommend.py
@@ -299,6 +299,15 @@ def get_recommendations(prompt: str) -> tuple[str, list[dict]]:
 
         return formatted, explanations
 
+    except ImportError:
+        # Optional search deps (lancedb / sentence-transformers) are absent.
+        # An absent dependency is NOT "no matches" — swallowing it into an empty
+        # result is exactly the silent-inert failure GH#211 documents (the
+        # feature became a no-op and the absence was indistinguishable from it
+        # working). Propagate so the point of use — the `policy recommend` CLI —
+        # reports it loudly with the install hint rather than printing
+        # "No recommendations found" and exiting 0.
+        raise
     except Exception as e:
         print(f"⚠️ MACF: Search error: {e}", file=sys.stderr)
         return "", []

--- a/macf/tests/test_handle_user_prompt_submit.py
+++ b/macf/tests/test_handle_user_prompt_submit.py
@@ -237,3 +237,36 @@ class TestUserActivityFromPayload:
 
         age = time.time() - _get_last_user_activity_timestamp("s1")
         assert age < 60, f"submit still read as {age / 60:.0f} minutes stale"
+
+
+class TestPolicyInjectionRemoved:
+    """The per-prompt policy-recommendation injection is retired (GH#211).
+
+    Discovery is pull, not push: agents consult the corpus on recognised demand
+    (policy_awareness §2.5), and task-start still auto-surfaces CEP nav guides.
+    A recommender fired into every turn was stale noise; these tests pin its
+    absence so it cannot silently return.
+    """
+
+    def test_hook_has_no_policy_injection_function(self):
+        import macf.hooks.handle_user_prompt_submit as h
+        assert not hasattr(h, "get_policy_injection"), (
+            "the per-prompt policy recommender must not be reintroduced in the hook"
+        )
+
+    def test_output_carries_no_policy_recommendation_block(self, mock_dependencies):
+        import json
+        from macf.hooks.handle_user_prompt_submit import run
+
+        # A policy-relevant prompt is exactly what would have triggered the
+        # injection; the output must not carry the recommendation block.
+        result = run(json.dumps({
+            "session_id": "s1",
+            "prompt": "How do I manage TODOs and backups and checkpoints?",
+        }))
+
+        context = result["hookSpecificOutput"]["additionalContext"]
+        assert "Policy Recommendations" not in context
+        assert "📚 Policy Recommendations" not in context
+        # The rest of the DEV_DRV context is unaffected.
+        assert "🏗️ MACF" in context

--- a/macf/tests/test_recommend.py
+++ b/macf/tests/test_recommend.py
@@ -214,6 +214,25 @@ class TestGetRecommendations:
                 assert formatted_output == ""
                 assert explanations == []
 
+    def test_import_error_propagates_not_swallowed(self):
+        """Missing optional deps must PROPAGATE, not degrade to an empty result.
+
+        An absent dependency is not "no matches" (GH#211). Swallowing it into
+        ("", []) is the silent-inert failure the injection removal was about;
+        the recommend CLI relies on the ImportError reaching it to print the
+        install hint and exit non-zero. A generic Exception still degrades
+        gracefully (test above); only ImportError propagates.
+        """
+        with patch('macf.utils.recommend._get_db_path') as mock_path:
+            mock_db = MagicMock(spec=Path)
+            mock_db.exists.return_value = True
+            mock_path.return_value = mock_db
+
+            with patch('macf.utils.recommend.search_policies',
+                       side_effect=ImportError('lancedb not installed')):
+                with pytest.raises(ImportError):
+                    get_recommendations("test query with enough length")
+
 
 class TestExplainedRecommendationMethods:
     """Test ExplainedRecommendation methods."""


### PR DESCRIPTION
Closes #211.

## Problem

MacEff policy discovery is **pull, not push** — `policy list` → navigate → read, because a governance corpus cannot be preloaded and still leave room to work. The one place the framework did the opposite was a per-turn injection into `UserPromptSubmit`, labelled an experiment (Cycle 338) and never concluded. It:

- **flooded** — and what floods gets skimmed; an injection nobody reads still *looks* like policy awareness, worse than none;
- **recommended against a stale snapshot** — the index is rebuilt by nothing automatic (no hook, no CI, no setup step);
- **taxed ~4s** on the hook that runs before every single turn;
- on at least one host had **silently degraded to a no-op** that nobody noticed — the absence indistinguishable from the feature working, which is the finding.

## Fix — retire the push, strengthen the pull

- **Remove** `get_policy_injection()` and its wiring from `UserPromptSubmit`. The Markov work-mode recommender in `handle_stop.py` is a **separate** mechanism and is untouched; the task-start CEP nav-guide injection is also separate and stays.
- **Degrade loudly at the point of use**: `recommend.get_recommendations()` now *propagates* `ImportError` instead of swallowing it into an empty result, so the `policy recommend` CLI reports an absent optional dependency with the install hint and a non-zero exit rather than printing "No recommendations found". A generic search exception still degrades gracefully.
- **Document the pull obligation** so removing the push does not remove the expectation: `policy_awareness` §2.5 "When to Consult the Corpus" (v1.0.0→1.1.0) names the recognised-demand moments (task/phase orientation, before shipping a fix, when a bug resists the first hypothesis, unfamiliar domains) and the on-demand commands — `policy search` (keyword, always available) and `policy recommend` (semantic).

## Acceptance (all met)

- [x] Injection removed from `UserPromptSubmit`
- [x] Markov recommender in `stop.py` untouched
- [x] `policy search` / `policy recommend` remain available and documented as the on-demand path
- [x] Optional-dependency absence surfaces at the point of use rather than returning empty
- [x] Policy documents when an agent is expected to consult the corpus
- [x] Cycle 338 experiment conclusion recorded before the code was deleted

## Verification

- Hook regression test pins the injection's absence; recommend test asserts `ImportError` propagates; existing suites green.
- Live: `policy recommend` on the dev host surfaced a policy section retired in a prior cycle — a direct demonstration of the stale-index harm this removes. (Auto-rebuild-on-ship is a reasonable follow-up; it was a "should", not an acceptance item here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)