### PR TITLE
fix(task): provision the home task store instead of hoping someone opts in

### DIFF
--- a/docker/scripts/start.py
+++ b/docker/scripts/start.py
@@ -192,6 +192,62 @@ If you extend the convention, leave a note here so it stays shared.
 """
 
 
+def create_task_store(public: Path, username: str) -> Path:
+    """Create the agent's live task store under agent/public/.
+
+    This is the store, not ``task_archives`` beside it — the archive existed in
+    provisioning for a long time while the store it archives from did not, which
+    is how the gap stayed invisible.
+
+    Its absence is silent and expensive. Without this directory (and the
+    matching ``task_store.mode`` key, see ``configure_task_store``) macf falls
+    back to CC's per-session store: completed tasks are deleted once the last
+    open task closes, and a continue/rewind forks the store into copies that
+    then diverge. Everything works until history is expected to survive.
+
+    Must run at init time for the same reason as the mailbox: agent/public/ is
+    550 under immutable_structure, so the agent cannot create it afterwards.
+    """
+    tasks = public / 'tasks'
+    tasks.mkdir(mode=0o750, exist_ok=True)
+    run_command(['chown', f'{username}:agents_all', str(tasks)])
+    run_command(['chmod', '750', str(tasks)])
+    return tasks
+
+
+def configure_task_store(maceff_dir: Path, username: str) -> bool:
+    """Point the agent's config at the home task store. Returns True if usable.
+
+    The directory alone is not enough: without this key macf reads the legacy
+    per-session store and the provisioned directory sits empty and unread. Both
+    halves or neither.
+
+    Read-modify-write, because an upgrade path finds a config already holding
+    identity and hook settings — pointing an agent at a store is not a reason to
+    discard who it is. An unreadable config is left untouched and reported
+    rather than replaced, since overwriting it would destroy exactly the
+    information nobody can reconstruct.
+    """
+    config_file = maceff_dir / 'config.json'
+    config_data = {}
+    if config_file.exists():
+        try:
+            config_data = json.loads(config_file.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            log(f"WARNING: {config_file} unreadable ({e}); leaving it alone. "
+                f"{username} will fall back to the legacy task store.")
+            return False
+    if (config_data.get('task_store') or {}).get('mode') != 'home':
+        config_data.setdefault('task_store', {})
+        config_data['task_store']['mode'] = 'home'
+        config_data['task_store'].setdefault('path', 'agent/public/tasks')
+        config_file.write_text(json.dumps(config_data, indent=2) + '\n')
+        log(f"Set task_store.mode=home for {username}")
+    run_command(['chown', f'{username}:{username}', str(config_file)])
+    run_command(['chmod', '600', str(config_file)])
+    return True
+
+
 def create_amail_tree(public: Path, username: str) -> Path:
     """Create the agent's amail mailbox under agent/public/.
 
