### PR TITLE
fix(tests): give the tmux sandbox a PATH, and a socket path that fits

### DIFF
--- a/macf/tests/conftest.py
+++ b/macf/tests/conftest.py
@@ -26,6 +26,8 @@ This fixture is module-local (not global) because:
 
 import json
 import os
+import subprocess
+import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -757,3 +759,69 @@ def mock_temporal_context_hook():
 def mock_minimal_timestamp_hook():
     """Return fixed minimal timestamp for high-frequency hooks."""
     return "12:45:30 AM"
+
+
+# A unix socket path is capped by `sockaddr_un.sun_path`: 104 bytes on the BSDs
+# and macOS, 108 on Linux. Nothing reports this as a length error -- the bind
+# simply fails, and tmux surfaces it as "error connecting to <path> (File name
+# too long)".
+SUN_PATH_MAX = 104 if sys.platform == "darwin" else 108
+
+
+@pytest.fixture
+def tmux_sandbox_env():
+    """An environment for driving tmux against a private, disposable server.
+
+    Three properties, all load-bearing, each one learned from a failure rather
+    than chosen up front:
+
+    - **$TMUX is stripped.** A tmux client that inherits $TMUX attaches to THAT
+      server and ignores TMUX_TMPDIR entirely. Every process inside a tmux pane
+      has $TMUX set -- which is how an agent runs this suite, and never how CI
+      runs it -- so a teardown `kill-server` reached the host's default server
+      and destroyed every session on it, including a live agent harness.
+
+    - **PATH is inherited.** An environment built from scratch carries no PATH,
+      and POSIX then falls back to a fixed `/usr/bin:/bin:/usr/sbin:/sbin`
+      (`os.confstr('CS_PATH')`). tmux is on that path under most Linux
+      packaging and is not under Homebrew, so a from-scratch env cannot find
+      the binary on macOS no matter what the developer's shell says.
+
+    - **The socket directory is short, and is deliberately not `tmp_path`.**
+      tmux appends `tmux-<uid>/default` to TMUX_TMPDIR, and macOS roots
+      `tmp_path` under `/private/var/folders/<2>/<26>/T/`, which overruns
+      SUN_PATH_MAX once pytest adds `pytest-of-<user>/pytest-<n>/<test>0/` --
+      142 bytes measured against a 104-byte cap. Linux's `/tmp/...` stays
+      under it.
+
+    The first two pull against each other, which is why both natural spellings
+    are wrong: `{**os.environ, ...}` keeps PATH but leaks $TMUX, and
+    `{"TMUX_TMPDIR": ...}` drops $TMUX but loses PATH.
+
+    Inheriting PATH also makes the `shutil.which("tmux")` skip guards on the
+    classes that use this fixture meaningful again. A guard is only worth
+    having if it queries the same thing the guarded operation will; while the
+    env was scrubbed, `which()` consulted the real PATH, found Homebrew's tmux,
+    declined to skip, and the subprocess then failed to find the same binary.
+    """
+    # macOS TMPDIR is too long to hold a socket, so ask for a short base
+    # explicitly rather than accepting the platform default.
+    base = "/tmp" if os.path.isdir("/tmp") else None
+    with tempfile.TemporaryDirectory(prefix="macf-tmux-", dir=base) as sock:
+        env = {k: v for k, v in os.environ.items() if k != "TMUX"}
+        env["TMUX_TMPDIR"] = sock
+
+        # Fail by name rather than by tmux's opaque "File name too long".
+        probe = os.path.join(sock, f"tmux-{os.getuid()}", "default")
+        assert len(probe) <= SUN_PATH_MAX, (
+            f"tmux socket path is {len(probe)} bytes, over the {SUN_PATH_MAX}-byte "
+            f"limit on this platform: {probe}"
+        )
+
+        yield env
+
+        # This teardown is the destructive one, and it is survivable only
+        # because the env above selects a private server. Target it explicitly
+        # so a future edit that reintroduces $TMUX cannot turn this line into
+        # kill-server against the host.
+        subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)

