### PR TITLE
docs(policy): settle experiment vs roadmap before the type comparison, not after

### DIFF
--- a/framework/policies/base/consciousness/experiments.md
+++ b/framework/policies/base/consciousness/experiments.md
@@ -3,7 +3,7 @@
 ## Meta-Policy: Policy Classification
 - **Tier**: RECOMMENDED
 - **Category**: Consciousness Development - Public Artifacts
-- **Version**: 1.0.0
+- **Version**: 1.1.0
 - **Dependencies**: policy_awareness, observations, reflections
 - **Authority**: MacEff Framework
 - **Status**: ACTIVE
@@ -44,6 +44,13 @@ Agents conduct structured experiments with clear hypotheses, methods, and succes
 - How do experiments differ from observations?
 - When should I run an experiment?
 - What makes a good experiment?
+
+1.0 Is this an experiment at all?
+- Is this work requirements gathering, or is it implementation?
+- On what dimensions do an experiment and a roadmap actually differ?
+- I think I already know the implementation — does that settle it?
+- The operator asked for an experiment but it looks like implementation. Now what?
+- What does each mis-typing cost?
 
 1.1 Experiment vs Observation vs Report
 - Am I testing or discovering?
@@ -347,7 +354,55 @@ An **experiment** is a consciousness artifact documenting **hypothesis testing**
 **Example Experiment** [c_73/s_4107604e/p_6c9eacb/t_1761703391/g_17e7b7d]:
 > "PreToolUse Smoke Test for Temporal Awareness" - Hypothesis: Can we inject temporal awareness via additionalContext? Method: Create minimal hook with temporal data. Success: If agent references time naturally. Result: Validated ✅
 
+### 1.0 Is this an experiment at all?
+
+Before comparing experiment against the other *documentation* types, settle the
+fork that is actually confused in practice: **is this work an experiment, or is it
+implementation?** An experiment gathers requirements and commits to nothing. A
+roadmap/MISSION implements, and its output is code that ships.
+
+| Dimension | EXPERIMENT | ROADMAP / MISSION |
+|---|---|---|
+| Purpose | requirements gathering | implementation |
+| Commitment | non-committal | committed |
+| Where the work lives | repro in the experiment's CA directory, out of the main tree | a branch, to be PR'd into the main tree |
+| What success means | it **answers** — validated *or rejected* both succeed | it **delivers** — only shipping succeeds |
+| A negative result | a win, and worth publishing | a failure |
+| Effect on uncertainty | reduces it | spends it |
+| What "done" leaves behind | a finding, and possibly a corrected assumption | shipped code, with its policy alongside |
+| Who consumes the output | the next planner, as a decision input | every agent, as a capability |
+| Blast radius | the agent's own artifact tree | shared framework behaviour |
+| Bounded by | the question — stop when answered | the scope — stop when the phases are done |
+| Gate | plan mode, then approval to run | PR review and CI |
+| Cost of being wrong | discard the repro | migration and rollback |
+| May depend on | nothing downstream | may cite an experiment as evidence |
+
+**"I already know the implementation" is not a discriminator.** It is the
+assumption under test. An agent that reclassifies an experiment into
+implementation because the remedy feels obvious has skipped the one step that
+would have caught it being wrong — and the remedy feeling obvious is the normal
+condition, not a special one.
+
+**When the operator asks for an experiment, deliver an experiment.** Their framing
+outranks the agent's confidence. If the work genuinely looks like implementation,
+that is a *proposal* to put to them, never a unilateral change of type.
+
+**Do not be impatient.** Hardening requirements first tends to produce a *better*
+roadmap, because the assumptions were played with and the wrong ones corrected
+before anything was built on them. §8 exists for exactly that conversion.
+
+Both mis-typings cost, so this is not an instruction to always experiment:
+
+- **Roadmap mis-typed as experiment**: exploration never converges, nothing
+  ships, and work whose answer was already known gets re-derived.
+- **Experiment mis-typed as roadmap**: a remedy is implemented for a defect that
+  was never characterised — frequently a second control installed beside an
+  existing one that already covered part of the case.
+
 ### 1.1 Experiment vs Observation vs Report
+
+These three are all **documentation** artifacts. If §1.0 settled that the work is
+implementation, none of them is the answer — see `roadmaps_drafting.md`.
 
 **Three Artifact Types Compared**:
 
@@ -381,7 +436,13 @@ Observation (documents discovery)
 Personal Policy (encodes practice)
     ↓ contributes to
 Report (summarizes project outcomes)
