### PR TITLE
IL — the grammar shape and the service model (v0.3.0)

### DIFF
--- a/framework/policies/base/operations/instruction_language.md
+++ b/framework/policies/base/operations/instruction_language.md
@@ -2,8 +2,8 @@
 
 **Type**: Operations Infrastructure
 **Scope**: All agents (PA and SA)
-**Status**: ACTIVE (partial — foundational principles; see §1)
-**Version**: 0.2.0
+**Status**: ACTIVE
+**Version**: 0.3.0
 **Methodology**: Policy as Spec — this policy IS the specification. Implementation must match.
 
 ---
@@ -30,9 +30,11 @@ the instruction *vocabularies* were nearly disjoint, while the underlying
 
 ## CEP Navigation Guide
 
-**1 Scope of This Version**
-- What does this version define, and what is deferred?
-- Why land the foundational principles before the full grammar?
+**1 The Shape**
+- What is the canonical form of an IL directive?
+- What do the two terminators mean, and what parser work do they do?
+- What are `.subtype`, `(target)`, and the `# rider`?
+- How is IL recognised for a token the agent has never seen?
 
 **2 The Two Layers: Grammar and Vocabulary**
 - What is universal (grammar) versus per-pair (vocabulary)?
@@ -46,31 +48,78 @@ the instruction *vocabularies* were nearly disjoint, while the underlying
 - What does "a grammar that cannot express half-compliance cannot suffer it" mean?
 - What is the one-obligation design rule?
 
+**4 The Service Model**
+- How does an interrupting directive bind to the work stack?
+- What is the service-discipline axis, and how does observability set it?
+- What overrides does a correction need (abandon vs defer)?
+- How does an autonomous sprint change the interrupt?
+
+**5 Scope and Forthcoming Work**
+- What is fully canonical, and what is still per-pair or unbuilt?
+
 === CEP_NAV_BOUNDARY ===
 
-## 1. Scope of This Version
+## 1. The Shape
 
-IL is being canonicalized in stages, in order of evidential standing. This
-version (0.2.0) lands the two principles that are supported by comparison across
-independent pairs and by matched failures in more than one:
+The canonical form of an IL directive:
 
-- **§2 — the two-layer architecture** (grammar vs vocabulary), and
-- **§3 — one obligation per form.**
+```
+TOKEN[.subtype][(target)][ : | ! ] payload   [# rider]
+```
 
-**Deferred to a later version, and intentionally not specified here:**
+- **TOKEN** — an UPPERCASE directive class (`RULE`, `RESUME`, `IDEA`, `GO`, …).
+  Uppercase is part of the recognition trigger; lowercase directive-shaped forms
+  are treated as ordinary prose (empirically they are typos).
+- **`.subtype`** — SPECIALIZATION: `X.y` = *y is a kind of X* (`TASK.bug`,
+  `TASK.detour`).
+- **`(target)`** — PARAMETERIZATION: `X(t)` = *X acts on / is written into t*
+  (`RULE(TM)` — the target is what the rule is written into, not a kind of rule).
+  A different relation from `.subtype`, and a distinct structural slot because dot
+  notation cannot express it. **Provenance:** this slot is retained on the
+  evidence of a single pair; unlike the rest of the shape it is not yet
+  corroborated by a second corpus, and a reader should weight it accordingly.
 
-- **The concrete grammar** — the exact *shape* of a directive (its tokens,
-  modifiers, and terminators) and its parse rules. A working draft exists and is
-  in cross-pair review; it is not yet canonical.
-- **The service model** — how an interrupting directive is absorbed and how prior
-  work is resumed. This depends on runtime behaviour still being characterized and
-  on a second pair's corpus, and is deferred rather than frozen on one pair's
-  practice.
+### 1.1 The terminators carry the parse
 
-Landing the principles first is deliberate: §2 and §3 are the load-bearing design
-decisions — they determine what *can* be expressed and how directives are
-structured — and they are stable regardless of how the concrete shape settles. A
-deployment can adopt them now without waiting for the grammar spec.
+Both terminators may be followed by text. The distinction is not *presence* of a
+payload but its **grammatical role**:
+
+- **`:`** — the payload is the directive's **argument**, the thing it operates on.
+  Dropping it destroys the instruction. → An unknown `TOKEN:` **traps and
+  queries**; it is never silently read as prose.
+- **`!`** — the payload is a **rider or colored-prose instruction**: the token
+  *tones or qualifies* what follows rather than consuming it (`UGH! get rid of the
+  old injection…` is an affect marker on an ordinary request, not a directive
+  taking "get rid of…" as an argument). → An unknown `TOKEN!` **acknowledges and
+  continues**; register the tone, keep reading, do not interrogate it.
+
+The terminator, not the token, carries the parse: a single token may appear with
+**both** terminators. A vocabulary registry (§2.5) therefore records a
+terminator as a property of the **occurrence**, never as a fixed attribute of the
+token.
+
+### 1.2 The `# rider`
+
+A modifier attaches to a directive with `#`:
+
+```
+GO!  # pause around the wind-down boundary
+```
+
+The rider can itself contain a full IL form, which is the mechanism by which one
+directive composes with another — composition is a rider phenomenon, not a
+separate stacking syntax.
+
+### 1.3 Self-identifying, with a false-positive guard
+
+The grammar parses **independently of the vocabulary**: an uppercase TOKEN,
+optional slots, and a terminator are recognised as IL even when the TOKEN is
+unknown — so a novel coinage costs one clarifying question (§2.6), not a silently
+dropped instruction. Recognition requires the token at a **directive position**
+(start of a message or line, or after a clause boundary), not anywhere in prose,
+so an exclamation embedded in a fixed phrase is not mistaken for a directive. The
+terminator **and** the position together identify IL; the terminator alone
+over-fires.
 
 ## 2. The Two Layers: Grammar and Vocabulary
 
