### PR TITLE
test(isolation): isolate the task store at the boundary, and notice a leak

### DIFF
--- a/macf/tests/conftest.py
+++ b/macf/tests/conftest.py
@@ -29,6 +29,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import warnings
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
@@ -151,6 +152,161 @@ def isolated_agent_home(tmp_path, monkeypatch):
     yield test_home
 
     find_agent_home.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def isolated_task_store(tmp_path, monkeypatch):
+    """Point the task store at a per-test directory, at the boundary.
+
+    The agent home fixture above already isolates the store *indirectly*: the
+    home store resolves through `find_agent_home()`, so isolating the home
+    isolates the store as a side effect. That is true today and it is not
+    something to rely on. It holds only while the store keeps resolving through
+    that one function, it depends on an lru_cache being cleared, and if it ever
+    stops holding, the failure mode is a silent write into the durable record of
+    what an agent was doing -- discovered, if at all, by noticing a wrong status
+    months later. That is exactly how it was discovered the first time.
+
+    So the store is isolated here directly and for its own sake.
+    `MACF_TASKS_DIR` also forces `TaskReader._resolve_home_store()` to return
+    None, so neither backend can address anything outside `tmp_path`.
+
+    Boundary isolation rather than patched write paths, deliberately. Patching
+    named symbols covers the writes you predicted; a path you did not predict
+    goes to the real store while the test passes. A test module that isolated by
+    patching `_create_task_file`, `update_task_file` and `TaskReader` still
+    re-opened a completed task in a live store, because the auto-start chain
+    reached a write that was not in that set. An environment variable has no
+    escape path. This is the same reasoning that removed the `testing`
+    parameter: code-level isolation creates two universes and the tests then
+    verify the wrong one.
+
+    Tests needing a specific backend override this — `MACF_TASK_STORE_DIR` takes
+    precedence, and `delenv` restores default resolution.
+
+    Yields:
+        Path to the isolated task directory
+    """
+    test_tasks = tmp_path / "_macf_isolated_tasks"
+    test_tasks.mkdir(parents=True, exist_ok=True)
+    # Both, and in this order. MACF_TASK_STORE_DIR outranks MACF_TASKS_DIR in
+    # `_resolve_home_store`, so setting only the latter would leave the store
+    # pointing at whatever a developer happens to export in their own shell --
+    # isolation that works on the machine that does not need it and fails on the
+    # one that does.
+    monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
+    monkeypatch.setenv("MACF_TASKS_DIR", str(test_tasks))
+
+    yield test_tasks
+
+
+class LiveStoreTouched(UserWarning):
+    """The real task store changed while the suite ran.
+
+    Its own category so it can be filtered to an error (`-W error::...`) by
+    anyone who wants the CI behaviour locally.
+    """
+
+
+def _fingerprint(dirs):
+    """Map every task file under `dirs` to (size, mtime_ns).
+
+    Cheap enough to run twice per session over a few thousand files, and it
+    catches modification of an existing file — which a count or a directory
+    mtime does not. A completed task being flipped back to in-progress changes
+    no filename and no file count.
+    """
+    seen = {}
+    for d in dirs:
+        for p in d.rglob("*.json"):
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            seen[str(p)] = (st.st_size, st.st_mtime_ns)
+    return seen
+
+
+@pytest.fixture(scope="session", autouse=True)
+def live_task_store_is_left_alone():
+    """Fail the run if it wrote into the developer's real task store.
+
+    The isolation above should make this impossible. The guard exists because
+    the previous isolation was also believed to make it impossible, and the leak
+    it missed was found months afterwards by noticing that a task which had
+    completed cleanly was somehow in progress again — with a test fixture's
+    breadcrumb in its update history.
+
+    A leak that announces itself is worth more than one that has to be inferred
+    from a wrong status later, so this reports at the end of the run rather than
+    leaving the evidence to be stumbled on.
+
+    Resolution happens at session start, before any per-test isolation applies,
+    so the paths are the real ones. Where there is no live store — CI, a fresh
+    checkout — there is nothing to fingerprint and the guard is inert.
+    """
+    from macf.task.reader import TaskReader
+
+    targets = []
+    try:
+        home = TaskReader._resolve_home_store()
+        if home and home.exists():
+            targets.append(home)
+        legacy = TaskReader._get_tasks_dir()
+        if legacy.exists():
+            targets.append(legacy)
+    except (OSError, ValueError, ImportError) as e:
+        print(f"⚠️ MACF: live task store guard could not resolve a store: {e}",
+              file=sys.stderr)
+
+    before = _fingerprint(targets)
+
+    yield
+
+    after = _fingerprint(targets)
+    if before == after:
+        return
+
+    added = sorted(set(after) - set(before))
+    removed = sorted(set(before) - set(after))
+    changed = sorted(p for p in set(before) & set(after) if before[p] != after[p])
+    detail = (
+        "the LIVE task store changed during this run — task files are the "
+        "durable record of what an agent was doing, and a test that can write "
+        "there can make finished work look unfinished.\n"
+        f"  added:   {added}\n"
+        f"  changed: {changed}\n"
+        f"  removed: {removed}"
+    )
+
+    # Strict only where a concurrent writer is impossible.
+    #
+    # This guard cannot see WHICH process wrote; it sees only that the store
+    # differs. On a workstation the agent that owns the store is often working
+    # in it while the suite runs, and those edits land inside the same window --
+    # measured, on the run that prompted this branch, where the three files it
+    # flagged were the author's own task notes. Failing on that would train
+    # everyone to ignore the one message that matters, and a detector that
+    # cries wolf gets muted, which is worse than not having one.
+    #
+    # In CI there is no other writer, so a difference means a test wrote it, and
+    # there the run fails. Elsewhere it reports and lets a human judge, because
+    # "these are my own edits" is a judgement only the human can make.
+    if os.environ.get("CI"):
+        pytest.fail(detail, pytrace=False)
+
+    # `warnings.warn`, not a print. pytest captures fixture stdout/stderr, so a
+    # printed notice is swallowed on a passing run — visible only when something
+    # else already failed, which is precisely when it is not needed. Warnings go
+    # to the end-of-run summary whether the run passed or not.
+    warnings.warn(
+        f"{detail}\n"
+        "  (not failing outside CI: a concurrent writer on this machine is the "
+        "benign explanation, and these are often the author's own edits. In CI "
+        "there is no other writer and this is an error.)",
+        LiveStoreTouched,
+        stacklevel=1,
+    )
 
 
 @pytest.fixture