--- a/macf/tests/test_harness_render.py
+++ b/macf/tests/test_harness_render.py
@@ -322,11 +322,9 @@ class TestStartScriptBehaviour:
     """
 
     @pytest.fixture
-    def sandbox(self, tmp_path):
+    def sandbox(self, tmp_path, tmux_sandbox_env):
         reg = tmp_path / "registry"
         reg.mkdir()
-        sock = tmp_path / "tmuxdir"
-        sock.mkdir()
         p = HarnessParams(
             agent="probe", home=tmp_path,
             python=Path("/bin/sleep"), macf_tools=Path("/bin/true"),
@@ -335,32 +333,15 @@ class TestStartScriptBehaviour:
         script = tmp_path / "start"
         script.write_text(render_start(p, attach_proxy=False))
         script.chmod(0o755)
-        # TMUX MUST BE STRIPPED, not merely overridden by TMUX_TMPDIR.
-        #
-        # A tmux client that inherits $TMUX attaches to THAT server and ignores
-        # TMUX_TMPDIR entirely. Every process inside a tmux pane has $TMUX set,
-        # so `{**os.environ, "TMUX_TMPDIR": ...}` isolates only when the suite
-        # is run from OUTSIDE tmux. Run from inside one -- which is how an agent
-        # runs it, and never how CI does -- the sandbox silently operated on the
-        # host's default server, and this fixture's teardown `kill-server`
-        # destroyed every session on it.
-        #
-        # That is not hypothetical: it killed the live agent harness on this
-        # host. Measured afterwards -- with $TMUX inherited, a sandbox session
-        # appears in the DEFAULT server's list; with $TMUX removed, it appears
-        # only in the private one and the default survives the kill-server.
-        #
-        # The property that makes this dangerous is that it is invisible in the
-        # environment where tests are normally run. A green suite in CI says
-        # nothing about the blast radius in the environment that matters.
-        env = {k: v for k, v in os.environ.items() if k != "TMUX"}
-        env["TMUX_TMPDIR"] = str(sock)
-        yield script, reg, env
-        # Belt and braces: target the private socket explicitly as well, so a
-        # future edit that reintroduces $TMUX cannot turn this into kill-server
-        # on the host. This teardown is the destructive one; it should be the
-        # most defensive line in the file.
-        subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
+        # The env, its private socket directory, and the destructive
+        # `kill-server` teardown all belong to the `tmux_sandbox_env` fixture in
+        # conftest. Read its docstring before changing anything about how tmux
+        # is reached from here: it carries the reasons for two non-obvious
+        # choices that were each paid for once -- $TMUX stripped (an inherited
+        # one made this fixture's teardown destroy the live agent harness on
+        # this host) and PATH inherited (a from-scratch env cannot find tmux
+        # under Homebrew, so the whole class crashed on macOS).
+        yield script, reg, tmux_sandbox_env
 
     def _run(self, script, env):
         return subprocess.run([str(script)], env=env, capture_output=True, text=True)
@@ -375,7 +356,7 @@ class TestStartScriptBehaviour:
             f'{{"supervisor_pid": {proc.pid}, "name": "{name}", "status": "running"}}')
         return proc
 
-    def test_the_sandbox_env_carries_no_TMUX(self, sandbox):
+    def test_the_sandbox_env_is_private_and_can_still_find_tmux(self, sandbox):
         """Blast-radius guard, and the most important test in this class.
 
         This fixture tears down with `tmux kill-server`. That is only survivable
@@ -384,6 +365,12 @@ class TestStartScriptBehaviour:
         points every client at the host's server. Restoring the natural
         `{**os.environ, ...}` spelling would make this class destroy the live
         agent harness again, with a green suite in CI to say it was fine.