@@ -79,13 +128,12 @@ bars.
 
 ### 2.1 Grammar (universal)
 
-The **grammar** is the structure of a directive — its shape and parse rules. It is
-**universal**: hand-curated, honoured by every agent, and changed only against a
-**high bar** — evidence from more than one independent operator–agent pair. The
-grammar is what lets an agent recognise a directive it has never seen as a
-directive rather than read it as prose; that property depends on the structure
-being pair-independent. (The concrete grammar spec is deferred to a later version
-per §1; this policy fixes only its *status* as the universal, high-bar layer.)
+The **grammar** is the structure of a directive (§1) — its shape and parse rules.
+It is **universal**: hand-curated, honoured by every agent, and changed only
+against a **high bar** — evidence from more than one independent operator–agent
+pair. The grammar is what lets an agent recognise a directive it has never seen as
+a directive rather than read it as prose; that property depends on the structure
+being pair-independent.
 
 ### 2.2 Vocabulary (per-pair)
 
@@ -141,10 +189,9 @@ follow:
 
 ### 2.6 Vocabulary evolves by clarify-then-codify
 
-Because the grammar is self-identifying (a directive is recognisable by its
-structure even when its token is unknown — full spec deferred per §1), an agent
-can meet a directive whose *form* it parses but whose *meaning* it does not know.
-The prescribed response is a **clarify-then-codify** loop:
+Because the grammar is self-identifying (§1.3), an agent can meet a directive
+whose *form* it parses but whose *meaning* it does not know. The prescribed
+response is a **clarify-then-codify** loop:
 
 1. State the inference and ask a cheap, confirmable question — *"I take this to
    mean X; record it?"* — then continue.
@@ -202,15 +249,106 @@ exists or it does not.
 - **The tell of a silent half-failure:** you have complied, it felt complete, and
   nothing changed on disk.
 
