### PR TITLE
fix(cli): keep `time` stdout to one timestamp; annotate on stderr

### DIFF
--- a/macf/docs/user/cli-reference.md
+++ b/macf/docs/user/cli-reference.md
@@ -114,9 +114,27 @@ Display current local time in ISO format.
 macf_tools time
 ```
 
-**Output:**
+**Output (stdout):**
 ```
 2025-11-27T21:17:57-05:00
+```
+
+**stdout carries exactly one ISO-8601 timestamp and nothing else.** It is a
+parsing contract, not merely a formatting habit — this is the kind of command
+other code reads.
+
+When the resolved agent root holds checkpoints, the gap since the most recent
+one is annotated **on stderr**:
+
+```
+Last CCP: 2025-11-27_143000_Phase_Complete_CCP.md (6h 12m ago)
+```
+
+An interactive caller sees both streams; a parser reading stdout sees only the
+timestamp. Redirect stderr to drop the annotation:
+
+```bash
+macf_tools time 2>/dev/null
 ```
 
 **Related:** `env`

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -514,7 +514,14 @@ def cmd_time(_: argparse.Namespace) -> int:
     current_time = _now_iso()
     print(current_time)
 
-    # Show gap since most recent CCP
+    # Show gap since most recent CCP.
+    #
+    # This goes to stderr, not stdout. `time` is documented as emitting a single
+    # ISO-8601 timestamp, which makes it the kind of command other code parses;
+    # a second line on stdout breaks every such consumer, and breaks them
+    # quietly, because the first line still parses for anything reading only one.
+    # Human-facing annotation belongs on stderr whenever stdout has a machine
+    # consumer, and an interactive caller still sees both streams.
     try:
         config = ConsciousnessConfig()
         checkpoints_path = config.get_checkpoints_path()
@@ -532,7 +539,8 @@ def cmd_time(_: argparse.Namespace) -> int:
                 delta = now - ccp_mtime
                 hours = int(delta.total_seconds() // 3600)
                 minutes = int((delta.total_seconds() % 3600) // 60)
-                print(f"Last CCP: {latest_ccp.name} ({hours}h {minutes}m ago)")
+                print(f"Last CCP: {latest_ccp.name} ({hours}h {minutes}m ago)",
+                      file=sys.stderr)
     except OSError as e:
         print(f"⚠️ MACF: CCP lookup failed: {e}", file=sys.stderr)
 

--- a/macf/tests/test_time_cli.py
+++ b/macf/tests/test_time_cli.py
@@ -90,7 +90,9 @@ class TestTimeCommand:
 
         Note: MACF fallback warnings to stderr are expected when running
         in test environment without session events - these are informational,
-        not errors.
+        not errors. The checkpoint annotation is also expected there: stdout
+        carries a machine-readable timestamp, so human-facing annotation goes
+        to stderr by design rather than as a warning.
         """
         result = subprocess.run(
             ['macf_tools', 'time'],
@@ -98,9 +100,55 @@ class TestTimeCommand:
         )
 
         assert result.returncode == 0
-        # Allow MACF informational warnings (fallback notices)
-        # but fail on actual Python errors/tracebacks
+        # Allow MACF informational warnings (fallback notices) and the
+        # checkpoint annotation, but fail on actual Python errors/tracebacks
         if result.stderr:
             for line in result.stderr.strip().split('\n'):
-                assert line.startswith('⚠️ MACF:') or not line, \
+                assert line.startswith(('⚠️ MACF:', 'Last CCP:')) or not line, \
                     f"Unexpected stderr: {line}"
+
+
+class TestTimeKeepsStdoutMachineReadable:
+    """The checkpoint annotation must not reach stdout.
+
+    This class exists because the tests above could not reliably see the
+    regression they were written to catch. `time` emits the annotation only when
+    it resolves an agent root that actually holds checkpoints, and the resolver
+    walks up from the CWD -- so whether the suite caught a broken contract was
+    decided by which directory pytest happened to be started in. Run from the
+    package: green. Run from a populated agent home: red, on the same commit.
+
+    A test whose outcome depends on the caller's working directory is not
+    pinning anything. Here the agent root is supplied explicitly and populated,
+    so the annotation is guaranteed to be produced and the only open question is
+    which stream it lands on.
+    """
+
+    @pytest.fixture
+    def populated_agent_root(self, tmp_path, monkeypatch):
+        """An agent root holding one checkpoint, selected explicitly."""
+        checkpoints = tmp_path / "agent" / "private" / "checkpoints"
+        checkpoints.mkdir(parents=True)
+        (checkpoints / "2026-01-01_000000_Probe_ccp.md").write_text("# probe\n")
+        monkeypatch.setenv("MACF_AGENT_ROOT", str(tmp_path / "agent"))
+        return checkpoints
+
+    def _run(self):
+        return subprocess.run(['macf_tools', 'time'], capture_output=True, text=True)
+
+    def test_the_annotation_is_actually_emitted(self, populated_agent_root):
+        """Guards the guard: without this, the purity test below would pass
+        vacuously on any commit where the annotation simply failed to resolve."""
+        result = self._run()
+        assert result.returncode == 0
+        assert 'Last CCP:' in result.stderr, (
+            "the checkpoint annotation was not produced at all, so the "
+            "stdout-purity assertion below proves nothing"
+        )
+
+    def test_stdout_carries_only_the_timestamp(self, populated_agent_root):
+        """The documented contract: one ISO-8601 timestamp, parseable whole."""
+        result = self._run()
+        assert result.returncode == 0
+        assert 'Last CCP:' not in result.stdout
+        datetime.fromisoformat(result.stdout.strip())


### PR DESCRIPTION
Closes #242.

## The fix

`macf_tools time` is documented as emitting a single ISO-8601 timestamp, which makes it the kind of command other code parses. It had begun printing a second line to **stdout**:

```
2026-08-10T13:17:57-04:00
Last CCP: 2026-07-31_..._CCP.md (242h 50m ago)
```

The annotation is worth having. stdout is the wrong stream for it — a second line breaks every parsing consumer, and breaks them *quietly*, because anything reading only the first line keeps working. The line moves to stderr. Interactive callers see both streams exactly as before; `2>/dev/null` gives a parser the bare timestamp.

Option 1 from the issue, for the reason the issue gave.

## The more interesting half: the tests could not be trusted to catch it again

`cmd_time` asks `ConsciousnessConfig().get_checkpoints_path()`, and `_find_agent_root()` resolves in this order:

1. `MACF_AGENT_ROOT`
2. container (`/.dockerenv`)
3. **walk up from `Path.cwd()` looking for `.claude`**
4. `$HOME`

It never consults `MACEFF_AGENT_HOME_DIR` — which `utils/paths.py:189` documents as *the* explicit configuration for the agent home. So the annotation appears or vanishes according to the directory the process was launched from, with the declared home set and ignored. Measured, same environment, same second:

```
$ (cd .../MacEff/macf   && macf_tools time)     # → timestamp only
$ (cd .../ClaudeTheBuilder && macf_tools time)  # → timestamp + Last CCP
```

So the existing assertions passed or failed on **where pytest was started**, not on whether the contract held. Same commit, two answers. That also resolves a small mystery: this was recorded as two failures on one occasion and zero on another, and neither observation was wrong.

`TestTimeKeepsStdoutMachineReadable` supplies the agent root explicitly and populates it, so the annotation is guaranteed to be produced and the only open question is which stream carries it. Two assertions rather than one, deliberately:

- `test_the_annotation_is_actually_emitted` — without it, the purity check below passes vacuously on any commit where the lookup silently resolves nothing
- `test_stdout_carries_only_the_timestamp` — the documented contract, parsed whole

`test_time_no_error_output` asserted every stderr line was a `⚠️ MACF:` warning. It now admits the annotation **by name**, rather than the annotation being dressed as a warning to satisfy it. It isn't a warning, and disguising it would make the stream less honest to pass a test.

## Verification

| | from the package | from an agent home |
|---|---|---|
| before | 5 passed | **2 failed**, 3 passed |
| after | 7 passed | 7 passed |

Red-proofed by stashing only the source change: all four relevant tests fail against the pre-fix implementation, including both new ones.

No programmatic consumer of `time` stdout exists in the tree — the remaining references are docs and policies describing interactive use, which are unaffected.

## Left for a separate issue

The resolver disagreement is a wider defect than this command and is not fixed here. Notably the suite's autouse `isolated_agent_home` fixture sets `MACEFF_AGENT_HOME_DIR` — so it does not isolate anything resolved through `ConsciousnessConfig`. Filing separately.
