### PR TITLE
fix(task): a parent whose phase is running is not a dropped frame

### DIFF
--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -4,7 +4,7 @@
 **Type**: Development Infrastructure
 **Scope**: All agents (PA and SA)
 **Status**: ACTIVE (successor to todo_hygiene.md)
-**Version**: 1.2
+**Version**: 1.3
 
 ---
 
@@ -159,7 +159,8 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 - Why is a tree of open tasks not yet a stack?
 - What are push, pop, and pop-reconciled in this system?
 - Why must a frame be durable before it is interrupted?
-- What distinguishes a parked frame from an abandoned one?
+- Which open frames are debts and which are not?
+- Why is a parent whose phase is running not a dropped frame?
 - How do I see what I was in the middle of?
 
 === CEP_NAV_BOUNDARY ===
@@ -1572,15 +1573,24 @@ An interruption may end a turn without giving the agent an opportunity to write 
 
 **Therefore the push must have already happened.** This is the load-bearing reason for the note-as-you-go discipline in §5: a note written while the work is fresh is a frame that survives; a note deferred until the work is finished is a frame that never existed if the work is interrupted first. The agent that writes only at completion has a stack that is empty precisely when it is needed.
 
-### 16.4 Parked is not abandoned
+### 16.4 Not every open frame is a debt
 
 An in-progress task that attention has left is not automatically a dropped frame. A task waiting on an incomplete blocker was set down for a reason and is **parked** — surfacing it as a problem is a false alarm, and a detector that raises false alarms is muted within a week.
 
 The distinction:
 
 - **active** — where attention is now. Not a debt.
+- **enclosing** — attention is *inside* this frame, in a descendant of it. Not a debt: the work is proceeding one level down.
 - **parked** — waiting on an unresolved blocker. Legitimately set down.
 - **abandoned** — unblocked, and attention went elsewhere without completing it. This is the dropped frame.
+
+These four are **exhaustive**: attention is here, or below here, or the frame is waiting on something, or it was dropped. That matters more than it sounds. A classifier that decides the first three and lets everything else fall through to `abandoned` has made the most alarming label its *residual* — the bucket that silently absorbs every case its author did not enumerate. `enclosing` exists because hierarchy was exactly such a case, and it was absorbed for as long as the taxonomy had three states.
+
+**Why the fourth state is load-bearing, and not bookkeeping.** A MISSION with a running phase is the ordinary shape of decomposed work. Classified as a dropped frame, it makes the false-alarm rate scale with *how faithfully work is decomposed* — so following §2.5 degrades the very detector this section exists to keep usable. A policy that punishes compliance with another policy is a defect in the pair, not a rough edge in one of them.
+
+**Enclosure is about where attention *is*, not about what is open underneath.** The tempting shortcut — treat any frame with an in-progress descendant as enclosing — absolves a parent that was dropped *together with* its child. If attention is on an unrelated frame, an ancestor and its descendant are both dropped, and both should say so. The correct test walks up from the active frame.
+
+**Whatever is recommended for resumption must be a frame that was actually dropped.** The classification is read; the recommendation is *acted on*. Pointing an agent at a parked frame sends it at something legitimately waiting on a blocker, and pointing it at an enclosing frame sends it at an ancestor of where it already is — both at the moment of a discontinuity, when the agent has least context with which to notice the advice is wrong.
 
 A second, purely structural check needs no timestamps at all: **a completed parent with an in-progress descendant is a contradiction.** A mission cannot honestly be complete while a phase inside it is still running. This catches the case where a whole branch was declared finished with one frame still open, and it is cheaper and more certain than any staleness heuristic.
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -5505,13 +5505,15 @@ def cmd_task_trace(args: argparse.Namespace) -> int:
             print(f"  {moved} #{touch.task_id:<6} {when:>8}  {note}")
         print()
 
-    owed = [f for f in frames if f.state != "active"]
+    # An enclosing frame owes nothing — the work is running inside it. Counting
+    # it as a debt would make the tally grow with every level of decomposition.
+    owed = [f for f in frames if f.state not in ("active", "enclosing")]
     print(f"🧵 Open frames: {len(frames)} ({len(owed)} awaiting a return)")
     if not frames:
         print("   ✅ nothing in progress")
         return 0
 
-    icon = {"active": "▶️ ", "parked": "⏸️ ", "abandoned": "⚠️ "}
+    icon = {"active": "▶️ ", "enclosing": "📂", "parked": "⏸️ ", "abandoned": "⚠️ "}
     for f in frames:
         when = _rel_age_short(f.last_touch) if f.last_touch else "never"
         print(f"   {icon.get(f.state, '  ')} #{f.task_id:<6} {f.state:<10} last touched {when}")
@@ -5521,8 +5523,13 @@ def cmd_task_trace(args: argparse.Namespace) -> int:
         if f.parent_completed and f.state != "active":
             print(f"        ⚠️  its parent is marked COMPLETE while this is still running")
 
