### PR TITLE
feat(task): task trace — the work stack, and the frames left behind

### DIFF
--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -142,8 +142,25 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 **11 Migration from TodoWrite**
 - What changed between paradigms?
 
-**12 Future Experiments**
+**12 Task Scope System**
+- How is scope set and cleared?
+- What does the scope gate enforce?
+
+**13 Future Experiments**
 - What knowledge gaps need empirical validation?
+
+**14 Integration with Other Policies**
+- Which policies does task management depend on?
+
+**15 Evolution & Feedback**
+- How do I propose a change to this policy?
+
+**16 The Work Stack**
+- Why is a tree of open tasks not yet a stack?
+- What are push, pop, and pop-reconciled in this system?
+- Why must a frame be durable before it is interrupted?
+- What distinguishes a parked frame from an abandoned one?
+- How do I see what I was in the middle of?
 
 === CEP_NAV_BOUNDARY ===
 
@@ -1521,6 +1538,65 @@ macf_tools task scope check                       # JSON output for Stop hook
 **DRAFT → OFFICIAL Path**: Validate §12 experiments, refine CLI based on usage.
 
 ---
+
+## 16 The Work Stack
+
+Tasks are usually described as a record of work. They are also, read a certain way, a **stack** — and that reading is what makes them useful at the moment an agent is most likely to lose its place.
+
+### 16.1 A tree of open tasks is not yet a stack
+
+An agent returning from an interruption, a context loss, or a handoff asks one question: *what was I in the middle of?* A tree of six open tasks answers a different question. It reports six unfinished things without saying which one attention actually left and owes a return to.
+
+The missing element is **ordering**. A stack is not a set of frames; it is an ordered set with a discipline about which one you return to. The tree holds the frames. The order in which attention moved through them is what turns a pile into a stack.
+
+That ordering already exists: every task update carries a breadcrumb with a timestamp, so the sequence of touches is recorded. A tree's recency marker is the maximum over those timestamps — a single pointer derived from a full trace. The trace is not missing, only reduced away at display time.
+
+### 16.2 The operations, and where each already lives
+
+| Stack operation | Mechanism |
+|---|---|
+| **push** | starting a task, or noting on one — the durable write |
+| **frame contents** | the task plus its timestamped update stream |
+| **pop** | completing the task |
+| **pop, reconciled** | the resume protocol: work last touched in an earlier cycle requires re-reading its history before continuing |
+| **stack contents** | open frames, oldest first |
+| **the path taken** | the visitation trace |
+
+The fourth row is the one worth noticing. Resuming stale work does not restore a frame blindly — it reports the frame's age and requires reconciliation first, because the world may have moved while the work was set down. That is the correct semantics for a pop, and it is why §5's reading discipline is not ceremony.
+
+### 16.3 A frame must be durable *before* it is interrupted
+
+An interruption may end a turn without giving the agent an opportunity to write anything down. Whatever was held only in the agent's head at that moment is gone, and no amount of good intent at interrupt time recovers it — the agent is not running at interrupt time.
+
+**Therefore the push must have already happened.** This is the load-bearing reason for the note-as-you-go discipline in §5: a note written while the work is fresh is a frame that survives; a note deferred until the work is finished is a frame that never existed if the work is interrupted first. The agent that writes only at completion has a stack that is empty precisely when it is needed.
+
+### 16.4 Parked is not abandoned
+
+An in-progress task that attention has left is not automatically a dropped frame. A task waiting on an incomplete blocker was set down for a reason and is **parked** — surfacing it as a problem is a false alarm, and a detector that raises false alarms is muted within a week.
+
+The distinction:
+
+- **active** — where attention is now. Not a debt.
+- **parked** — waiting on an unresolved blocker. Legitimately set down.
+- **abandoned** — unblocked, and attention went elsewhere without completing it. This is the dropped frame.
+
+A second, purely structural check needs no timestamps at all: **a completed parent with an in-progress descendant is a contradiction.** A mission cannot honestly be complete while a phase inside it is still running. This catches the case where a whole branch was declared finished with one frame still open, and it is cheaper and more certain than any staleness heuristic.
+
+### 16.5 Seeing the stack
+
+```
+macf_tools task trace            # open frames, oldest first, classified
+macf_tools task trace --path 20  # the order attention moved, most recent last
+```
+
+Read it after any discontinuity — a recovered session, a handoff, a return from an interruption — and before declaring a branch of work finished.
+
+### 16.6 Why this is an obligation and not a convenience
+
+Where an operator directs an agent by interruption, the two parties hold different responsibilities. The operator is entitled to raise something the moment it is noticed and then move on; that is what makes correcting cheap enough to do at all. The cost of that arrangement is that **someone must hold the interrupted work, and it is not the operator.**
+
+An agent that services the newest instruction and silently drops the previous one has not merely forgotten a task. It has broken the contract that made interrupting safe — and the operator, having moved on by design, is the last party able to notice.
+
 
 ## Wiki-Links
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -1,6 +1,6 @@
 # PYTHON_ARGCOMPLETE_OK
 # tools/src/maceff/cli.py
