### PR TITLE
Make the work stack a procedure, and name what a discontinuity is

### DIFF
--- a/framework/policies/base/context_management.md
+++ b/framework/policies/base/context_management.md
@@ -162,7 +162,7 @@ macf_tools hooks status      # Hook states with timestamps
 - Wind-down: CL20 (200k) → **CL4** (1M)
 - CCP trigger: CL5 (200k) → **CL1** (1M)
 - JOTEWR: CL2 (200k) → **CL0** (1M)
-- Use μC (Ctrl-D + `claude -c`) to extend cycles without compaction
+- Use a session resume (Ctrl-D + `claude -c`) to extend cycles without compaction
 
 **Communication Adaptation**:
 - **Normal** (<85%): Full explanations

--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -825,6 +825,8 @@ Work put down for one or more cycles loses its live working context to compactio
 2. **Prints a resume banner** — which cycle the task was last worked, how long ago, and the current cycle.
 3. **Prompts the resume ritual** — read the full history (`task get #N`), re-read every note in the update stream plus any `plan_ca_ref` it references, and **narrate your understanding of where things stand and the next step to the user before executing.**
 
+**Orient the whole stack before the single task.** A stale resume means you were away, so the frame you are resuming may not be the only one attention left open. Read the work stack first (§16.5) — it answers which frames exist and which one you actually owe a return to, a question no single task's history can answer. The per-task ritual above is step two of an orientation that begins at the stack.
+
 A same-cycle re-start of an already-active task stays a plain no-op — no banner, no ritual.
 
 **Obligation**: when the banner fires, perform the ritual. Do not resume mechanically off the compaction summary alone. The narration is the evidence you re-oriented; skipping it is the stale-resume anti-pattern.
@@ -1585,11 +1587,25 @@ A second, purely structural check needs no timestamps at all: **a completed pare
 ### 16.5 Seeing the stack
 
 ```
-macf_tools task trace            # open frames, oldest first, classified
-macf_tools task trace --path 20  # the order attention moved, most recent last
+macf_tools task trace            # the open frames, classified (§16.4)
+macf_tools task trace --path N   # the order attention moved through them
 ```
 
-Read it after any discontinuity — a recovered session, a handoff, a return from an interruption — and before declaring a branch of work finished.
+Consult `--help` for the current flags and output form; this policy governs *when* the trace must be read and *what it is for*, not how it renders.
+
+**Run it after any discontinuity, and before declaring a branch of work finished.** This is a *procedure*, not a suggestion. Reading a single task's history tells you where *one* frame stands; the trace tells you which frames are open at all and which one attention actually left — the question `task get` cannot answer.
+
+**What counts as a discontinuity is lost context, not a restarted process.** The two are routinely confused, and the confusion runs in both directions — performing a recovery ritual that is not needed, or skipping one that is:
+
+| Event | Context | Read the stack? |
+|---|---|---|
+| Compaction | destroyed | **yes** |
+| Cleared session | destroyed | **yes** |
+| Work last touched in an earlier cycle (§5.3.1) | lost while set down | **yes** |
+| Handoff — a frame opened by someone else | never held | **yes** |
+| Session resume (the process restarts, the conversation continues) | **intact** | **no** |
+
+A session resume is a rejoin, not a rebirth: the supervisor restarts the client and the conversation continues, so the working context is exactly what it was. Treating it as a recovery wastes the ritual and teaches the agent to perform orientation as ceremony rather than as the response to a real loss.
 
 ### 16.6 Why this is an obligation and not a convenience
 

--- a/framework/skills/maceff-knowledge-web-orient/SKILL.md
+++ b/framework/skills/maceff-knowledge-web-orient/SKILL.md
@@ -23,11 +23,13 @@ Orient to a task domain using the knowledge graph before diving into work.
 ```bash
 macf_tools policy navigate scholarship
 macf_tools policy navigate learnings
+macf_tools policy navigate task_management
 ```
 
 Read the sections that answer:
 - (scholarship) "How do wiki-links create concept-mediated edges and what graph tooling exists?"
 - (learnings) "What is the Mandatory Consult Step -- when must I consult the learnings index for previously-encountered problems, where does the index live, and how does the cluster taxonomy trigger it?"
