### PR TITLE
fix(task): render the trace newest-first, and stop the move marker lying

### DIFF
--- a/macf/docs/user/cli-reference.md
+++ b/macf/docs/user/cli-reference.md
@@ -1439,6 +1439,53 @@ macf_tools task get 67
 macf_tools task get #67  # Leading # is optional
 ```
 
+### task trace
+
+Show where attention has been, and what it owes a return to.
+
+**Syntax:**
+```bash
+macf_tools task trace [--path N] [--full] [--json]
+```
+
+**Options:**
+- `--path N` - Also render the last N touches, newest first
+- `--full` - Show note text in full instead of trimming it to one line
+- `--json` - Output as JSON
+
+**Description:** `task tree` answers *what work exists*. This answers *what was I in the middle of* — the question that matters after an interruption, a context loss, or a handoff, and the one a list of open tasks cannot answer on its own.
+
+Open tasks are reported as **frames**, classified by whether a return is genuinely owed:
+
+| State | Meaning |
+|---|---|
+| `active` | Where attention is now. Not a debt. |
+| `parked` | Waiting on an unresolved blocker. Legitimately set down. |
+| `abandoned` | Unblocked, and attention went elsewhere without completing it. |
+
+A frame whose parent is already marked complete is flagged separately — a parent cannot honestly be complete while a task inside it is still running, and that contradiction needs no timestamps to detect.
+
+**Output:**
+```
+👣 Where attention has been — 4 most recent, newest first
+
+  → #1210         1m  Task started via CLI
+  → #1206        25m  Task completed via CLI
+    #1206        42m  DISCIPLINE LAPSE, caught during review: the entire wo…
+  → #1205         2h  Filed the delivery-notification design
+
+🧵 Open frames: 1 (1 awaiting a return)
+   ⚠️  #200    abandoned  last touched 165d
+        #200 [^#197] - Phase 3: ...
+        ⚠️  its parent is marked COMPLETE while this is still running
+
+   Resume with:  macf_tools task start 200
+```
+
+In the path, `→` marks a touch where attention arrived from a *different* task; an unmarked line is a continued dwell on the same one. A trimmed note ends in `…` so a clipped note cannot be mistaken for one that simply ended there.
+
+**Related:** `task tree`, `task doctor`, `task start`
+
 ### task tree
 
 Display task hierarchy as a visual tree with status indicators, notes, and metadata.

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -5478,19 +5478,23 @@ def cmd_task_trace(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps({
             "frames": [vars(f) for f in frames],
-            "path": [vars(t) for t in visitation_trace(tasks)[-path_n:]] if path_n else [],
+            "path": [vars(t) for t in reversed(visitation_trace(tasks)[-path_n:])] if path_n else [],
         }, indent=2))
         return 0
 
     if path_n:
+        # Newest first: the question this answers is a recency question, and the
+        # convention every other log-shaped tool sets. The move markers survive
+        # the reversal because they were computed chronologically and carried on
+        # each touch — reading them off display adjacency would invert them.
         trace = visitation_trace(tasks)[-path_n:]
-        print(f"👣 Where attention has been — last {len(trace)} touch(es)\n")
-        previous = None
-        for touch in trace:
-            moved = "→" if touch.task_id != previous else " "
+        full = getattr(args, "full", False)
+        print(f"👣 Where attention has been — {len(trace)} most recent, newest first\n")
+        for touch in reversed(trace):
+            moved = "→" if touch.begins_dwell else " "
             when = _rel_age_short(touch.timestamp)
-            print(f"  {moved} #{touch.task_id:<6} {when:>8}  {touch.description[:56]}")
-            previous = touch.task_id
+            note = touch.description if full else _ellipsize(touch.description, 56)
+            print(f"  {moved} #{touch.task_id:<6} {when:>8}  {note}")
         print()
 
     owed = [f for f in frames if f.state != "active"]
@@ -5512,6 +5516,19 @@ def cmd_task_trace(args: argparse.Namespace) -> int:
     if owed:
         print(f"\n   Resume with:  macf_tools task start {owed[0].task_id}")
     return 0
+
+
+def _ellipsize(text: str, width: int) -> str:
+    """Trim to `width`, marking the cut so a truncated note cannot read as whole.
+
+    A note silently clipped mid-sentence looks like a note that simply ended
+    there, which is the reading most likely to mislead whoever is reconstructing
+    what they were doing.
+    """
+    text = (text or "").strip()
+    if len(text) <= width:
+        return text
+    return text[:width - 1].rstrip() + "…"
 
 
 def _rel_age_short(ts) -> str:
@@ -10146,6 +10163,10 @@ def _build_parser() -> argparse.ArgumentParser:
     task_trace_parser.add_argument(
         "--path", type=int, default=0, metavar="N",
         help="also show the last N touches, in the order they happened",
+    )
+    task_trace_parser.add_argument(
+        "--full", action="store_true",
+        help="show note text in full instead of trimming it to one line",
     )
     task_trace_parser.add_argument("--json", action="store_true", help="output as JSON")
     task_trace_parser.set_defaults(func=cmd_task_trace)

--- a/macf/src/macf/task/trace.py
+++ b/macf/src/macf/task/trace.py
@@ -27,11 +27,22 @@ _CYCLE_RE = re.compile(r'/c_(\d+)')
 
 @dataclass
 class Touch:
-    """One recorded moment of attention on one task."""
+    """One recorded moment of attention on one task.
+
+    ``begins_dwell`` marks a touch that arrived from a *different* task — the
+    moment attention moved rather than stayed. It is computed here, in
+    chronological order, and carried on the record.
+
+    That placement is deliberate. Deriving it at render time from whichever
+    line happens to sit above would make it a statement about the display
+    rather than about what happened, and reversing the output would silently
+    invert its meaning while it went on looking authoritative.
+    """
     timestamp: int
     task_id: str
     cycle: Optional[int]
     description: str
+    begins_dwell: bool = False
 
 
 @dataclass
@@ -91,6 +102,11 @@ def visitation_trace(tasks) -> List[Touch]:
                 description=desc.replace("\n", " ").strip(),
             ))
     touches.sort(key=lambda t: t.timestamp)
+    # Mark the moves once, in the order they happened.
+    previous = None
+    for touch in touches:
+        touch.begins_dwell = touch.task_id != previous
+        previous = touch.task_id
     return touches
 
 

--- a/macf/tests/test_task_cli.py
+++ b/macf/tests/test_task_cli.py
@@ -1412,6 +1412,11 @@ class TestTaskTraceCommand:
         assert "macf_tools task start 5" in result.stdout, "must name the remedy"
 
     def test_path_flag_shows_the_order_attention_moved(self, isolated_task_env):
+        """Newest first — this asserted the opposite until the ordering changed.
+
+        Kept rather than deleted: it is the test that caught the change, and
+        it now pins the current contract instead of the previous one.
+        """
         session = isolated_task_env['session_dir']
         self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
         self._seed(session, "5", "completed", 200)
@@ -1420,5 +1425,68 @@ class TestTaskTraceCommand:
         result = self._run(isolated_task_env['env'], "--path", "5")
         assert result.returncode == 0, result.stdout + result.stderr
         assert "Where attention has been" in result.stdout
-        assert result.stdout.index("#5") < result.stdout.index("#6"), \
-            "the path must render in the order the touches happened"
+        assert result.stdout.index("#6") < result.stdout.index("#5"), \
+            "the most recent touch must render first"
+
+
+class TestTaskTraceRendering:
+    """Newest-first, with truncation that admits it truncated."""
+
+    def _seed(self, session_dir, task_id, status, ts, note="touched", parent='"000"',
+              task_type="TASK"):
+        (session_dir / f"{task_id}.json").write_text(json.dumps({
+            "id": task_id,
+            "subject": f"  #{task_id} work item",
+            "status": status,
+            "description": (
+                '<macf_task_metadata version="1.0">\n'
+                f'task_type: {task_type}\n'
+                'created_by: PA\n'
+                f'parent_id: {parent}\n'
+                'updates:\n'
+                f'  - breadcrumb: s_t/c_1/g_abc1234/p_none/t_{ts}\n'
+                f'    description: {note}\n'
+                '</macf_task_metadata>\n'
+            ),
+        }))
+
+    def _run(self, env, *args):
+        return subprocess.run(["macf_tools", "task", "trace", *args],
+                              capture_output=True, text=True, env=env)
+
+    def test_path_renders_newest_first(self, isolated_task_env):
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "completed", 200, note="older")
+        self._seed(session, "6", "completed", 300, note="newer")
+
+        out = self._run(isolated_task_env['env'], "--path", "5").stdout
+        assert out.index("#6") < out.index("#5"), "newest touch must render first"
+        assert "newest first" in out
+
+    def test_open_frames_stay_below_the_path(self, isolated_task_env):
+        """Follow-on instruction belongs at the end, where the eye lands last."""
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "in_progress", 200)
+        self._seed(session, "6", "completed", 300)
+
+        out = self._run(isolated_task_env['env'], "--path", "5").stdout
+        assert out.index("Where attention has been") < out.index("Open frames")
+
+    def test_a_trimmed_note_says_so(self, isolated_task_env):
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "completed", 200, note="x" * 200)
+
+        out = self._run(isolated_task_env['env'], "--path", "3").stdout
+        assert "…" in out, "a silently clipped note reads as a note that simply ended there"
+
+    def test_full_flag_does_not_trim(self, isolated_task_env):
+        session = isolated_task_env['session_dir']
+        self._seed(session, "000", "in_progress", 100, parent="null", task_type="SENTINEL")
+        self._seed(session, "5", "completed", 200, note="y" * 120)
+
+        out = self._run(isolated_task_env['env'], "--path", "3", "--full").stdout
+        assert "y" * 120 in out
+        assert "…" not in out

--- a/macf/tests/test_task_trace.py
+++ b/macf/tests/test_task_trace.py
@@ -149,3 +149,40 @@ class TestContradictoryFrames:
             _Task("200", "in_progress", [_Update(900)], parent_id="197"),
         ]
         assert contradictory_frames(tasks) == []
+
+
+class TestMoveMarkerIsAPropertyOfTheTouch:
+    """The move marker must not be recomputed from display adjacency.
+
+    It says "attention arrived here from somewhere else", which is a fact about
+    the chronological sequence. Deriving it from whichever line sits above at
+    render time makes it a statement about the layout instead — and reversing
+    the output then inverts its meaning while it goes on looking authoritative.
+    """
+
+    def test_marks_only_the_touches_that_changed_task(self):
+        tasks = [
+            _Task("1", updates=[_Update(10), _Update(20)]),
+            _Task("2", updates=[_Update(30)]),
+        ]
+        trace = visitation_trace(tasks)
+        assert [(t.task_id, t.begins_dwell) for t in trace] == [
+            ("1", True), ("1", False), ("2", True)]
+
+    def test_the_marker_survives_reversal(self):
+        """The regression this class exists for.
+
+        Rendering newest-first must not change which touches are moves.
+        """
+        tasks = [
+            _Task("1", updates=[_Update(10)]),
+            _Task("2", updates=[_Update(20)]),
+            _Task("1", updates=[_Update(30)]),
+        ]
+        forward = [(t.task_id, t.begins_dwell) for t in visitation_trace(tasks)]
+        reversed_view = list(reversed(visitation_trace(tasks)))
+        assert [(t.task_id, t.begins_dwell) for t in reversed_view] == list(reversed(forward))
+
+    def test_the_first_touch_is_always_a_move(self):
+        tasks = [_Task("1", updates=[_Update(10)])]
+        assert visitation_trace(tasks)[0].begins_dwell is True


### PR DESCRIPTION
Operator feedback on #243: the path read oldest-first, which is the wrong default for a recency question. Every other log-shaped tool puts the newest line at the top, and *"what was I in the middle of"* is exactly that question.

## Reversing it exposed a real defect

The move marker — the `→` saying attention arrived here from a different task — was computed at render time by comparing each line to the one printed above it. Reversed, it still pointed at a neighbour, but the wrong one:

```
  → #1206   16m
  → #1209   16m