+## 4. The Service Model
+
+An IL directive is an **interrupt**: it arrives mid-work, must be serviced, and the
+work it interrupted must be resumed. IL does not invent a mechanism for this. It
+**binds to the work stack** already defined in `task_management` §16, and adds only
+the parts specific to directives.
+
+### 4.1 Binding to the work stack
+
+An inbound IL directive mid-work becomes a **push** — a task, or a note on one —
+exactly as `task_management` §16 defines: servicing the directive is the work,
+and resuming prior work is a **reconciled pop** (the resume protocol, which reports
+a frame's age and requires reconciliation before continuing). All of the
+mechanics — that a frame must be durable *before* the interrupt (§16.3), the
+active / parked / abandoned distinction and the structural completed-parent check
+(§16.4), and how to see the stack via `macf_tools task trace` (§16.5) — live in
+that policy and are not restated here. **IL directives are simply a source of stack
+frames**, and the operator's entitlement to interrupt-and-forget while the agent
+holds the interrupted work is the obligation stated in §16.6.
+
+This binding is the recommended pattern; a deployment that adopts it inherits §16's
+guarantees. The additions below are the IL-specific layer on top of it.
+
+### 4.2 Service discipline follows observability (universal)
+
+Each directive is serviced under one of two disciplines:
+
+- **preempt-now** — unwind and service immediately;
+- **service-at-next-boundary** — queue to the next clean stopping point.
+
+Which one applies is **not a fixed property of the form**. It follows from a
+property of the channel:
+
+> **The party who can observe what they are interrupting may interrupt harder.**
+> An operator watching the session may issue **preempt-now** directives. Inbound
+> correspondence from a party who cannot see the agent's current state — a
+> different host, hours offset (e.g. asynchronous inter-agent mail) — defaults to
+> **service-at-next-boundary**.
+
+This is the one genuinely universal element of the service model, because it
+derives from observability rather than from any pair's taste.
+
+### 4.3 Autonomous operation inverts the interrupt
+
+IL was shaped for the attended case: the operator watches, the agent executes, the
+operator corrects. In an autonomous sprint the assumption inverts — the agent has
+its own scope and plan, so an inbound directive **interrupts the agent's plan, not
+the operator's.** Binding IL to the work stack (§4.1) is what keeps this coherent:
+the directive becomes a frame the sprint can see and the scope gate accounts for,
+so "resume the sprint" and "pop the frame" are the same operation rather than two
+competing stacks.
+
+A consequence worth stating, because it changes autonomy and not just syntax: in
+an unattended sprint the operator's observability drops to nearly nothing (§4.2),
+so an interrupt is **more** costly, not less — the agent may be mid-phase on work
+no one has seen. The same directive that is service-at-boundary while the operator
+watches may warrant preempt-now unattended, precisely because no one else will
+catch an error for hours.
+
+### 4.4 Override: abandon versus defer
+
+The default pop resumes the frame below. But some corrections **invalidate** it —
+*"stop, that whole approach is wrong"* means the frame beneath should be
+**discarded**, not resumed. A directive therefore needs one marker with two
+outcomes: **resume-below** (the default) or **discard-below**. Without it, a
+faithful agent dutifully returns to work the operator has already killed, which is
+worse than dropping it.
+
+Frame staleness and depth-reporting are **not** IL-specific overrides — they are
+the reconciled-pop and trace mechanics of §16 (a resumed frame is validated for
+age before restoration; the stack is surfaced via `task trace`). IL relies on them
+rather than restating them.
+
+## 5. Scope and Forthcoming Work
+
+**Canonical now:** the shape (§1), the two-layer architecture and namespacing
+(§2), one-obligation-per-form (§3), and the observability rule (§4.2). These are
+supported by comparison across independent pairs or by matched failures in more
+than one.
+
+**Per-pair pattern, not universal law:** the service-model binding (§4.1, §4.3,
+§4.4). It is expressible in the grammar and recommended, but rests on one pair's
+practice for its finer contracts; it is expected to evolve at the vocabulary
+layer's speed (§2.6) rather than be frozen here.
+
+**Forthcoming tooling (not policy):** the vocabulary-registry generator described
+in §2.5 — the per-agent read-only usage record and the union reader — is build
+work, not yet shipped. The stack/detector tooling the service model binds to
+already exists (`task_management` §16 / `macf_tools task trace`).
+
 ---
 
 ## Wiki-Links
 
-<!-- NORMATIVE node. Links are what this policy governs: the two-layer IL
-     architecture, per-pair namespacing, and the one-obligation design rule. -->
+<!-- NORMATIVE node. Links are what this policy governs: the IL shape, the
+     two-layer grammar/vocabulary architecture, per-pair namespacing, the
+     one-obligation rule, and the binding of directives to the work stack. -->
 
-[[instruction_language]] [[single_source_of_truth]] [[silent_failure]] [[verification]]
+[[instruction_language]] [[single_source_of_truth]] [[silent_failure]] [[verification]] [[task_lifecycle]] [[autonomous_operation]]
 
 ---
 
-*Foundational principles landed; concrete grammar and service model forthcoming (§1).*
+*Grammar and the two-layer architecture canonical; the service-model binding is a per-pair pattern over the work stack (task_management §16); the vocabulary-registry generator is forthcoming.*


### PR DESCRIPTION
Completes the Instruction Language policy with the two sections held back from the first landing (#240) for cross-pair review. Builds on the merged task-tree work stack (#243).

## §1 The Shape
The canonical directive form `TOKEN[.subtype][(target)][ : | ! ] payload [# rider]`, **self-identifying** so an unseen token is recognised as a directive rather than read as prose. The two terminators carry the parse by the payload's **grammatical role**: `:` takes an *argument* (an unknown one traps and queries); `!` takes a *rider/affect* (an unknown one acknowledges and continues). A token may appear with **both** terminators, so a registry records the terminator per *occurrence*, not per token. `(target)` parameterization is retained as a structural slot with its single-pair provenance stated honestly. Recognition requires a directive position (not the terminator alone) to avoid false positives.

## §4 The Service Model
Binds IL to the **work stack** (`task_management` §16) rather than defining a parallel mechanism: an inbound directive is a *push*, servicing is the work, resume is a *reconciled pop*. Durability-before-interrupt, parked-vs-abandoned, and the trace all live in §16 and are **referenced, not restated** (avoiding the two-policies-one-subject drift). IL adds only the directive-specific layer:
- **Service discipline follows observability** — "the party who can see what they interrupt may interrupt harder" (operator preempt-now; blind async peer service-at-boundary). The one genuinely universal element of the model.
- **The autonomous-mode inversion** — in a sprint an inbound directive interrupts the *agent's* plan; binding to the stack keeps the two from competing.
- **Abandon-vs-defer** — a correction may invalidate the frame below (discard-below vs the default resume-below).

## §5 Scope
States plainly what is **canonical** (shape, layering, one-obligation, the observability rule), what is a **per-pair pattern** (the service binding), and what is **forthcoming tooling** (the vocabulary-registry generator; the stack/detector tooling it binds to already ships via §16).

## Verification
- Discoverable via `policy list` / `navigate` / `read`; `§16` cross-reference resolves on main.
- Manifest-awareness, manifest-merging, and policy-CLI suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)