-    if owed:
-        print(f"\n   Resume with:  macf_tools task start {owed[0].task_id}")
+    # Recommend a frame that was actually dropped. Pointing at a parked frame
+    # sends the agent at something legitimately waiting on a blocker, and this
+    # line is the one an agent *acts* on — during recovery, when it has least
+    # context with which to notice the advice is wrong.
+    dropped = [f for f in owed if f.state == "abandoned"]
+    if dropped:
+        print(f"\n   Resume with:  macf_tools task start {dropped[0].task_id}")
     return 0
 
 

--- a/macf/src/macf/task/trace.py
+++ b/macf/src/macf/task/trace.py
@@ -56,9 +56,21 @@ class Frame:
     ``parked``
         Waiting on an incomplete blocker. Legitimately set down, and flagging
         it would be crying wolf — the distinction that keeps this useful.
+    ``enclosing``
+        Attention is *inside* this frame, in a descendant of it. Not a debt:
+        the work is proceeding one level down. A MISSION with a running phase
+        is the ordinary case, and calling it a dropped frame would make the
+        false-alarm rate scale with *good* decomposition discipline.
     ``abandoned``
         Unblocked, and attention went elsewhere without completing it. This is
         the dropped frame.
+
+    The four states partition the open frames exhaustively: attention is here,
+    or below here, or the frame is waiting on something, or it was dropped.
+    That is why ``abandoned`` can be decided last without being a *residual* —
+    the distinction matters, because a catch-all branch assigns the most
+    alarming label to every case its author did not enumerate. ``enclosing``
+    exists precisely because hierarchy was such a case.
     """
     task_id: str
     subject: str
@@ -130,6 +142,21 @@ def open_frames(tasks) -> List[Frame]:
         if ts is not None and ts > newest_ts:
             newest_ts, newest_id = ts, str(task.id)
 
+    # Every ancestor of the active frame encloses it. Walking *up* from where
+    # attention is costs one pass and answers the question directly; asking
+    # instead "does any descendant happen to be in progress" would wrongly
+    # absolve a parent whose child was dropped alongside it.
+    enclosing_ids = set()
+    seen = set()
+    cursor = newest_id
+    while cursor is not None and cursor not in seen:
+        seen.add(cursor)
+        node = by_id.get(cursor)
+        parent_id = getattr(getattr(node, "mtmd", None), "parent_id", None)
+        cursor = str(parent_id) if parent_id is not None else None
+        if cursor is not None:
+            enclosing_ids.add(cursor)
+
     frames = []
     for task in in_progress:
         tid = str(task.id)
@@ -141,8 +168,13 @@ def open_frames(tasks) -> List[Frame]:
         parent = by_id.get(str(parent_id)) if parent_id is not None else None
         parent_completed = bool(parent and parent.status in ("completed", "archived"))
 
+        # Order encodes precedence. Where attention *is* outranks where it is
+        # waiting: a frame with work running inside it is not "set down waiting
+        # on a blocker", whatever its blocker list still says.
         if tid == newest_id:
             state = "active"
+        elif tid in enclosing_ids:
+            state = "enclosing"
         elif blockers_open:
             state = "parked"
         else:

--- a/macf/tests/test_task_trace.py
+++ b/macf/tests/test_task_trace.py
@@ -122,6 +122,90 @@ class TestOpenFrames:
         assert open_frames([]) == []
 
 
+class TestEnclosingFrames:
+    """A parent holding the frame attention is working inside is not a debt.
+
+    Before this state existed, ``abandoned`` was the else-branch, and the
+    classifier only ever looked *upward* (blockers, parent) — never down. So a
+    MISSION with a running phase fell through to "dropped frame" by
+    construction, and the false-alarm rate scaled with how faithfully work was
+    decomposed. Following the decomposition policy degraded the very detector
+    the work-stack policy depends on.
+    """
+
+    def test_a_parent_of_the_active_frame_encloses_it(self):
+        tasks = [
+            _Task("10", "in_progress", [_Update(100)]),
+            _Task("30", "in_progress", [_Update(900)], parent_id="10"),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states == {"30": "active", "10": "enclosing"}
+
+    def test_a_genuinely_dropped_frame_is_still_abandoned(self):
+        """The control, and the reason the test above proves anything.
+
+        A fix that simply stopped emitting ``abandoned`` would satisfy every
+        assertion about enclosing frames. This is the known-answer case: an
+        unblocked, unrelated, in-progress frame that attention left really is a
+        dropped frame, and the classifier must still say so.
+        """
+        tasks = [
+            _Task("10", "in_progress", [_Update(100)]),
+            _Task("30", "in_progress", [_Update(900)], parent_id="10"),
+            _Task("40", "in_progress", [_Update(50)]),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["40"] == "abandoned", "the fix must not silence the state"
+        assert states["10"] == "enclosing"
+
+    def test_enclosure_reaches_through_grandparents(self):
+        tasks = [
+            _Task("10", "in_progress", [_Update(100)]),
+            _Task("20", "in_progress", [_Update(200)], parent_id="10"),
+            _Task("30", "in_progress", [_Update(900)], parent_id="20"),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states == {"30": "active", "20": "enclosing", "10": "enclosing"}
+
+    def test_a_parent_dropped_alongside_its_child_is_not_absolved(self):
+        """The discriminator between the correct rule and the tempting one.
+
+        "Does any descendant happen to be in progress" would call the parent
+        enclosing here — but attention is on an unrelated frame, and parent and
+        child were dropped together. Enclosure is about where attention *is*,
+        not about what is merely open underneath.
+        """
+        tasks = [
+            _Task("10", "in_progress", [_Update(100)]),
+            _Task("30", "in_progress", [_Update(200)], parent_id="10"),
+            _Task("40", "in_progress", [_Update(900)]),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["10"] == "abandoned"
+        assert states["30"] == "abandoned"
+
+    def test_enclosing_outranks_parked(self):
+        """Work running inside a frame means it is not waiting, whatever its
+        blocker list still says — and a stale blocker should not disguise
+        where attention actually is."""
+        tasks = [
+            _Task("10", "in_progress", [_Update(100)], blocked_by=["9"]),
+            _Task("9", "pending", [_Update(10)]),
+            _Task("30", "in_progress", [_Update(900)], parent_id="10"),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["10"] == "enclosing"
+
+    def test_a_parent_link_cycle_does_not_hang(self):
+        """Corrupt hierarchy is a data bug, not a reason to spin forever."""
+        tasks = [
+            _Task("1", "in_progress", [_Update(100)], parent_id="2"),
+            _Task("2", "in_progress", [_Update(900)], parent_id="1"),
+        ]
+        states = {f.task_id: f.state for f in open_frames(tasks)}
+        assert states["2"] == "active"
+
+
 class TestContradictoryFrames:
     def test_completed_parent_with_running_child_is_flagged(self):
         """A structural check needing no timestamps: a parent cannot honestly