+- (task_management) "What must I read to know which work frames are open and which one attention last left, and when is reading it required?"
 
 ---
 
@@ -41,6 +43,15 @@ consultation trigger's cluster taxonomy in auto-loaded memory, and where a clust
 plausibly fits, open the learnings index and scan that cluster's activation hooks
 for a problem of the same class as this one. Reading a relevant prior learning
 before you start is the point of orienting; finding none is a valid, cheap outcome.
+
+### Step 0.5: Orient the Work Stack
+
+Starting new work is one of the moments the task management policy names for
+reading the work stack. Do what that policy section prescribes: read the stack
+before opening a new frame, so a frame you left open elsewhere is resolved or
+deliberately parked rather than silently buried under this one. Domain
+orientation (below) answers *"what do I know about X?"*; the stack answers
+*"what did I leave open?"* — both precede the first edit.
 
 ### Step 1: Identify Key Concepts
 

--- a/framework/skills/maceff-restart-session/SKILL.md
+++ b/framework/skills/maceff-restart-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maceff-restart-session
-description: Trigger a μC (microcompaction) by restarting the current session via the auto-restart supervisor. Use when user requests restart, μC, or session refresh.
+description: Trigger a session resume by restarting the current session via the auto-restart supervisor. The process restarts; the conversation continues. Use when user requests a session resume, restart, session refresh, or reload of settings/permissions (also recognizes the deprecated term "μC").
 ---
 
 # Restart Session via Auto-Restart Supervisor
@@ -28,7 +28,7 @@ If no supervisor is running, inform the user:
 macf_tools auto-restart restart <PID>
 ```
 
-4. **Notify Telegram** (if channel available) that μC was triggered
+4. **Notify Telegram** (if channel available) that a session resume was triggered
 
 ## What Happens
 
@@ -36,5 +36,19 @@ macf_tools auto-restart restart <PID>
 - Countdown runs (default 5s) in the supervisor terminal
 - CC relaunches with same command + args via `claude -c`
 - SessionStart hook fires on resume
-- Cycle number does NOT increment (μC, not full compaction)
+- Cycle number does NOT increment (a session resume is not a compaction)
 - Session ID remains the same (CC resume)
+
+## What a Session Resume Is NOT
+
+A session resume is **not** a context loss. The conversation continues via
+`claude -c` — the process restarted, the context did not. This is a rejoin, not a
+rebirth.
+
+So no recovery ritual applies: do not re-read consciousness artifacts, do not
+re-orient the work stack, and do not report to the user as though returning from a
+mind-wipe. Pick up where you left off.
+
+The orientation rituals belong to the events that actually destroy context —
+compaction, a cleared session, or work resumed from an earlier cycle — not to a
+process that restarted underneath a continuous conversation.

--- a/framework/skills/maceff-sprint/SKILL.md
+++ b/framework/skills/maceff-sprint/SKILL.md
@@ -71,9 +71,11 @@ Do NOT proceed to Step 3 until the user has restarted and returned. Creating the
 ```bash
 macf_tools policy navigate autonomous_sprint
 macf_tools policy read autonomous_sprint