--- a/macf/tests/test_papercuts.py
+++ b/macf/tests/test_papercuts.py
@@ -62,11 +62,20 @@ class TestHomeStoreIsGitignored:
         return home
 
     def _create_task(self, home, title, log):
+        # The backend under test is selected by the config.json written above,
+        # so the subprocess must not inherit a variable that selects a different
+        # one. `MACF_TASKS_DIR` is set for every test by conftest's
+        # `isolated_task_store`, and it forces the legacy per-session store --
+        # which would leave this class asserting about a home store that was
+        # never used. The isolation those variables provide is not needed here:
+        # `home` is already a tmp_path.
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("MACF_TASKS_DIR", "MACF_TASK_STORE_DIR")}
+        env["MACEFF_AGENT_HOME_DIR"] = str(home)
+        env["MACF_EVENTS_LOG_PATH"] = str(log)
         return subprocess.run(
             ["macf_tools", "task", "create", "task", title, "--plan", "smoke"],
-            capture_output=True, text=True,
-            env={**os.environ, "MACEFF_AGENT_HOME_DIR": str(home),
-                 "MACF_EVENTS_LOG_PATH": str(log)},
+            capture_output=True, text=True, env=env,
         )
 
     def test_store_is_ignored_after_first_task(self, tmp_path):

--- a/macf/tests/test_task_create_sprint_play_time.py
+++ b/macf/tests/test_task_create_sprint_play_time.py
@@ -61,6 +61,20 @@ def mock_task_infra(tmp_path, monkeypatch):
     Patch the file-system and event-log side effects so tests run without a
     real CC task store, breadcrumb, or TM daemon.
 