### PR DESCRIPTION
## The defect

`task trace` classified a MISSION as **abandoned** — the dropped-frame state — whenever the phase inside it was where attention actually was.

The classifier only ever looked *upward* (blockers, parent) and never down, and `abandoned` was the **else-branch**:

```python
if tid == newest_id:   state = "active"
elif blockers_open:    state = "parked"
else:                  state = "abandoned"
```

So an ancestor of the active frame fell through to the most alarming label **by construction**. The only way to escape it was for the parent to be the newest-touched — which would then mislabel the genuinely active child. The two could never both be right, which is the tell that the taxonomy was short a state rather than the code merely having a bug.

## Why it mattered

This inverts an incentive the work-stack policy depends on. §16.4 justifies the parked/abandoned split precisely because *"a detector that raises false alarms is muted within a week"* — and the defect made the false-alarm rate scale with **how faithfully work is decomposed**. Following the decomposition guidance degraded the detector the work-stack guidance needs.

It is worst during recovery, which is the moment the trace exists to serve. A successor reading ⚠️ on the mission it is meant to be working either wastes effort reconciling a frame nobody dropped, or learns to discount the marker entirely.

## The fix

A fourth state, `enclosing` — attention is *inside* this frame, in a descendant of it. Not a debt.

The four states now partition open frames exhaustively, which is what stops `abandoned` being a residual bucket that silently absorbs every case its author did not enumerate. Hierarchy was exactly such a case.

**Enclosure is about where attention *is*, not what is open underneath.** The tempting rule — "any frame with an in-progress descendant" — would absolve a parent dropped *together with* its child, so the implementation walks up from the active frame instead. Precedence is `active > enclosing > parked > abandoned`: work running inside a frame means it is not waiting, whatever its blocker list still says.

Three render sites, because the state is only half the fix if the renderer still treats it as a debt:

- the awaiting-a-return tally excludes enclosing frames (it was growing with every level of decomposition)
- the icon distinguishes them
- **the resume line now names a frame that was actually dropped** — previously it could send an agent at a parked frame legitimately waiting on a blocker, or at the ancestor of where it already was

That last one matters most: the classification is *read*, but the resume line is *acted on*.

## Policy ships with it

§16.4 documents the fourth state and is renamed to "Not every open frame is a debt" — it now draws more than one distinction. Its CEP navigation question is updated too: it still asked the superseded three-state question, so an agent routed there by navigation would have been handed the old taxonomy.

## Verification

Six new tests, **each verified by mutation to be capable of failing** — the point of the exercise, since a green test that cannot go red is the defect class this fix is about:

| Mutation | Result |
|---|---|
| remove the `enclosing` branch | 4 red, including the control |
| substitute the any-descendant rule | the discriminator test red, alone |
| remove the cycle guard | the cycle test **hangs** (killed at 15s) |

The control asserts a genuinely dropped frame is **still** abandoned — without it, this fix would be indistinguishable from deleting the warning.

Full suite: **1555 passed, 9 xfailed**. Confirmed on a live tree that happened to exercise all four states at once: the mission moved ⚠️ → 📂, a phase genuinely set down still read ⚠️, a blocked task still read parked, and the resume line named the dropped frame instead of the ancestor.