```

That claims a move from 1206 to 1209. Attention had gone the other way. **The marker went on looking authoritative while asserting the opposite of what happened.**

I produced that output myself, in a throwaway script written to answer the ordering question casually — which is a reasonable illustration of how cheap this class of mistake is.

## The fix is not to recompute it in the renderer

`begins_dwell` is now computed **once, chronologically, and carried on the touch**. It is a fact about the sequence rather than about the layout, so no display order can invert it.

That is the discipline the coding standards ask for elsewhere: derive from the authority, attach to the record, don't re-derive from whatever happens to be adjacent. A renderer that recomputes a relationship from its own output is deriving from a copy.

## The rest

- **Open frames stay at the bottom.** The frames block ends in a suggested next command, and follow-on instruction belongs where the eye lands last.
- **Trimmed notes end in `…`** — a note clipped mid-sentence otherwise reads as a note that simply *ended* there, which is the reading most likely to mislead someone reconstructing what they were doing.
- **`--full`** turns trimming off.
- Adds the **cli-reference entry** the command shipped without.

## Note on one changed test

`test_path_flag_shows_the_order_attention_moved` asserted the old ordering. It is **updated rather than deleted** — it is the test that caught the change, and it now pins the current contract instead of the previous one. Flagging it explicitly so the flipped assertion isn't mistaken for a weakened one.

## Verification

21 trace tests passing, including a regression that reverses the trace and asserts the markers still describe the same transitions.

Local suite: 1533 passed, 9 failed — the same 9 unrelated pre-existing failures filed today as #241 (tmux helper strips `PATH`) and #242 (`time` contract). They reproduce on clean `main`.