+
+Experiment (validated, and crystallized per §8)
+    ↓ converts to
+ROADMAP / MISSION (implements, on a branch, PR'd to main)
 ```
+The second path leaves the documentation family entirely. It is the only route
+from an experiment to shipped code, and it runs through §8 rather than around it.
 
 ### 1.2 Formal vs Informal Experiments
 

--- a/framework/policies/base/consciousness/roadmaps_drafting.md
+++ b/framework/policies/base/consciousness/roadmaps_drafting.md
@@ -1,6 +1,6 @@
 # Roadmaps Policy: Drafting & Planning
 
-**Version**: 2.3
+**Version**: 2.4
 **Tier**: MANDATORY
 **Category**: Consciousness - Planning
 **Status**: ACTIVE
@@ -36,10 +36,22 @@ Roadmaps are **strategic planning artifacts** that preserve complex development 
 
 ### Optional But Recommended
 
-- Investigation projects with uncertain scope
-- Experimental work requiring structured exploration
+- Investigation projects whose *implementation* scope is uncertain
 - Documentation projects with multiple deliverables
 - Integration work across repositories
+
+### Not This Policy — Use `experiments.md`
+
+- Work that tests whether an approach is right, rather than building it
+- Anything the operator asked for as an experiment
+- Structured exploration whose deliverable is a finding rather than shipped code
+
+These read as roadmap triggers because they are uncertain and multi-step, and
+uncertainty is on the list above. The distinction is *what the uncertainty is
+about*: how much work there is, versus whether the approach is sound. A roadmap
+spends certainty; an experiment produces it. `experiments.md` §1.0 carries the
+full comparison, and §8 there covers converting a validated experiment into a
+roadmap — which is the intended route to implementation, not a detour around it.
 
 ### When NOT Required
 
@@ -346,13 +358,30 @@ The Explore subagent is designed for codebase discovery without making changes:
 
 ### Complexity Triggers
 
+**First, check it is a roadmap at all.** A roadmap implements: it commits, it
+lives on a branch, and it is PR'd into the main tree. If the work is instead
+*requirements gathering* — non-committal, repro kept in a CA directory out of the
+main tree, and finished when it has an answer rather than when it has shipped —
+it is an experiment. See `experiments.md` §1.0 for the dimensions, and §8 there
+for converting a validated experiment into a roadmap.
+
+Note that "I already know the implementation" does not settle it. That belief is
+the assumption an experiment exists to test, and it is the ordinary condition
+rather than a special one.
+
 **Create roadmap when work has**:
 - **Multiple phases** (>3 distinct stages)
-- **Uncertain scope** (investigation or exploration)
+- **Uncertain scope** — but see the caution below
 - **Coordination needs** (multiple agents or specialists)
 - **Temporal span** (crosses compaction boundaries)
 - **Risk factors** (architecture changes, migrations)
 - **Delegation requirements** (specialist handoffs)
+
+**Caution on uncertain scope**: uncertainty about *how much implementation work
+there is* is a roadmap trigger. Uncertainty about *whether the approach is right*
+is not — that is an experiment, and building a roadmap on it spends certainty the
+work does not yet have. Investigation and exploration belong to experiments;
+roadmaps consume their findings.
 
 ### Decision Tree
 


### PR DESCRIPTION
Fixes #259

`experiments.md` documented the exit from an experiment thoroughly and the entrance not at all. Section 8 covers Experiment -> MISSION conversion across four subsections. The up-front disambiguation, 1.1, compared Experiment against Observation and Report -- all three documentation types -- so the fork that actually gets confused, documentation versus implementation, never appeared. An agent can rule out observation and report and land on "experiment" by elimination without considering that the work was implementation.

Adds section 1.0 with a dimensions table: purpose, commitment, where the work lives, what success means, what a negative result is worth, effect on uncertainty, blast radius, bounding condition, gate, cost of being wrong. Both mis-typings are named so the guidance does not just push everything toward experimenting.

Two points that are easy to get backwards, both stated explicitly:

- "I already know the implementation" is not a discriminator. It is the assumption under test, and it is the normal condition rather than a special one.
- When the operator asks for an experiment, their framing outranks the agent's confidence. Reclassifying is a proposal to put to them, not a unilateral move.

`roadmaps_drafting.md` had the same gap pointing the other way, and it was more direct: its triggers listed "uncertain scope (investigation or exploration)" and "experimental work requiring structured exploration" as reasons to create a roadmap. That contradicts `experiments.md` on exactly the case in question. Now qualified -- uncertainty about how much implementation work exists is a roadmap trigger; uncertainty about whether the approach is sound is an experiment -- with a pointer to 1.0 and to the section 8 conversion route.

Policy text only; no behaviour changes.

**Test evidence**: full suite passes locally, 1573 passed / 9 xfailed. Verified separately that the new nav entry renders through `macf_tools policy navigate experiments` and that `policy read experiments --section 1.0` resolves, since a section the CEP navigation cannot reach is invisible to the discovery path it was written for.