+
+        The PATH half is the opposite mistake and was made next: an env built
+        from scratch is private but cannot find the tmux binary anywhere off the
+        POSIX fallback path, so the whole class crashed on macOS while CI stayed
+        green. Both halves are asserted here because a fix for either one alone
+        reintroduces the other.
 
         Asserted on the env rather than by running the destructive path, so the
         guard costs nothing and cannot itself be the thing that goes wrong.
@@ -395,6 +382,13 @@ class TestStartScriptBehaviour:
             "on it -- including a live agent harness -- will be destroyed"
         )
         assert env.get("TMUX_TMPDIR"), "the private socket dir must still be set"
+        assert env.get("PATH"), (
+            "the sandbox env carries no PATH; the subprocess will fall back to "
+            f"{os.confstr('CS_PATH')!r} and will not find tmux anywhere else -- "
+            "which is every Homebrew install"
+        )
+        # The socket-path length invariant is asserted in the fixture itself,
+        # where it covers every consumer rather than only this class.
 
     def test_creates_a_session_when_nothing_holds_the_name(self, sandbox):
         script, _reg, env = sandbox

--- a/macf/tests/test_session_identifier.py
+++ b/macf/tests/test_session_identifier.py
@@ -68,9 +68,15 @@ class TestTheSubstitutionIsActuallyNecessary:
     and the originating issue shows how easily an unmeasured assertion about
     these tools turns out to be wrong."""
 
-    def _roundtrip(self, name, tmp_path):
-        """Create a session under `name`; report the name tmux actually stored."""
-        env = {"TMUX_TMPDIR": str(tmp_path)}
+    def _roundtrip(self, name, env):
+        """Create a session under `name`; report the name tmux actually stored.
+
+        `env` comes from the `tmux_sandbox_env` fixture, which selects a private
+        server without scrubbing PATH. Building it here as
+        `{"TMUX_TMPDIR": ...}` was the earlier spelling and left the subprocess
+        with no PATH at all, so tmux was unreachable wherever it lives outside
+        the POSIX fallback -- every Homebrew install, i.e. every macOS.
+        """
         subprocess.run(["tmux", "kill-server"], env=env, capture_output=True)
         subprocess.run(["tmux", "new-session", "-d", "-s", name, "sleep 5"],
                        env=env, capture_output=True)
@@ -82,22 +88,22 @@ class TestTheSubstitutionIsActuallyNecessary:
         return stored, addressable
 
     @pytest.mark.parametrize("bad", ["Name.suffix", "Name:suffix"])
-    def test_tmux_silently_rewrites_these_and_the_name_stops_addressing(self, bad, tmp_path):
+    def test_tmux_silently_rewrites_these_and_the_name_stops_addressing(self, bad, tmux_sandbox_env):
         """The failure mode that motivates substituting at all: new-session
         SUCCEEDS, and the name you asked for addresses nothing afterwards."""
-        stored, addressable = self._roundtrip(bad, tmp_path)
+        stored, addressable = self._roundtrip(bad, tmux_sandbox_env)
         assert stored != bad, "tmux accepted this verbatim — the rule may be stale"
         assert not addressable
 
-    def test_the_substituted_form_survives_and_addresses(self, tmp_path):
-        stored, addressable = self._roundtrip(IDENT, tmp_path)
+    def test_the_substituted_form_survives_and_addresses(self, tmux_sandbox_env):
+        stored, addressable = self._roundtrip(IDENT, tmux_sandbox_env)
         assert stored == IDENT
         assert addressable
 
-    def test_at_sign_is_a_convention_choice_not_a_tmux_constraint(self, tmp_path):
+    def test_at_sign_is_a_convention_choice_not_a_tmux_constraint(self, tmux_sandbox_env):
         """Recorded so the choice stays revisable: tmux keeps '@' verbatim, so
         substituting it is ours to reconsider, not a limit we ran into."""
-        stored, addressable = self._roundtrip(CARD, tmp_path)
+        stored, addressable = self._roundtrip(CARD, tmux_sandbox_env)
         assert stored == CARD
         assert addressable
 


### PR DESCRIPTION
Closes #241 — with a correction to it.

## The issue was right about four of the seven failures, and wrong about three

I filed #241 after diagnosing one symptom and generalising it to the other, because both presented as "tmux fails on macOS". Running them rather than re-reading the report shows two independent causes.

### Four in `test_session_identifier.py` — the reported cause

`env = {"TMUX_TMPDIR": str(tmp_path)}` builds the subprocess environment from scratch. A dict with no `PATH` does not mean "inherit PATH"; POSIX falls back to a fixed `/usr/bin:/bin:/usr/sbin:/sbin`. tmux is on that under most Linux packaging and is not under Homebrew, so the binary is unreachable on macOS regardless of the developer's shell. `FileNotFoundError: 'tmux'`, as reported.

The `shutil.which("tmux")` guard made this worse. It consults the **real** PATH, finds Homebrew's tmux, and declines to skip; the subprocess then consults the **scrubbed** env and cannot find the same binary. The guard and the operation disagreed about which PATH was in play, so the guard turned a clean skip into a crash on exactly the machines it was written to protect.

### Three in `test_harness_render.py` — a different bug in the same clothes

That fixture already inherited the environment, deliberately and with a long comment saying why, so `PATH` was never missing there. The actual error:

```
error connecting to …/pytest-of-cversek/pytest-156/test_is_a_no_op_when_this_harn0/tmuxdir/tmux-501/default (File name too long)
```

`sockaddr_un.sun_path` caps a unix socket path at **104 bytes** on macOS, 108 on Linux. macOS roots `tmp_path` under `/private/var/folders/<2>/<26>/T/`; once pytest adds `pytest-of-<user>/pytest-<n>/<test>0/tmuxdir/` and tmux appends `tmux-<uid>/default`, the path measures **142 bytes**. Linux builds the same path under `/tmp/` and stays inside the limit.

Nothing reports this as a length problem — the bind just fails and tmux surfaces it as "File name too long", which reads like a filename complaint rather than a socket-path limit.

## The fix

One `tmux_sandbox_env` fixture in `conftest.py`, because the two properties pull against each other and both natural spellings get one of them wrong:

| spelling | private server | can find tmux |
|---|---|---|
| `{**os.environ, "TMUX_TMPDIR": …}` | ❌ leaks `$TMUX` | ✅ |
| `{"TMUX_TMPDIR": …}` | ✅ | ❌ no PATH |
| the fixture | ✅ strips only `$TMUX` | ✅ inherits the rest |

The `$TMUX` half is not theoretical: a client that inherits `$TMUX` attaches to *that* server and ignores `TMUX_TMPDIR`, so this fixture's teardown `kill-server` reaches the host's default server. It destroyed a live agent harness on this host once. Every process inside a tmux pane has `$TMUX` set — which is how an agent runs the suite, and never how CI runs it.

The fixture also allocates its socket directory under a short base instead of accepting the platform temp default, and asserts the resulting path fits, so a future regression fails by name rather than as tmux's opaque message.

The existing blast-radius guard now asserts the PATH half alongside the `$TMUX` half, since fixing either one alone reintroduces the other.

## Verification

Red before green, both directions:

- **Before**: full suite `7 failed, 1535 passed, 5 skipped, 9 xfailed` (291s)
- **Deliberately re-scrubbed**: 5 failures — the four session tests *and the new guard*, which is how I know the guard's assertion fires rather than only its teardown erroring
- **After**: `83 passed, 5 skipped` across both modules; full suite re-run below

## Left open

There is no macOS runner. `runs-on: ubuntu-latest`, matrixed over Python versions only, against a stated Mac-and-Linux minimum. Both bugs here were green in CI by construction, and the next one will be too. Whether to add a matrix entry is a cost question and is not decided here.