@@ -754,6 +810,9 @@ def create_agent_tree(username: str, agent_spec: AgentSpec, defaults_config: Opt
     run_command(['chown', f'{username}:agents_all', str(task_archives)])
     run_command(['chmod', '750', str(task_archives)])
 
+    # Create the live task store (MACF infrastructure, always needed).
+    create_task_store(public, username)
+
     # Create the amail mailbox (MACF infrastructure, always needed).
     create_amail_tree(public, username)
 
@@ -798,6 +857,9 @@ def create_agent_tree(username: str, agent_spec: AgentSpec, defaults_config: Opt
         log(f"Initialized agent_state.json for {username}")
     run_command(['chown', f'{username}:{username}', str(state_file)])
     run_command(['chmod', '600', str(state_file)])
+
+    # Point the agent at the home task store (pairs with create_task_store).
+    configure_task_store(maceff_dir, username)
 
 
 def create_personal_policies(username: str) -> None:

--- a/framework/policies/base/development/task_management.md
+++ b/framework/policies/base/development/task_management.md
@@ -4,7 +4,7 @@
 **Type**: Development Infrastructure
 **Scope**: All agents (PA and SA)
 **Status**: ACTIVE (successor to todo_hygiene.md)
-**Version**: 1.3
+**Version**: 1.4
 
 ---
 
@@ -16,7 +16,7 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 
 **Two storage backends** (see §0.1):
 - **Legacy (default)**: CC's `~/.claude/tasks/{session_uuid}/*.json`. Session-scoped — a new session UUID (continue / rewind / child) gets a *copy* that then diverges, and CC deletes all completed task files when the last open task completes. Fragile for long-lived history.
-- **Home store (opt-in)**: a single project-scoped directory under the agent home (`{agent_home}/agent/public/tasks/`, default), alongside the other consciousness artifacts. Set `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (or `MACF_TASK_STORE_DIR`). Not keyed by session UUID, so it survives fork/rewind and CC never touches it. This is the recommended backend for any agent that wants durable task history.
+- **Home store (provisioned)**: a single project-scoped directory under the agent home (`{agent_home}/agent/public/tasks/`, default), alongside the other consciousness artifacts. Selected by `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (or `MACF_TASK_STORE_DIR`). Not keyed by session UUID, so it survives fork/rewind and CC never touches it. **Provisioning creates it** — `macf_tools task store-init` builds the directory and writes the config key, and provisioning calls it. An agent that reaches its first task write without a home store was not provisioned; that is a bug in provisioning, not a preference the agent expressed.
 
 **Supersedes**: `todo_hygiene.md` (DEPRECATED)
 
@@ -26,6 +26,8 @@ Task management policy governs the use of Claude Code native Task* tools (TaskCr
 
 **0 Task Storage & Persistence**
 - Where are task files stored?
+- Who creates the home store, and what does it mean if an agent does not have one?
+- How do I move an existing agent onto the home store without losing history?
 - What creates new session UUIDs?
 - What is the ID assignment behavior?
 - What epistemological gaps remain?
@@ -175,6 +177,19 @@ Each task is stored as `{id}.json` (e.g., `1.json`, `67.json`) in the active sto
 
 - **Legacy**: `~/.claude/tasks/{session_uuid}/{id}.json` — one directory per CC session.
 - **Home store**: `{agent_home}/agent/public/tasks/{id}.json` — one project-scoped directory, no session UUID. Activated by `task_store.mode: "home"` in `{agent_home}/.maceff/config.json` (path overridable; env `MACF_TASK_STORE_DIR` wins). The `TaskReader` resolves this via a `HOME_STORE_UUID` sentinel; all create/read/archive/CLI paths inherit it through `session_path`. Completed-task hiding (`.{id}.json`) is a CC-scanner concern and is skipped here, so the home store stays plain `{id}.json`.
+
+### 0.1.1 Provisioning and migration
+
+The home store is **built by provisioning**, not chosen afterwards. `macf_tools task store-init` creates the directory and writes `task_store.mode: "home"`, preserving every other key in an existing config; it is idempotent, so provisioning and upgrade paths can both call it unconditionally. It deliberately does **not** migrate — provisioning a fresh home and rescuing an existing history are different operations with different failure modes, and one command doing both would make `--dry-run` mean two things.
+
+An existing agent moves with `macf_tools task migrate-store`, which **copies, verifies by sha256 byte-for-byte, and only then flips the config**. That order is the whole design: a config pointed at an unverified store fails later and elsewhere, and reads as amnesia rather than as a bad copy. The legacy directories are never deleted, so reverting is a one-line config edit.
+
+Two properties of migration exist because their absence was a silent partial:
+
+- **Every legacy directory is migrated, not just the live one.** An agent that has been continued, rewound or forked has several session directories. Migrating only the current one produces a success message, a populated store, and a directory nothing will ever mention again — a partial result shaped exactly like a complete one.
+- **Divergent copies are refused, not resolved.** A fork duplicates the store and both sides then move on, so the same id can exist twice with different content. Migration reports the conflicts and stops; `--force` takes the most recently modified copy and *names the discarded ones*, because a silent choice discards whichever copy lost a coin toss.
+
+Dot-prefixed completed tasks are normalised to plain `{id}.json` on the way in. The prefix exists solely to hide files from CC's scanner and the home store is never scanned, so carrying it across leaves one directory holding two conventions — and shell globs skip dotfiles, so anyone counting with `ls *.json` silently undercounts completed work.
 
 ### 0.2 Persistence Behavior
 

--- a/macf/src/macf/cli.py
+++ b/macf/src/macf/cli.py
@@ -5571,6 +5571,78 @@ def _doctor_check_subject_markers(tasks) -> "list[tuple[str, str, str]]":
     return findings
 
 
+def cmd_task_store_init(args: argparse.Namespace) -> int:
+    """Provision the home task store for an agent home, idempotently.
+
+    This is the mechanism provisioning calls so the home store is *built*
+    rather than opted into. It had been neither: nothing in agent init, config
+    init or any downstream provisioning script created the directory or wrote
+    the config key, so every agent silently ran on the session-scoped legacy
+    store — the one CC deletes from and that a fork duplicates.
+
+    Deliberately does NOT migrate. Provisioning a fresh home and rescuing an
+    existing history are different operations with different failure modes, and
+    a command that quietly did both would make ``--dry-run`` mean two things.
+    Use ``task migrate-store`` for the second.
+
+    Idempotent: safe to run on every provision and every upgrade.
+    """
+    from .task.reader import TaskReader
+
+    if getattr(args, "home", None):
+        agent_home = Path(args.home).expanduser()
+        if not agent_home.is_dir():
+            print(f"❌ Not a directory: {agent_home}", file=sys.stderr)
+            return 1
+    else:
+        agent_home = find_agent_home()
+        if not agent_home:
+            print("❌ Could not determine the agent home; pass --home.",
+                  file=sys.stderr)
+            return 1
+
+    _, rel = TaskReader._load_task_store_config()
+    store = agent_home / rel
+    config_path = agent_home / ".maceff" / "config.json"
+
+    created = not store.exists()
+    try:
+        store.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(f"❌ Could not create {store}: {e}", file=sys.stderr)
+        return 1
+    print(f"{'✅ Created' if created else '✓ Present'}: {store}")
+
+    # Read-modify-write. A fresh home has no config at all, and an existing one
+    # holds identity and hook settings that must survive being pointed at a new
+    # store.
+    config = {}
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"❌ Refusing to overwrite unreadable {config_path}: {e}",
+                  file=sys.stderr)
+            print("   The directory exists; fix the config and re-run.")
+            return 1
+
+    was = (config.get("task_store") or {}).get("mode")
+    config.setdefault("task_store", {})
+    config["task_store"]["mode"] = "home"
+    config["task_store"].setdefault("path", rel)
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+    except OSError as e:
+        print(f"❌ Could not write {config_path}: {e}", file=sys.stderr)
+        return 1
+    print(f"{'✓ Already' if was == 'home' else '✅ Set'}: "
+          f"task_store.mode = home  ({config_path})")
+
+    _ensure_store_gitignored_for_migration(store)
+    return 0
+
+
 def cmd_task_migrate_store(args: argparse.Namespace) -> int:
     """Move the legacy per-session task store into the project-scoped home store.
 
@@ -5588,6 +5660,16 @@ def cmd_task_migrate_store(args: argparse.Namespace) -> int:
 
     The legacy directory is never deleted. Reverting is a one-line config edit
     as long as it is still there.
+
+    **Every** legacy session directory is migrated, not just the current one. An
+    agent that has been continued, rewound or forked has several, and migrating
+    only the session that happens to be live produces a result shaped exactly
+    like a complete one: a success message, a populated store, and a directory
+    left behind that nothing will ever mention again.
+
+    Dot-prefixed completed tasks are normalised to plain ``{id}.json`` on the
+    way in, because the prefix exists solely to hide files from CC's scanner and
+    the home store is never scanned.
     """
     import hashlib
     from .task import TaskReader
@@ -5595,39 +5677,97 @@ def cmd_task_migrate_store(args: argparse.Namespace) -> int:
     dry_run = getattr(args, "dry_run", False)
     force = getattr(args, "force", False)
 
+    def _digest(p):
+        return hashlib.sha256(p.read_bytes()).hexdigest()
+
     mode, rel = TaskReader._load_task_store_config()
     if mode == "home" and not force:
         print("✅ Already on the home store — nothing to migrate.")
-        print("   Re-run with --force to copy the current session's legacy "
-              "files in anyway.")
+        print("   Re-run with --force to copy any remaining legacy files in.")
         return 0
 
-    legacy = TaskReader(session_uuid=TaskReader()._detect_current_session())
-    source = legacy.session_path
-    if not source or not source.exists():
-        print(f"❌ No legacy task store found for the current session.")
+    # Every session directory, oldest first, not merely the live one.
+    #
+    # Resolved through TaskReader rather than from Path.home(): MACF_TASKS_DIR
+    # relocates the legacy root for isolation, and reading ~/.claude directly
+    # ignores it — which points a sandboxed run at the real store. The mirror of
+    # the leak reader.py guards against in the other direction.
+    cc_root = TaskReader._get_tasks_dir()
+    source_dirs = sorted(
+        (d for d in cc_root.glob("*/") if d.is_dir()),
+        key=lambda d: d.name,
+    ) if cc_root.exists() else []
+    if not source_dirs:
+        print("❌ No legacy task store found under "
+              f"{cc_root} — nothing to migrate.")
         return 1
 
     agent_home = find_agent_home()
     target = agent_home / rel
     config_path = agent_home / ".maceff" / "config.json"
 
-    files = legacy.list_task_files(include_hidden=True)
-    hidden = [f for f in files if f.name.startswith(".")]
+    # Gather every file from every directory, keyed by the name it will land
+    # under. Normalising the dot prefix here is what makes two directories
+    # comparable at all: ".7.json" and "7.json" are the same task.
+    by_target_name = {}
+    total_seen = 0
     print(f"📦 Migrate task store")
-    print(f"   from: {source}  ({len(files)} files, {len(hidden)} hidden)")
+    for d in source_dirs:
+        files = TaskReader(session_uuid=d.name).list_task_files(include_hidden=True)
+        hidden = [f for f in files if f.name.startswith(".")]
+        total_seen += len(files)
+        print(f"   from: {d}  ({len(files)} files, {len(hidden)} hidden)")
+        for f in files:
+            by_target_name.setdefault(f.name.lstrip("."), []).append(f)
     print(f"   to:   {target}")
     print(f"   config: {config_path}")
+    print(f"   {total_seen} file(s) across {len(source_dirs)} directory(ies) "
+          f"-> {len(by_target_name)} task(s)")
 
-    if not files:
+    if not by_target_name:
         print("❌ Legacy store is empty — refusing to migrate nothing.")
         return 1
 
+    # Divergence between directories. A fork copies the store and both sides
+    # then move on, so the same id can exist twice with different content.
+    # Choosing silently would discard whichever copy lost a coin toss.
+    conflicts = {}
+    chosen = {}
+    for name, candidates in sorted(by_target_name.items()):
+        digests = {_digest(c) for c in candidates}
+        if len(digests) == 1:
+            chosen[name] = candidates[0]
+        else:
+            conflicts[name] = candidates
+            chosen[name] = max(candidates, key=lambda p: p.stat().st_mtime)
+
+    if conflicts and not force:
+        print(f"\n❌ {len(conflicts)} task(s) differ between legacy directories:")
+        for name, cands in list(conflicts.items())[:5]:
+            print(f"   {name}")
+            for c in sorted(cands, key=lambda p: p.stat().st_mtime, reverse=True):
+                stamp = datetime.fromtimestamp(c.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+                print(f"      {stamp}  {c.parent.name}/{c.name}")
+        if len(conflicts) > 5:
+            print(f"   ... and {len(conflicts) - 5} more")
+        print("\n   Refusing to choose for you. Re-run with --force to take the "
+              "most recently modified copy of each,")
+        print("   which is reported per file so the discarded ones are named "
+              "rather than silently dropped.")
+        return 1
+    if conflicts:
+        print(f"\n⚠️  {len(conflicts)} divergent task(s); taking most recent:")
+        for name, cands in sorted(conflicts.items()):
+            keep = chosen[name]
+            dropped = [f"{c.parent.name}/{c.name}" for c in cands if c is not keep]
+            print(f"   {name}: keeping {keep.parent.name}/{keep.name}, "
+                  f"discarding {', '.join(dropped)}")
+
     collisions = []
     if target.exists():
-        for f in files:
-            if (target / f.name).exists():
-                collisions.append(f.name)
+        for name in chosen:
+            if (target / name).exists():
+                collisions.append(name)
     if collisions and not force:
         print(f"\n❌ {len(collisions)} file(s) already exist in the target "
               f"(e.g. {collisions[:3]}).")
@@ -5641,25 +5781,22 @@ def cmd_task_migrate_store(args: argparse.Namespace) -> int:
     # 1. COPY
     target.mkdir(parents=True, exist_ok=True)
     copied = 0
-    for f in files:
+    for name, src in sorted(chosen.items()):
         try:
-            (target / f.name).write_bytes(f.read_bytes())
+            (target / name).write_bytes(src.read_bytes())
             copied += 1
         except OSError as e:
-            print(f"❌ Copy failed at {f.name}: {e}", file=sys.stderr)
+            print(f"❌ Copy failed at {name}: {e}", file=sys.stderr)
             print("   Config NOT flipped; the legacy store is untouched.")
             return 1
 
     # 2. VERIFY before flipping. A config pointed at an unverified store fails
     #    later, elsewhere, and looks like data loss rather than a bad copy.
-    def _digest(p):
-        return hashlib.sha256(p.read_bytes()).hexdigest()
-
     mismatched = []
-    for f in files:
-        dest = target / f.name
-        if not dest.exists() or _digest(dest) != _digest(f):
-            mismatched.append(f.name)
+    for name, src in chosen.items():
+        dest = target / name
+        if not dest.exists() or _digest(dest) != _digest(src):
+            mismatched.append(name)
     if mismatched:
         print(f"\n❌ Verification failed for {len(mismatched)} file(s): "
               f"{mismatched[:5]}")
@@ -5692,7 +5829,9 @@ def cmd_task_migrate_store(args: argparse.Namespace) -> int:
     # helper gates on — calling it before the flip would silently no-op.
     _ensure_store_gitignored_for_migration(target)
 
-    print(f"\n📁 The legacy store is retained at:\n   {source}")
+    print("\n📁 The legacy store(s) are retained at:")
+    for d in source_dirs:
+        print(f"   {d}")
     print("   Nothing was deleted — revert by setting task_store.mode back to "
           "\"legacy\".")
     print("\n▶️  Verify with: macf_tools task tree")
@@ -8343,7 +8482,8 @@ def cmd_task_complete(args: argparse.Namespace) -> int:
 
     if success:
         # Hide completed task file from CC's native scanner (dot-prefix).
-        # No-op in the home store, which CC never scans — report accordingly.
+        # hide_task_file guards this itself — it returns early for a non-CC
+        # store — so the call is safe everywhere and only the report is gated.
         from .task.reader import hide_task_file, _is_cc_session_dir
         if reader.session_path:
             hide_task_file(reader.session_path, str(task_id))
@@ -10170,6 +10310,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="proceed even if the target already holds files of the same name",
     )
     task_migrate_parser.set_defaults(func=cmd_task_migrate_store)
+
+    task_store_init_parser = task_sub.add_parser(
+        "store-init",
+        help="provision the home task store and point the config at it",
+    )
+    task_store_init_parser.add_argument(
+        "--home", default=None,
+        help="agent home to provision (default: this agent's home)",
+    )
+    task_store_init_parser.set_defaults(func=cmd_task_store_init)
 
     task_trace_parser = task_sub.add_parser(
         "trace",

--- a/macf/tests/test_container_amail_tree.py
+++ b/macf/tests/test_container_amail_tree.py
@@ -111,3 +111,70 @@ def test_is_idempotent_across_restarts(start_module, public_dir, calls):
 def test_returns_the_mailbox_path(start_module, public_dir, calls):
     result = start_module.create_amail_tree(public_dir, "pa_test")
     assert result == public_dir / "amail"
+
+
+class TestTaskStoreProvisioning:
+    """The live task store must be built by provisioning, like the mailbox.
+
+    ``task_archives`` was created here for a long time while ``tasks`` -- the
+    store it archives *from* -- was not, so provisioning appeared to know about
+    the task subsystem while leaving every agent on CC's per-session store. That
+    store deletes completed tasks and forks on rewind, and the failure is
+    invisible until history is expected to survive.
+    """
+
+    def test_creates_the_store(self, start_module, public_dir, calls):
+        start_module.create_task_store(public_dir, "pa_test")
+        assert (public_dir / "tasks").is_dir()
+
+    def test_store_is_distinct_from_the_archive(self, start_module, public_dir, calls):
+        """CONTROL against the original confusion: creating the store must not
+        be satisfied by the archive directory existing."""
+        (public_dir / "task_archives").mkdir()
+        start_module.create_task_store(public_dir, "pa_test")
+        assert (public_dir / "tasks").is_dir()
+        assert (public_dir / "tasks") != (public_dir / "task_archives")
+
+    def test_idempotent_on_reprovision(self, start_module, public_dir, calls):
+        start_module.create_task_store(public_dir, "pa_test")
+        (public_dir / "tasks" / "7.json").write_text("{}")
+        start_module.create_task_store(public_dir, "pa_test")
+        assert (public_dir / "tasks" / "7.json").exists(), "reprovision destroyed tasks"
+
+    def test_grants_group_access_for_peer_traversal(self, start_module, public_dir, calls):
+        start_module.create_task_store(public_dir, "pa_test")
+        assert ["chown", "pa_test:agents_all", str(public_dir / "tasks")] in calls
+        assert ["chmod", "750", str(public_dir / "tasks")] in calls
+
+
+class TestTaskStoreConfig:
+    """The directory alone leaves the agent reading the legacy store."""
+
+    def test_writes_mode_home_on_a_bare_maceff_dir(self, start_module, tmp_path, calls):
+        m = tmp_path / ".maceff"
+        m.mkdir()
+        assert start_module.configure_task_store(m, "pa_test") is True
+        import json as _json
+        cfg = _json.loads((m / "config.json").read_text())
+        assert cfg["task_store"]["mode"] == "home"
+        assert cfg["task_store"]["path"] == "agent/public/tasks"
+
+    def test_preserves_identity_on_upgrade(self, start_module, tmp_path, calls):
+        import json as _json
+        m = tmp_path / ".maceff"
+        m.mkdir()
+        (m / "config.json").write_text(_json.dumps(
+            {"agent_identity": {"moniker": "Keep Me"}}))
+        assert start_module.configure_task_store(m, "pa_test") is True
+        cfg = _json.loads((m / "config.json").read_text())
+        assert cfg["agent_identity"]["moniker"] == "Keep Me"
+        assert cfg["task_store"]["mode"] == "home"
+
+    def test_leaves_an_unreadable_config_untouched(self, start_module, tmp_path, calls):
+        """CONTROL: overwriting a corrupt config would destroy exactly the
+        information nobody can reconstruct. Report and decline."""
+        m = tmp_path / ".maceff"
+        m.mkdir()
+        (m / "config.json").write_text("{not json")
+        assert start_module.configure_task_store(m, "pa_test") is False
+        assert (m / "config.json").read_text() == "{not json"

--- a/macf/tests/test_papercuts.py
+++ b/macf/tests/test_papercuts.py
@@ -148,14 +148,24 @@ class TestMigrateStore:
         )
 
     def test_migrates_including_hidden_completed_tasks(self, tmp_path):
+        """Hidden completed tasks must survive the move — under plain names.
+
+        The guarantee this test was written for is unchanged: a dot-prefixed
+        completed task is not dropped. What changed is the name it lands under.
+        The prefix exists solely to hide files from CC's scanner, which never
+        looks at the home store, so carrying it across leaves one directory
+        holding two conventions — and shell globs skip dotfiles, so anyone
+        counting with `ls *.json` silently undercounts completed work.
+        """
         home, _ = self._legacy_setup(tmp_path)
         result = self._run(home, tmp_path)
         assert result.returncode == 0, result.stdout + result.stderr
 
         target = home / "agent" / "public" / "tasks"
         names = {p.name for p in target.iterdir()}
-        assert names == {"000.json", "1.json", "2.json", ".3.json"}, names
-        assert ".3.json" in names, "hidden completed task was dropped"
+        assert names == {"000.json", "1.json", "2.json", "3.json"}, names
+        assert "3.json" in names, "hidden completed task was dropped"
+        assert ".3.json" not in names, "dot prefix carried into the home store"
 
     def test_config_is_flipped_to_home(self, tmp_path):
         home, _ = self._legacy_setup(tmp_path)

--- a/macf/tests/test_task_home_store.py
+++ b/macf/tests/test_task_home_store.py
@@ -201,3 +201,145 @@ class TestSprintPlayTimeNoSelfCollision:
         assert f.exists()
         data = json.loads(f.read_text())
         assert "provisional" not in data["subject"]
+
+
+class TestStoreInit:
+    """Provisioning builds the store; it is not opted into after the fact.
+
+    Nothing in agent init, config init, or any downstream provisioning script
+    created the directory or wrote the config key, so every provisioned agent
+    silently ran on the session-scoped legacy store -- the one CC deletes from
+    and a fork duplicates.
+    """
+
+    def _run(self, home):
+        import argparse
+        from macf.cli import cmd_task_store_init
+        return cmd_task_store_init(argparse.Namespace(home=str(home)))
+
+    def test_creates_store_and_sets_mode_on_a_bare_home(self, tmp_path):
+        assert self._run(tmp_path) == 0
+        assert (tmp_path / "agent" / "public" / "tasks").is_dir()
+        cfg = json.loads((tmp_path / ".maceff" / "config.json").read_text())
+        assert cfg["task_store"]["mode"] == "home"
+
+    def test_preserves_existing_config_keys(self, tmp_path):
+        """A provisioned home already holds identity and hook settings. Pointing
+        it at a new store must not be a rewrite."""
+        maceff = tmp_path / ".maceff"
+        maceff.mkdir()
+        (maceff / "config.json").write_text(json.dumps(
+            {"agent_identity": {"moniker": "Keep Me"}, "hooks": {"capture_output": True}}))
+        assert self._run(tmp_path) == 0
+        cfg = json.loads((maceff / "config.json").read_text())
+        assert cfg["agent_identity"]["moniker"] == "Keep Me"
+        assert cfg["hooks"]["capture_output"] is True
+        assert cfg["task_store"]["mode"] == "home"
+
+    def test_idempotent(self, tmp_path):
+        assert self._run(tmp_path) == 0
+        assert self._run(tmp_path) == 0
+        cfg = json.loads((tmp_path / ".maceff" / "config.json").read_text())
+        assert cfg["task_store"]["mode"] == "home"
+
+    def test_refuses_to_clobber_an_unreadable_config(self, tmp_path):
+        """CONTROL on the read-modify-write: corrupt config must abort, not be
+        silently replaced with a fresh one that drops the agent's identity."""
+        maceff = tmp_path / ".maceff"
+        maceff.mkdir()
+        (maceff / "config.json").write_text("{not json")
+        assert self._run(tmp_path) == 1
+        assert (maceff / "config.json").read_text() == "{not json"
+
+
+class TestMigrateEveryLegacyDirectory:
+    """Migrating only the live session leaves a directory nothing will mention.
+
+    An agent that has been continued, rewound or forked has several session
+    dirs. The old implementation resolved exactly one -- the current session --
+    and reported success, which is a partial result shaped like a complete one.
+    """
+
+    @pytest.fixture
+    def legacy_agent(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MACF_TASKS_DIR", raising=False)
+        monkeypatch.delenv("MACF_TASK_STORE_DIR", raising=False)
+        monkeypatch.setenv("MACEFF_AGENT_HOME_DIR", str(tmp_path))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        find_agent_home.cache_clear()
+        (tmp_path / ".maceff").mkdir()
+        tasks = tmp_path / ".claude" / "tasks"
+        (tasks / "aaaa-1111").mkdir(parents=True)
+        (tasks / "bbbb-2222").mkdir(parents=True)
+        yield tmp_path
+        find_agent_home.cache_clear()
+
+    def _run(self, dry_run=False, force=False):
+        import argparse
+        from macf.cli import cmd_task_migrate_store
+        return cmd_task_migrate_store(
+            argparse.Namespace(dry_run=dry_run, force=force))
+
+    def test_migrates_tasks_from_every_directory(self, legacy_agent):
+        t = legacy_agent / ".claude" / "tasks"
+        (t / "aaaa-1111" / "1.json").write_text('{"id": "1"}')
+        (t / "bbbb-2222" / "2.json").write_text('{"id": "2"}')
+        assert self._run() == 0
+        store = legacy_agent / "agent" / "public" / "tasks"
+        # The second assertion is the one that matters: migrating only the
+        # "current" directory satisfies the first and fails this.
+        assert (store / "1.json").exists()
+        assert (store / "2.json").exists(), "a whole legacy directory was stranded"
+
+    def test_normalises_the_hidden_dot_prefix(self, legacy_agent):
+        """The prefix exists only to hide files from CC's scanner, which never
+        looks at the home store. Carrying it in leaves one directory with two
+        conventions, and shell globs skip the dotted half."""
+        t = legacy_agent / ".claude" / "tasks"
+        (t / "aaaa-1111" / ".7.json").write_text('{"id": "7"}')
+        assert self._run() == 0
+        store = legacy_agent / "agent" / "public" / "tasks"
+        assert (store / "7.json").exists()
+        assert not (store / ".7.json").exists()
+
+    def test_identical_copies_across_directories_are_not_a_conflict(self, legacy_agent):
+        t = legacy_agent / ".claude" / "tasks"
+        (t / "aaaa-1111" / "5.json").write_text('{"id": "5"}')
+        (t / "bbbb-2222" / "5.json").write_text('{"id": "5"}')
+        assert self._run() == 0
+        assert (legacy_agent / "agent" / "public" / "tasks" / "5.json").exists()
+
+    def test_divergent_copies_refuse_rather_than_choose(self, legacy_agent):
+        """A fork copies the store and both sides move on. Choosing silently
+        discards whichever copy lost a coin toss."""
+        t = legacy_agent / ".claude" / "tasks"
+        (t / "aaaa-1111" / "5.json").write_text('{"id": "5", "v": "old"}')
+        (t / "bbbb-2222" / "5.json").write_text('{"id": "5", "v": "new"}')
+        assert self._run() == 1
+        assert not (legacy_agent / "agent" / "public" / "tasks" / "5.json").exists()
+        cfg = json.loads((legacy_agent / ".maceff" / "config.json").read_text() or "{}") \
+            if (legacy_agent / ".maceff" / "config.json").exists() else {}
+        assert (cfg.get("task_store") or {}).get("mode") != "home", \
+            "config must not flip when the migration refused"
+
+    def test_force_takes_the_newest_divergent_copy(self, legacy_agent):
+        import os, time
+        t = legacy_agent / ".claude" / "tasks"
+        old = t / "aaaa-1111" / "5.json"
+        new = t / "bbbb-2222" / "5.json"
+        old.write_text('{"id": "5", "v": "old"}')
+        new.write_text('{"id": "5", "v": "new"}')
+        os.utime(old, (1000, 1000))
+        os.utime(new, (2000, 2000))
+        assert self._run(force=True) == 0
+        got = (legacy_agent / "agent" / "public" / "tasks" / "5.json").read_text()
+        assert '"new"' in got
+
+    def test_dry_run_touches_nothing(self, legacy_agent):
+        t = legacy_agent / ".claude" / "tasks"
+        (t / "aaaa-1111" / "1.json").write_text('{"id": "1"}')
+        assert self._run(dry_run=True) == 0
+        assert not (legacy_agent / "agent" / "public" / "tasks" / "1.json").exists()
+
+    def test_empty_legacy_refuses(self, legacy_agent):
+        assert self._run() == 1


### PR DESCRIPTION
## The gap was one directory wide

Provisioning created `agent/public/task_archives` and never created `agent/public/tasks` — the store the archive archives *from*. Provisioning appeared to know about the task subsystem while leaving every agent on CC's per-session store: the one that deletes completed tasks when the last open task closes, and that a continue/rewind forks into copies that then diverge.

**The failure is invisible.** Everything works until history is expected to survive.

Measured on a live deployment rather than inferred:

| Check | Finding |
|---|---|
| `config init` | writes identity/logging/hooks — no `task_store` |
| `agent init` | CLAUDE.md preamble only — no scaffolding |
| `reader.py` | absent block → falls back to `legacy` |
| Live agents | **3 of 4** had no home store |
| Worst case | 161 tasks across **two divergent** session directories |

## Provisioning now builds it

In the shared container provisioner, so both downstream deployments get it from one place:

- `create_task_store()` / `configure_task_store()` in `start.py`, called at init beside the amail tree. Extracted as named functions because the inline version could not be tested — and because `agent/public/` is 550 by the time an agent could ask for it. **Init or never.**
- `macf_tools task store-init` for homes that aren't container-provisioned. Read-modify-write, so identity and hook settings survive being pointed at a store. Idempotent.

`store-init` deliberately **does not migrate**. Provisioning a fresh home and rescuing an existing history are different operations with different failure modes; one command doing both would make `--dry-run` mean two things.

## Migration: three fixes, each a silent partial

- **Every legacy session directory**, not just the live one. Migrating the current one produced a success message, a populated store, and a directory nothing would ever mention again.
- **Divergent copies refused, not resolved.** `--force` takes the most recent *and names the discarded copies* — a silent choice discards whichever copy lost a coin toss.
- **Dot prefix normalised.** It only hides files from CC's scanner, which never looks here. Carrying it across leaves one directory with two conventions, and shell globs skip dotfiles.

Copy → sha256 verify → **then** flip is preserved. Legacy directories are still never deleted.

## Policy ships with it

The home store is documented as **provisioned** rather than opt-in, with a new section on provisioning vs migration and the reasoning behind each behaviour above. An agent reaching its first task write without a home store is now a provisioning bug, not a preference.

## Verification

Mutation-tested against a bar fixed before implementation — *the multi-dir case must be demonstrated on a fixture where migrating only one directory would pass a naive test*:

| Mutation | Result |
|---|---|
| revert to single-directory | 3 red, incl. "a whole legacy directory was stranded" |
| drop dot normalisation | exactly its own test red |

**Full suite: 1573 passed, 9 xfailed.**

A bug caught by that full run and worth naming: the legacy root was first resolved via `Path.home()`, which **bypasses the `MACF_TASKS_DIR` isolation override** — under test it read the real home's task directory instead of the fixture's. A sandboxed run reaching into the live store is the mirror of a leak `reader.py` guards against in the other direction. Now resolved through `TaskReader._get_tasks_dir()`.

One existing test changed rather than deleted: the hidden-completed-task case asserted a `.3.json` landing name. Its guarantee — the task is not dropped — is unchanged and still asserted; it now also pins that the dot is *not* carried in.