+    These fakes give determinism -- fixed ids, a fixed breadcrumb, assertable
+    call records. They are NOT the isolation, and were mistaken for it once.
+
+    Patching named symbols covers the write paths you predicted. This set did
+    not cover the one the auto-start chain reaches, so it wrote to the real
+    store while every test passed, and a completed task in a live agent store
+    came back as in_progress with `s_test/c_1/g_abc/p_def/t_1000` in its update
+    history. Nobody noticed for months.
+
+    Isolation is at the boundary now, in conftest's autouse `isolated_task_store`
+    (plus a session guard that fails the run if the live store changes). An
+    environment variable has no escape path; a list of patched names has one for
+    every path not on the list.
+
     Returns a dict of mock handles for assertion.
     """
     # Task ID counter (start at 200 to avoid collisions with stub task IDs)


### PR DESCRIPTION
Closes #247 — with one correction and one addition.

## The correction: it does not reproduce

The issue describes a live leak. It is not live any more, and I checked rather than assuming either way.

All **1,198** task files in a live store fingerprinted by content → ran `test_task_create_sprint_play_time.py` (20 passed) → re-fingerprinted. Nothing added, changed, or removed.

The reason is incidental. The home store resolves through `find_agent_home()`, and conftest's autouse `isolated_agent_home` fixture — added later, for an unrelated leak into the ideas bank — isolates `find_agent_home()`. It closed this one without anyone intending it to.

Worth stating plainly, because it changes what the fix is for: **the store is currently isolated by accident.** That holds only while it keeps resolving through that one function, it depends on an `lru_cache` being cleared, and if it lapses the failure mode is a silent write into the durable record of what an agent was doing.

While investigating I also ran a check that counted `*.json` in the store and reported it unchanged. Completed tasks are **dot-prefixed**, so that glob had been comparing 73 of 1,198 files. It could not have detected the leak it was ruling out, and I read it as reassurance for several minutes.

## The fix: isolation on purpose

`isolated_task_store` (autouse) sets `MACF_TASKS_DIR` to a per-test directory — which also forces `_resolve_home_store()` to return `None`, so neither backend can address anything outside `tmp_path` — and clears `MACF_TASK_STORE_DIR`.

That second half is not decoration. `MACF_TASK_STORE_DIR` **outranks** `MACF_TASKS_DIR` in the resolver, so setting only the latter would leave the store pointing at whatever a developer exports in their own shell: isolation that works on the machine that doesn't need it and fails on the one that does. I nearly shipped that, and caught it by reading the precedence order rather than by any test failing.

This is issue suggestion 1, applied globally rather than to one module — boundary isolation has no escape path, whereas a list of patched symbols has one for every path not on the list.

## The addition: a leak that announces itself

Issue suggestion 2. `live_task_store_is_left_alone` resolves the real store at session start — before any per-test isolation applies, so the paths are the real ones — fingerprints it as `path → (size, mtime_ns)`, and fails the run at the end naming what changed:

```
the test run wrote into the LIVE task store — task files are the durable record
of what an agent was doing, and a test that can write there can make finished
work look unfinished.
  added:   []
  changed: ['.../1.json']
  removed: []
```

Where there is no live store (CI, a fresh checkout) there is nothing to fingerprint and the guard is inert.

It records **size and mtime**, not a file count, because the original incident changed no filename and no file count — it flipped a status inside an existing file. That is precisely what my own `*.json` count missed.

### Both failure modes red-proofed

Against a temporary store, so no real data was involved:

| simulated leak | guard result |
|---|---|
| new file written into the store | ✅ caught, reported under `added` |
| `completed` → `in_progress` in an existing file | ✅ caught, reported under `changed` |

The second is the one that matters — it is the #200 failure mode, and invisible to any count- or listing-based check.

## Why the guard is strict only in CI

Not timidity. It cannot see *which* process wrote — only that the store differs. On a workstation the agent that owns the store is often working in it while the suite runs, and those edits land inside the same window.

That is not hypothetical: **the first run of this guard flagged three files, and all three were my own task notes**, written from another process while the suite ran. The store was intact; the guard was wrong.

A detector that cries wolf gets muted, which is worse than not having one. So:

- **In CI** there is no other writer. A difference means a test wrote it → the run fails.
- **Elsewhere** it warns with identical detail and lets a human judge, because "those are my own edits" is a judgement only a human can make.

It warns via `warnings.warn`, not `print` — pytest captures fixture output, so a printed notice is swallowed on a passing run and appears only when something else already failed, which is exactly when it isn't needed. Its own `LiveStoreTouched` category, so `-W error::LiveStoreTouched` gives CI behaviour locally.

**Stated plainly so the coverage isn't overread:** where the guard is strict (CI) there is no live store to protect, and where there is a live store to protect (a workstation) it warns rather than fails. So as shipped it will not fail any run today. Its value is the visible warning in the only environment where the leak can actually occur, plus a tripwire if CI ever runs against a populated home. Calling that "the leak now fails the build" would be overclaiming.

## One real break, fixed rather than adjusted

Three tests in `test_papercuts.py::TestHomeStoreIsGitignored` failed against the new isolation. They select the home-store backend through a `config.json` they write, then build their subprocess env as `{**os.environ, ...}` — which inherits `MACF_TASKS_DIR` and forces the *legacy* backend, leaving the class asserting about a store that was never used.

They now exclude both store variables explicitly. The isolation isn't needed there — their home is already a `tmp_path` — and the variable contradicts the thing under test.

Worth noting the shape: an environment merged from `os.environ` silently inheriting something that changes behaviour is the same bug as #241, two hours apart, in a different subsystem.

## Left in place

The fakes in `test_task_create_sprint_play_time.py` stay. They give determinism — fixed ids, a fixed breadcrumb, assertable call records — which is a real need. Their docstring now records that they are *not* the isolation and were taken for it once.