+macf_tools policy navigate task_management
 ```
 
 Extract requirements by answering:
+- (task_management) What must I read to know which work frames are open and which one attention last left, and when is reading it required? (Applies when the sprint's live context was actually lost — compaction, a cleared session, or scoped work last touched in an earlier cycle. A session resume does not qualify: the conversation continues, so the context is intact.)
 - What defines the scoped task set and how should it be declared?
 - How does the scope gate work at task completion?
 - What does mode-locking mean for the Markov recommender?

--- a/framework/skills/maceff-tree-awareness/SKILL.md
+++ b/framework/skills/maceff-tree-awareness/SKILL.md
@@ -68,6 +68,24 @@ tree -L 3 "${MACEFF_ROOT}/framework"
 
 **Purpose**: Policy files, subagent definitions, templates organization
 
+### 4. Work-Stack Awareness (what was I in the middle of?)
+
+The commands above restore awareness of the *repository* tree. A compaction also
+cost you the *work* stack — which frames were open, and which one attention had
+actually left. Restore that too:
+
+```bash
+macf_tools policy navigate task_management
+```
+
+Read the section that answers: **"What must I read to know which work frames are
+open and which one attention last left, and when is reading it required?"** —
+then do what it prescribes.
+
+**Purpose**: Repository-structure awareness keeps you from editing the wrong
+file; work-stack awareness keeps you from resuming the wrong task. Recovery is
+not complete until both are restored.
+
 ## After Running Commands
 
 **Report to user using this language:**

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -10405,7 +10405,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ar_list.set_defaults(func=lambda args: _cmd_ar_list(args))
 
     # auto-restart restart
-    ar_restart = ar_sub.add_parser("restart", help="trigger restart (μC) for a supervised process")
+    ar_restart = ar_sub.add_parser("restart", help="trigger a session resume (restart) for a supervised process")
     ar_restart.add_argument("pid", type=int, help="supervisor PID")
     ar_restart.set_defaults(func=lambda args: _cmd_ar_restart(args))
 

--- a/macf/src/macf/hooks/handle_session_start.py
+++ b/macf/src/macf/hooks/handle_session_start.py
@@ -193,7 +193,7 @@ def run(stdin_json: str = "", **kwargs) -> Dict[str, Any]:
             })
             # Fall through to compaction recovery (skip migration check)
         elif source == 'resume':
-            # μC (microcompaction) resume — NOT a compaction, NOT a migration.
+            # Session resume — NOT a compaction, NOT a migration.
             # Same session continues. Skip all compaction/migration detection.
             # CRITICAL: Do NOT fall through to PHASE 3 JSONL scanning, which
             # would find stale compact_boundary markers from earlier real


### PR DESCRIPTION
The work stack (`task_management` §16, added in #243) was *described* but not wired into the procedures that need it — and its §16.5 example had already gone stale: it documented the trace's sort order, which #246 then reversed.

## Stop encoding presentation in policy

Documenting a tool's output format in policy is what made that line lie. §16.5 now defers to `--help` for flags and rendering, and governs only **when** the trace must be read and **what it is for**. §5.3.1 likewise points at §16 instead of restating its vocabulary.

## Wire it into the procedures

- **§5.3.1 (stale resume)** — orient the whole stack before the single task. Reading one task's history tells you where *that* frame stands; the stack tells you which frames exist and which one you owe a return to.
- **§16.5** — states the obligation directly: read it after a discontinuity, and before declaring a branch of work finished.

## Name what a discontinuity actually is

The trigger is **lost context, not a restarted process** — a distinction that was being confused in both directions (performing a recovery ritual that isn't needed, or skipping one that is):

| Event | Context | Read the stack? |
|---|---|---|
| Compaction | destroyed | yes |
| Cleared session | destroyed | yes |
| Work last touched in an earlier cycle | lost while set down | yes |
| Handoff — a frame opened by someone else | never held | yes |
| **Session resume** (process restarts, conversation continues) | **intact** | **no** |

A session resume is a rejoin, not a rebirth. Treating it as a recovery teaches orientation as ceremony rather than as a response to real loss.

## Skills reference the policy rather than embedding it

Per `skills_writing` §2.2, the skills navigate `task_management` and ask a **timeless question** — so they adapt automatically when the procedure or the tool changes, instead of going stale the way the §16.5 example did. `tree-awareness`, `knowledge-web-orient`, and `sprint` gain the pointer; `restart-session` gains a "What a Session Resume Is NOT" section. The task-management skill needs no change — its CLI-first discovery already surfaces the command.

## Deprecate "μC" in favour of "session resume"

The auto-restart path now serves settings and permission reloads, which "microcompaction" never described. The restart skill still *recognizes* the legacy term so existing usage keeps working; nothing emits it.

## Verification

410 tests pass across the CLI, session-start, task, manifest, and policy suites. No skill hardcodes the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