-import argparse, json, os, subprocess, sys, glob, platform, socket
+import argparse, json, os, subprocess, sys, glob, platform, socket, time
 from pathlib import Path
 from datetime import datetime, timezone
 try:
@@ -5461,6 +5461,70 @@ def cmd_task_reparent(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_task_trace(args: argparse.Namespace) -> int:
+    """Show where attention has been, and what it owes a return to.
+
+    The tree answers "what work exists". This answers "what was I in the middle
+    of" — which after an interrupt, a compaction, or a handoff is the question
+    that actually needs answering, and the one a tree of six open tasks cannot.
+    """
+    from .task import TaskReader
+    from .task.trace import visitation_trace, open_frames
+
+    tasks = TaskReader().read_all_tasks()
+    frames = open_frames(tasks)
+    path_n = getattr(args, "path", 0)
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "frames": [vars(f) for f in frames],
+            "path": [vars(t) for t in visitation_trace(tasks)[-path_n:]] if path_n else [],
+        }, indent=2))
+        return 0
+
+    if path_n:
+        trace = visitation_trace(tasks)[-path_n:]
+        print(f"👣 Where attention has been — last {len(trace)} touch(es)\n")
+        previous = None
+        for touch in trace:
+            moved = "→" if touch.task_id != previous else " "
+            when = _rel_age_short(touch.timestamp)
+            print(f"  {moved} #{touch.task_id:<6} {when:>8}  {touch.description[:56]}")
+            previous = touch.task_id
+        print()
+
+    owed = [f for f in frames if f.state != "active"]
+    print(f"🧵 Open frames: {len(frames)} ({len(owed)} awaiting a return)")
+    if not frames:
+        print("   ✅ nothing in progress")
+        return 0
+
+    icon = {"active": "▶️ ", "parked": "⏸️ ", "abandoned": "⚠️ "}
+    for f in frames:
+        when = _rel_age_short(f.last_touch) if f.last_touch else "never"
+        print(f"   {icon.get(f.state, '  ')} #{f.task_id:<6} {f.state:<10} last touched {when}")
+        print(f"        {_strip_ansi(f.subject)[:96]}")
+        if f.blockers_open:
+            print(f"        ⏸  waiting on {', '.join('#' + b for b in f.blockers_open)}")
+        if f.parent_completed and f.state != "active":
+            print(f"        ⚠️  its parent is marked COMPLETE while this is still running")
+
+    if owed:
+        print(f"\n   Resume with:  macf_tools task start {owed[0].task_id}")
+    return 0
+
+
+def _rel_age_short(ts) -> str:
+    """Compact relative age, e.g. '3m', '5h', '12d'."""
+    if not ts:
+        return "?"
+    secs = max(0, int(time.time() - int(ts)))
+    for unit, size in (("d", 86400), ("h", 3600), ("m", 60)):
+        if secs >= size:
+            return f"{secs // size}{unit}"
+    return f"{secs}s"
+
+
 def _doctor_check_subject_markers(tasks) -> "list[tuple[str, str, str]]":
     """Find tasks whose stored ``[^#N]`` marker disagrees with ``parent_id``.
 
@@ -7986,7 +8050,13 @@ def cmd_task_complete(args: argparse.Namespace) -> int:
         try:
             from .modes import detect_auto_mode
             _auto, _ = detect_auto_mode(get_current_session_id())
-        except Exception:
+        except (ImportError, OSError, ValueError) as e:
+            # Not knowing the mode is survivable — the warning below still
+            # prints and the operator still decides. Swallowing the reason is
+            # not: it would hide a broken mode subsystem behind a completion
+            # that merely looks conservative.
+            print(f"⚠️ MACF: could not resolve mode for completion gate: {e}",
+                  file=sys.stderr)
             _auto = False
         _listing = ", ".join(f"#{cid}({st})" for cid, st in _open_children[:8])
         print(f"⚠️  Task #{task_id} has {len(_open_children)} incomplete child task(s): {_listing}")
@@ -10068,6 +10138,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="proceed even if the target already holds files of the same name",
     )
     task_migrate_parser.set_defaults(func=cmd_task_migrate_store)
+
+    task_trace_parser = task_sub.add_parser(
+        "trace",
+        help="show where attention has been and what it owes a return to",
+    )
+    task_trace_parser.add_argument(
+        "--path", type=int, default=0, metavar="N",
+        help="also show the last N touches, in the order they happened",
+    )
+    task_trace_parser.add_argument("--json", action="store_true", help="output as JSON")
+    task_trace_parser.set_defaults(func=cmd_task_trace)
 
     task_doctor_parser = task_sub.add_parser(
         "doctor",

--- a/macf/src/macf/task/trace.py
+++ b/macf/src/macf/task/trace.py
@@ -1,0 +1,157 @@
+"""Where attention has been, and what it owes a return to.
+
+The task tree shows *where* work is. It does not show the order attention moved
+through it, and that ordering is the difference between a stack and a pile: a
+tree with six open tasks tells you six things are unfinished, not which one you
+were in the middle of and meant to come back to.
+
+The ordering is not missing — it is discarded. Every task update carries a
+breadcrumb with a ``t_`` timestamp, so the full visitation sequence is already
+on disk. The tree's recency marker is the ``argmax`` over those timestamps, and
+reducing an ordered trace to a single pointer throws away everything except its
+last element.
+
+This module performs the other reductions: the path attention actually took,
+and the frames it left behind without returning.
+"""
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+SENTINEL_TASK_ID = "000"
+
+#: Breadcrumb epoch component, e.g. ``.../t_1786375853``.
+_TS_RE = re.compile(r'/t_(\d+)')
+_CYCLE_RE = re.compile(r'/c_(\d+)')
+
+
+@dataclass
+class Touch:
+    """One recorded moment of attention on one task."""
+    timestamp: int
+    task_id: str
+    cycle: Optional[int]
+    description: str
+
+
+@dataclass
+class Frame:
+    """An in-progress task, classified by whether a return is actually owed.
+
+    ``state`` is one of:
+
+    ``active``
+        The current position of attention. Not a debt.
+    ``parked``
+        Waiting on an incomplete blocker. Legitimately set down, and flagging
+        it would be crying wolf — the distinction that keeps this useful.
+    ``abandoned``
+        Unblocked, and attention went elsewhere without completing it. This is
+        the dropped frame.
+    """
+    task_id: str
+    subject: str
+    state: str
+    last_touch: Optional[int]
+    blockers_open: List[str]
+    parent_completed: bool
+
+
+def _breadcrumbs(task):
+    for update in (getattr(getattr(task, "mtmd", None), "updates", None) or []):
+        bc = getattr(update, "breadcrumb", "") or ""
+        if bc:
+            yield bc, (getattr(update, "description", "") or "")
+
+
+def last_touch(task) -> Optional[int]:
+    """Epoch of the most recent recorded update, or None if never touched."""
+    stamps = [int(m.group(1)) for bc, _ in _breadcrumbs(task)
+              for m in [_TS_RE.search(bc)] if m]
+    return max(stamps) if stamps else None
+
+
+def visitation_trace(tasks) -> List[Touch]:
+    """Every recorded touch across all tasks, in the order they happened.
+
+    This is the path attention took. Consecutive touches on the same task are
+    preserved rather than collapsed — the dwell is part of the shape.
+    """
+    touches = []
+    for task in tasks:
+        for bc, desc in _breadcrumbs(task):
+            m = _TS_RE.search(bc)
+            if not m:
+                continue
+            cyc = _CYCLE_RE.search(bc)
+            touches.append(Touch(
+                timestamp=int(m.group(1)),
+                task_id=str(task.id),
+                cycle=int(cyc.group(1)) if cyc else None,
+                description=desc.replace("\n", " ").strip(),
+            ))
+    touches.sort(key=lambda t: t.timestamp)
+    return touches
+
+
+def open_frames(tasks) -> List[Frame]:
+    """In-progress tasks, classified by whether a return is genuinely owed.
+
+    Ordered oldest-touch first, so the frame most likely to have been forgotten
+    is the one reported first.
+    """
+    by_id = {str(t.id): t for t in tasks}
+    in_progress = [t for t in tasks
+                   if t.status == "in_progress" and str(t.id) != SENTINEL_TASK_ID]
+    if not in_progress:
+        return []
+
+    # The current position: whichever task was touched last overall. It is
+    # in-progress by definition of being where we are, and is not a debt.
+    newest_id, newest_ts = None, -1
+    for task in tasks:
+        ts = last_touch(task)
+        if ts is not None and ts > newest_ts:
+            newest_ts, newest_id = ts, str(task.id)
+
+    frames = []
+    for task in in_progress:
+        tid = str(task.id)
+        blockers_open = [
+            str(b) for b in (getattr(task, "blocked_by", None) or [])
+            if str(b) in by_id and by_id[str(b)].status not in ("completed", "archived")
+        ]
+        parent_id = getattr(getattr(task, "mtmd", None), "parent_id", None)
+        parent = by_id.get(str(parent_id)) if parent_id is not None else None
+        parent_completed = bool(parent and parent.status in ("completed", "archived"))
+
+        if tid == newest_id:
+            state = "active"
+        elif blockers_open:
+            state = "parked"
+        else:
+            state = "abandoned"
+
+        frames.append(Frame(
+            task_id=tid,
+            subject=getattr(task, "subject", "") or "",
+            state=state,
+            last_touch=last_touch(task),
+            blockers_open=blockers_open,
+            parent_completed=parent_completed,
+        ))
+
+    frames.sort(key=lambda f: (f.last_touch is None, f.last_touch or 0))
+    return frames
+
+
+def contradictory_frames(tasks) -> List[Frame]:
+    """Frames whose parent is complete while they are still running.
+
+    A structural check needing no timestamps: a parent cannot honestly be
+    complete while a child of it is in progress. Cheaper and more certain than
+    the staleness heuristic, and it catches the case where a whole branch was
+    declared finished with one phase still open.
+    """
+    return [f for f in open_frames(tasks)
+            if f.parent_completed and f.state != "active"]

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -1362,3 +1362,63 @@ class TestTaskTreeSuccinctProgressiveDisclosure:
         out = self._tree(isolated_task_env['env'])
         assert 'COMPLETED MIDDLE' in out
         assert 'ACTIVE GRANDCHILD' in out, f"active grandchild hidden by collapse:\n{out}"
+
+
+class TestTaskTraceCommand:
+    """`task trace` surfaces the frame an interrupt left behind."""
+
+    def _seed(self, session_dir, task_id, status, ts, parent='"000"', task_type="TASK"):
+        (session_dir / f"{task_id}.json").write_text(json.dumps({
+            "id": task_id,
+            "subject": f"  #{task_id} work item",
+            "status": status,
+            "description": (
+                '<macf_task_metadata version="1.0">\n'
+                f'task_type: {task_type}\n'
+                'created_by: PA\n'
+                f'parent_id: {parent}\n'
+                'updates:\n'
+                f'  - breadcrumb: s_t/c_1/g_abc1234/p_none/t_{ts}\n'
+                '    description: touched\n'
+                '</macf_task_metadata>\n'
+            ),
+        }))
+
+    def _run(self, env, *args):
+        return subprocess.run(
+            ["macf_tools", "task", "trace", *args],
+            capture_output=True, text=True, env=env,
+        )
+
+    def test_reports_no_open_frames_on_a_clean_tree(self, isolated_task_env):
+        self._seed(isolated_task_env['session_dir'], "000", "in_progress", 100,
+                   parent="null", task_type="SENTINEL")
+        self._seed(isolated_task_env['session_dir'], "1", "completed", 200)
+
+        result = self._run(isolated_task_env['env'])
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "nothing in progress" in result.stdout
+
+    def test_surfaces_an_abandoned_frame(self, isolated_task_env):
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "in_progress", 200)   # left behind
+        self._seed(session, "6", "completed", 900)     # attention moved here
+
+        result = self._run(isolated_task_env['env'])
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "#5" in result.stdout
+        assert "abandoned" in result.stdout
+        assert "macf_tools task start 5" in result.stdout, "must name the remedy"
+
+    def test_path_flag_shows_the_order_attention_moved(self, isolated_task_env):
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "completed", 200)
+        self._seed(session, "6", "completed", 300)
+
+        result = self._run(isolated_task_env['env'], "--path", "5")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Where attention has been" in result.stdout
+        assert result.stdout.index("#5") < result.stdout.index("#6"), \
+            "the path must render in the order the touches happened"

--- a/macf/tests/test_task_trace.py
+++ b/macf/tests/test_task_trace.py
@@ -1,0 +1,151 @@
+"""The trace answers "what was I in the middle of", which a tree cannot.
+
+A tree with six open tasks reports six unfinished things. It does not report
+which one attention left and owes a return to — and that distinction is the
+whole difference between a stack and a pile.
+"""
+import pytest
+
+from macf.task.trace import (
+    Frame,
+    contradictory_frames,
+    last_touch,
+    open_frames,
+    visitation_trace,
+)
+
+
+class _Update:
+    def __init__(self, ts, desc="", cycle=7):
+        self.breadcrumb = f"s_abc/c_{cycle}/g_deadbee/p_none/t_{ts}"
+        self.description = desc
+
+
+class _Mtmd:
+    def __init__(self, updates=None, parent_id=None):
+        self.updates = updates or []
+        self.parent_id = parent_id
+
+
+class _Task:
+    def __init__(self, task_id, status="pending", updates=None,
+                 parent_id=None, blocked_by=None, subject=None):
+        self.id = task_id
+        self.status = status
+        self.subject = subject or f"  #{task_id} a task"
+        self.mtmd = _Mtmd(updates, parent_id)
+        self.blocked_by = blocked_by or []
+
+
+class TestLastTouch:
+    def test_returns_the_most_recent_stamp(self):
+        t = _Task("1", updates=[_Update(100), _Update(300), _Update(200)])
+        assert last_touch(t) == 300
+
+    def test_none_when_never_touched(self):
+        assert last_touch(_Task("1")) is None
+
+
+class TestVisitationTrace:
+    def test_orders_touches_across_tasks_by_time(self):
+        tasks = [
+            _Task("1", updates=[_Update(300, "third")]),
+            _Task("2", updates=[_Update(100, "first"), _Update(200, "second")]),
+        ]
+        assert [t.description for t in visitation_trace(tasks)] == [
+            "first", "second", "third"]
+
+    def test_preserves_consecutive_touches_on_one_task(self):
+        """Dwell is part of the shape — collapsing runs would hide how long
+        attention actually stayed somewhere."""
+        tasks = [_Task("1", updates=[_Update(10), _Update(20), _Update(30)])]
+        assert [t.task_id for t in visitation_trace(tasks)] == ["1", "1", "1"]
+
+    def test_carries_the_cycle_from_the_breadcrumb(self):
+        tasks = [_Task("1", updates=[_Update(10, cycle=42)])]
+        assert visitation_trace(tasks)[0].cycle == 42
+
+
+class TestOpenFrames:
+    def test_the_newest_touched_in_progress_task_is_active_not_a_debt(self):
+        tasks = [
+            _Task("1", "in_progress", [_Update(100)]),
+            _Task("2", "in_progress", [_Update(900)]),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states == {"2": "active", "1": "abandoned"}
+
+    def test_a_frame_with_an_open_blocker_is_parked_not_abandoned(self):
+        """The distinction that keeps the detector usable.
+
+        A blocked frame was set down for a reason. Flagging it would cry wolf
+        on correct behaviour, and a detector that cries wolf gets muted.
+        """
+        tasks = [
+            _Task("1", "in_progress", [_Update(100)], blocked_by=["9"]),
+            _Task("9", "pending", [_Update(50)]),
+            _Task("2", "in_progress", [_Update(900)]),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["1"] == "parked"
+
+    def test_a_completed_blocker_no_longer_parks_a_frame(self):
+        tasks = [
+            _Task("1", "in_progress", [_Update(100)], blocked_by=["9"]),
+            _Task("9", "completed", [_Update(50)]),
+            _Task("2", "in_progress", [_Update(900)]),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["1"] == "abandoned", "a resolved blocker leaves a real debt"
+
+    def test_oldest_frame_reported_first(self):
+        """The most-forgotten frame is the one most worth surfacing."""
+        tasks = [
+            _Task("1", "in_progress", [_Update(100)]),
+            _Task("2", "in_progress", [_Update(200)]),
+            _Task("3", "in_progress", [_Update(900)]),
+        ]
+        assert [f.task_id for f in open_frames(tasks)][0] == "1"
+
+    def test_sentinel_is_never_a_frame(self):
+        tasks = [_Task("000", "in_progress", [_Update(100)])]
+        assert open_frames(tasks) == []
+
+    def test_pending_and_completed_tasks_are_not_frames(self):
+        tasks = [
+            _Task("1", "pending", [_Update(100)]),
+            _Task("2", "completed", [_Update(200)]),
+        ]
+        assert open_frames(tasks) == []
+
+    def test_no_open_work_is_an_empty_stack(self):
+        assert open_frames([]) == []
+
+
+class TestContradictoryFrames:
+    def test_completed_parent_with_running_child_is_flagged(self):
+        """A structural check needing no timestamps: a parent cannot honestly
+        be complete while a child of it is still in progress."""
+        tasks = [
+            _Task("197", "completed", [_Update(50)]),
+            _Task("200", "in_progress", [_Update(100)], parent_id="197"),
+            _Task("2", "in_progress", [_Update(900)]),
+        ]
+        assert [f.task_id for f in contradictory_frames(tasks)] == ["200"]
+
+    def test_open_parent_with_running_child_is_ordinary(self):
+        tasks = [
+            _Task("197", "in_progress", [_Update(50)]),
+            _Task("200", "in_progress", [_Update(100)], parent_id="197"),
+            _Task("2", "in_progress", [_Update(900)]),
+        ]
+        assert contradictory_frames(tasks) == []
+
+    def test_the_active_frame_is_not_reported_as_contradictory(self):
+        """Where attention is right now is not a dropped frame, even if the
+        parent bookkeeping is wrong — report it as work, not as debt."""
+        tasks = [
+            _Task("197", "completed", [_Update(50)]),
+            _Task("200", "in_progress", [_Update(900)], parent_id="197"),
+        ]
+        assert contradictory_frames(tasks) == []


### PR DESCRIPTION
A tree of open tasks answers *"what is unfinished"*. After an interruption, a context loss, or a handoff the question is different — *"what was I in the middle of"* — and six open tasks do not answer it.

The missing element is **ordering**. A stack is an ordered set with a discipline about which frame you return to; without the order, the tree is a pile.

## The ordering already exists — it is discarded at render

Every task update carries a breadcrumb with an epoch timestamp, so the visitation sequence is already on disk. The tree's recency marker is `argmax` over that sequence: an ordered trace reduced to its last element. Recovering the path needs no new instrumentation, only a reduction that is not lossy.

Against a live store, **3,497 touches** were recoverable.

```
$ macf_tools task trace --path 6
👣 Where attention has been — last 6 touch(es)

  → #1202         1h  ATTACK FINDINGS on the draft. Tested against the corpus
    #1202         1h  Task completed via CLI
  → #1203         1h  INTERRUPT MECHANISM — research complete
    #1203         1h  Task completed via CLI
  → #1204        53m  Task completed via CLI
  → #1205        52m  Filed the delivery-notification design

🧵 Open frames: 1 (1 awaiting a return)
   ⚠️  #200    abandoned  last touched 165d
        #200 [^#197] - Phase 3: ...
        ⚠️  its parent is marked COMPLETE while this is still running

   Resume with:  macf_tools task start 200
```

## Parked is not abandoned

A frame waiting on an unresolved blocker was set down for a reason. Flagging it would cry wolf on correct behaviour — and **a detector that cries wolf gets muted, which is worse than not having one.** Frames are classified `active` / `parked` / `abandoned`, and the blocker's status is checked before anything is called a debt.

I did not design that distinction; I got it from examining the specimen. The 165-day frame carried a `blocked_by`, and had its blocker still been open it would have been legitimately parked rather than dropped.

## Two checks, deliberately different

- **Structural** — a completed parent with an in-progress descendant. Needs no timestamps: a mission cannot honestly be complete while a phase inside it runs.
- **Temporal** — in-progress, *unblocked*, attention elsewhere.

On the relationship to #235's guard: `task complete` currently **warns about open children and proceeds**, so the contradictory state remains reachable. And a write-time warning can never surface a contradiction created *before* it existed — which is exactly the population a detector is for. The two are complementary, not redundant.

## Policy

`task_management` gains **§16 "The Work Stack"**, mapping push / pop / pop-reconciled onto mechanisms that already exist. Worth noting that **"reconciled, not blindly restored" is already implemented** — the resume ritual prints a stale task's age and requires re-reading its history before continuing. The section also states why a frame must be durable *before* it is interrupted rather than written at interrupt time, as an observable property with its reproduction attached.

## Two repairs this ran into

- **CEP navigation drift in `task_management`** — the guide omitted §12, §14 and §15 and gave §12 the content of §13, so `policy navigate` advertised a structure the document no longer had. Same class as the scholarship §9 collision fixed in #191.
- **A silent `except Exception` in the completion gate** (from #235). The repository's own pre-commit guard rejects it, which blocks *every* commit touching `cli.py`. Fixed here rather than bypassed with `--no-verify`.

Both are noted so the extra diff is not a surprise.

## Verification

18 new tests (15 unit, 3 CLI), all passing. The new module sits **outside the hook import path**, so it cannot contribute to an all-hooks failure.

**On local suite state, stated honestly:** 9 tests fail on this machine and are unrelated to this branch — 7 from a tmux helper that strips `PATH` from its subprocess env (#241) and 2 from a `time` contract change (#242). Both were filed separately today. They reproduce on clean `main` with this branch's changes stashed.

I attempted an automated with/without failure diff and **discarded the result**: an intervening stash-pop meant both passes measured the same tree, so the clean-looking output proved nothing. CI is the better adjudicator here regardless, since it runs the Linux environment where those 9 pass.